### PR TITLE
✨ Feat: 로그인 후 원래 페이지 복귀, 로그아웃 목적지 개선

### DIFF
--- a/apps/page0127/app/(auth)/login/page.tsx
+++ b/apps/page0127/app/(auth)/login/page.tsx
@@ -10,9 +10,20 @@ import {
 
 import { LoginWithGoogleButton } from '@/features/auth/ui/LoginWithGoogleButton';
 
-// 로그인 페이지
+type LoginPageProps = {
+  searchParams: Promise<{ redirect?: string }>;
+};
 
-const LoginPage = () => {
+/**
+ * 로그인 페이지
+ *
+ * 학습 포인트: `?redirect=` 를 여기(Server Component)에서 읽어 버튼에 내린다.
+ * 클라이언트에서 useSearchParams 로 읽으면 Suspense 경계가 필요해지는데,
+ * 페이지가 이미 서버에서 파라미터를 받을 수 있으므로 그럴 이유가 없다.
+ */
+const LoginPage = async ({ searchParams }: LoginPageProps) => {
+  const { redirect } = await searchParams;
+
   return (
     <div className='flex min-h-screen items-center justify-center'>
       <Card className='w-full max-w-md shadow-none'>
@@ -21,7 +32,7 @@ const LoginPage = () => {
           <CardDescription>어서 오세요. 책장이 기다리고 있어요.</CardDescription>
         </CardHeader>
         <CardContent>
-          <LoginWithGoogleButton />
+          <LoginWithGoogleButton next={redirect} />
           {/* 약관 링크는 실제 페이지로 연결한다 (기존 href='#' 죽은 링크) */}
           <p className='mt-4 text-center text-sm text-text-subtle'>
             로그인하면{' '}

--- a/apps/page0127/app/auth/callback/route.ts
+++ b/apps/page0127/app/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { createClient } from '@/shared/config/supabase/server';
 import { isBannedRedirect } from '@/shared/lib/auth/isBannedRedirect';
+import { toSafeRedirect } from '@/shared/lib/auth/safeRedirect';
 
 import { ensureProfile } from '@/entities/profile/api/getProfile';
 
@@ -35,7 +36,8 @@ export async function GET(request: NextRequest) {
         data.user.email!,
         data.user.user_metadata
       );
-      const redirectTo = next ?? `/${profile.username}`;
+      // next 는 사용자가 조작할 수 있는 값이다 — 외부 URL 이면 버리고 본인 서재로 보낸다
+      const redirectTo = toSafeRedirect(next) ?? `/${profile.username}`;
       return NextResponse.redirect(`${origin}${redirectTo}`);
     }
   }

--- a/apps/page0127/src/features/auth/api/useGoogleLogin.ts
+++ b/apps/page0127/src/features/auth/api/useGoogleLogin.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/shared/config/supabase/client';
+import { toSafeRedirect } from '@/shared/lib/auth/safeRedirect';
 
 /**
  * Google OAuth 로그인 Custom Hook
@@ -20,7 +21,8 @@ export const useGoogleLogin = () => {
   // const [isLoading, setIsLoading] = useState(false);
   // const [error, setError] = useState<string | null>(null);
 
-  const login = async () => {
+  /** @param next 로그인 후 돌아갈 내부 경로. 없으면 콜백이 본인 서재로 보낸다 */
+  const login = async (next?: string | null) => {
     const supabase = createClient();
 
     // OAuth 리디렉션 URL 설정
@@ -30,6 +32,14 @@ export const useGoogleLogin = () => {
     //   프로덕션에서도 localhost로 돌아오는 문제가 있었음 → 환경변수는 폴백으로만.
     const siteUrl = location.origin || process.env.NEXT_PUBLIC_SITE_URL;
 
+    // 로그인 뒤 돌아갈 곳을 콜백까지 들려 보낸다.
+    // 여기서 한 번 걸러도 콜백에서 다시 검증한다 — 콜백 URL 은 사용자가 직접
+    // 만들어 열 수 있어서 클라이언트 검증만으로는 못 막는다.
+    const safeNext = toSafeRedirect(next);
+    const callbackUrl = safeNext
+      ? `${siteUrl}/auth/callback?next=${encodeURIComponent(safeNext)}`
+      : `${siteUrl}/auth/callback`;
+
     // Google OAuth 로그인 시작
     // signInWithOAuth는 즉시 리디렉션 발생 → 외부 Google 로그인 페이지로 이동
     const { error } = await supabase.auth.signInWithOAuth({
@@ -38,7 +48,7 @@ export const useGoogleLogin = () => {
         // OAuth 콜백 후 리디렉션될 URL
         // - 로컬: http://localhost:3000/auth/callback
         // - 프로덕션: https://yourdomain.com/auth/callback (환경 변수 설정 필요)
-        redirectTo: `${siteUrl}/auth/callback`,
+        redirectTo: callbackUrl,
       },
     });
 

--- a/apps/page0127/src/features/auth/api/useLogout.ts
+++ b/apps/page0127/src/features/auth/api/useLogout.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { createClient } from '@/shared/config/supabase/client';
+import { isProtectedPath } from '@/shared/lib/auth/protectedRoutes';
 
 /**
  * 로그아웃 Custom Hook
@@ -49,10 +50,15 @@ export const useLogout = () => {
     // 피드·댓글 캐시가 섞이면 안 된다.
     queryClient.clear();
 
-    // 로그아웃 후에는 홈으로 보낸다. 이 서비스는 비로그인 상태에서도 전체 도서·공개
-    // 서재를 볼 수 있어서, 로그인 화면으로 보내면 둘러볼 길을 막는다(계정 삭제도 홈으로 간다).
-    router.push('/');
+    // 보던 곳이 로그인 없이도 볼 수 있는 페이지면 그 자리에 머문다.
+    // 책 소개·남의 서재를 구경하다 로그아웃했다고 홈으로 쫓아낼 이유가 없다.
+    // 보호 페이지(내 서재·설정 등)에 있었다면 더는 볼 수 없으므로 홈으로 보낸다.
+    if (isProtectedPath(window.location.pathname)) {
+      router.push('/');
+    }
+
     // Server Component가 렌더해 둔 인증 상태(헤더 아바타 등)를 버린다.
+    // 제자리에 머무는 경우에도 필요하다 — 안 하면 로그인된 화면이 그대로 남는다.
     router.refresh();
   };
 

--- a/apps/page0127/src/features/auth/ui/LoginWithGoogleButton.tsx
+++ b/apps/page0127/src/features/auth/ui/LoginWithGoogleButton.tsx
@@ -40,6 +40,8 @@ type LoginWithGoogleButtonProps = {
     | 'link';
   className?: string;
   children?: React.ReactNode;
+  /** 로그인 후 돌아갈 내부 경로. 로그인 페이지가 ?redirect= 에서 받아 넘긴다 */
+  next?: string | null;
 };
 
 export const LoginWithGoogleButton = ({
@@ -47,11 +49,17 @@ export const LoginWithGoogleButton = ({
   className = 'w-full',
   variant = 'default',
   children = 'Google로 로그인',
+  next,
 }: LoginWithGoogleButtonProps) => {
   const { login } = useGoogleLogin();
 
   return (
-    <Button onClick={login} className={className} size={size} variant={variant}>
+    <Button
+      onClick={() => login(next)}
+      className={className}
+      size={size}
+      variant={variant}
+    >
       <Icons name='google' />
       {children}
     </Button>

--- a/apps/page0127/src/shared/config/supabase/middleware.ts
+++ b/apps/page0127/src/shared/config/supabase/middleware.ts
@@ -76,10 +76,17 @@ export async function updateSession(request: NextRequest): Promise<{
       (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
     );
 
-  // 비로그인 사용자가 보호된 경로에 접근하면 로그인 페이지로 리디렉션
+  // 비로그인 사용자가 보호된 경로에 접근하면 로그인 페이지로 리디렉션.
+  // 원래 가려던 곳을 redirect 로 남겨, 로그인 뒤 그리로 돌아가게 한다
+  // (안 남기면 로그인 후 본인 서재로만 가서 하려던 일을 잃는다).
   if (!user && isProtected) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
+    url.search = '';
+    url.searchParams.set(
+      'redirect',
+      `${pathname}${request.nextUrl.search}${request.nextUrl.hash}`
+    );
     return { response: NextResponse.redirect(url), user, supabase };
   }
 

--- a/apps/page0127/src/shared/config/supabase/middleware.ts
+++ b/apps/page0127/src/shared/config/supabase/middleware.ts
@@ -2,6 +2,8 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { createServerClient } from '@supabase/ssr';
 
+import { isProtectedPath } from '@/shared/lib/auth/protectedRoutes';
+
 import type { SupabaseClient, User } from '@supabase/supabase-js';
 
 /**
@@ -47,34 +49,10 @@ export async function updateSession(request: NextRequest): Promise<{
     data: { user },
   } = await supabase.auth.getUser();
 
-  // 보호된 경로 prefix 목록 — app/(protected) 그룹과 동기화한다.
-  // 여기에 누락되더라도 (protected)/layout.tsx 의 가드가 안전망으로 동작한다.
-  // '/dashboard'는 이제 로그인 사용자의 /{username}으로 리다이렉트만 하는
-  // 얇은 스텁이라 보호가 필요 없다 (안 걸려도 로그인 자체는 각 실제 기능에서 확인한다).
-  const PROTECTED_PREFIXES = [
-    '/admin',
-    '/books',
-    '/feed',
-    '/search',
-    '/settings',
-    '/notifications',
-  ];
-
-  // /books 하위지만 로그인 없이 열어두는 경로 — app/(public)/books 와 동기화한다.
-  // 카탈로그와 책 정보는 서비스의 얼굴이자 SEO 자산이다.
-  // 로그인은 "담아둘 때" 필요하지 "구경할 때" 필요한 게 아니다.
-  const PUBLIC_EXCEPTIONS = ['/books/all', '/books/info'];
-
+  // 경로 판정은 shared/lib/auth/protectedRoutes 한 곳에 있다.
+  // 로그아웃(useLogout)도 같은 함수를 써서 "막는 곳"과 "머물러도 되는 곳"이 어긋나지 않는다.
   const { pathname } = request.nextUrl;
-
-  const isPublicException = PUBLIC_EXCEPTIONS.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
-  );
-  const isProtected =
-    !isPublicException &&
-    PROTECTED_PREFIXES.some(
-      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
-    );
+  const isProtected = isProtectedPath(pathname);
 
   // 비로그인 사용자가 보호된 경로에 접근하면 로그인 페이지로 리디렉션.
   // 원래 가려던 곳을 redirect 로 남겨, 로그인 뒤 그리로 돌아가게 한다

--- a/apps/page0127/src/shared/lib/auth/protectedRoutes.test.ts
+++ b/apps/page0127/src/shared/lib/auth/protectedRoutes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isProtectedPath } from './protectedRoutes';
+
+describe('isProtectedPath', () => {
+  it('보호 경로는 true', () => {
+    expect(isProtectedPath('/feed')).toBe(true);
+    expect(isProtectedPath('/settings/profile')).toBe(true);
+    expect(isProtectedPath('/admin')).toBe(true);
+    expect(isProtectedPath('/notifications')).toBe(true);
+  });
+
+  it('공개 예외가 보호 목록을 이긴다', () => {
+    // /books 로 시작하지만 누구나 볼 수 있어야 하는 경로
+    expect(isProtectedPath('/books/all')).toBe(false);
+    expect(isProtectedPath('/books/info/abc-123')).toBe(false);
+  });
+
+  it('개인 서재 책 상세는 보호 경로다', () => {
+    expect(isProtectedPath('/books/some-book-id')).toBe(true);
+  });
+
+  it('공개 페이지는 false', () => {
+    expect(isProtectedPath('/')).toBe(false);
+    expect(isProtectedPath('/login')).toBe(false);
+    expect(isProtectedPath('/terms')).toBe(false);
+    // 공개 프로필·공개 책 상세 — /{username}, /{username}/{bookId}
+    expect(isProtectedPath('/dreamfulbud')).toBe(false);
+    expect(isProtectedPath('/dreamfulbud/book-id')).toBe(false);
+  });
+
+  it('접두사만 같은 다른 경로를 보호로 오인하지 않는다', () => {
+    // '/searchable' 은 '/search' 로 시작하지만 다른 경로다
+    expect(isProtectedPath('/searchable')).toBe(false);
+    expect(isProtectedPath('/bookstore')).toBe(false);
+  });
+});

--- a/apps/page0127/src/shared/lib/auth/protectedRoutes.ts
+++ b/apps/page0127/src/shared/lib/auth/protectedRoutes.ts
@@ -1,0 +1,46 @@
+/**
+ * 로그인이 필요한 경로 판정 — 미들웨어와 클라이언트가 함께 쓴다.
+ *
+ * 왜 한 곳에 모으는가: 미들웨어는 "막을 곳"을, 로그아웃은 "머물러도 되는 곳"을
+ * 알아야 하는데 둘은 같은 질문이다. 각자 목록을 들고 있으면 한쪽만 고쳐져
+ * "로그아웃했더니 접근 못 하는 페이지에 남는" 어긋남이 생긴다.
+ */
+
+/**
+ * 보호된 경로 prefix — app/(protected) 그룹과 동기화한다.
+ * 여기에 누락되더라도 (protected)/layout.tsx 의 가드가 안전망으로 동작한다.
+ * '/dashboard'는 로그인 사용자의 /{username}으로 리다이렉트만 하는 얇은 스텁이라 뺀다.
+ */
+export const PROTECTED_PREFIXES = [
+  '/admin',
+  '/books',
+  '/feed',
+  '/search',
+  '/settings',
+  '/notifications',
+] as const;
+
+/**
+ * /books 하위지만 로그인 없이 열어두는 경로 — app/(public)/books 와 동기화한다.
+ * 카탈로그와 책 정보는 서비스의 얼굴이자 SEO 자산이다.
+ * 로그인은 "담아둘 때" 필요하지 "구경할 때" 필요한 게 아니다.
+ */
+export const PUBLIC_EXCEPTIONS = ['/books/all', '/books/info'] as const;
+
+const startsWithSegment = (pathname: string, prefix: string) =>
+  pathname === prefix || pathname.startsWith(`${prefix}/`);
+
+/**
+ * 이 경로가 로그인을 요구하는가.
+ *
+ * 공개 예외가 보호 목록보다 우선한다 — `/books/info/xxx` 는 `/books` 로 시작하지만
+ * 누구나 볼 수 있어야 한다.
+ */
+export function isProtectedPath(pathname: string): boolean {
+  if (PUBLIC_EXCEPTIONS.some((prefix) => startsWithSegment(pathname, prefix))) {
+    return false;
+  }
+  return PROTECTED_PREFIXES.some((prefix) =>
+    startsWithSegment(pathname, prefix)
+  );
+}

--- a/apps/page0127/src/shared/lib/auth/safeRedirect.test.ts
+++ b/apps/page0127/src/shared/lib/auth/safeRedirect.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { toSafeRedirect } from './safeRedirect';
+
+describe('toSafeRedirect', () => {
+  it('내부 경로는 그대로 통과시킨다', () => {
+    expect(toSafeRedirect('/books/info/abc')).toBe('/books/info/abc');
+    expect(toSafeRedirect('/dreamfulbud/book-id')).toBe('/dreamfulbud/book-id');
+  });
+
+  it('쿼리와 해시를 붙인 내부 경로도 유지한다', () => {
+    expect(toSafeRedirect('/search?q=카프카#top')).toBe('/search?q=카프카#top');
+  });
+
+  it('값이 없으면 null', () => {
+    expect(toSafeRedirect(null)).toBeNull();
+    expect(toSafeRedirect('')).toBeNull();
+  });
+
+  // 오픈 리다이렉트 방어 — 여기를 통과시키면 로그인 직후 외부 사이트로 튕겨나간다
+  it('절대 URL은 막는다', () => {
+    expect(toSafeRedirect('https://evil.com')).toBeNull();
+    expect(toSafeRedirect('http://evil.com/path')).toBeNull();
+  });
+
+  it('프로토콜 상대 URL(//, /\\)은 막는다', () => {
+    // 브라우저는 //evil.com 을 현재 프로토콜의 외부 주소로 해석한다
+    expect(toSafeRedirect('//evil.com')).toBeNull();
+    // 일부 브라우저는 백슬래시를 슬래시처럼 다룬다
+    expect(toSafeRedirect('/\\evil.com')).toBeNull();
+    expect(toSafeRedirect('/\\\\evil.com')).toBeNull();
+  });
+
+  it('슬래시로 시작하지 않는 값은 막는다', () => {
+    expect(toSafeRedirect('books/all')).toBeNull();
+    expect(toSafeRedirect('javascript:alert(1)')).toBeNull();
+  });
+
+  it('앞뒤 공백이 섞인 우회 시도를 막는다', () => {
+    // ' //evil.com' 처럼 공백을 앞에 붙이면 startsWith('//') 검사를 피할 수 있다
+    expect(toSafeRedirect(' //evil.com')).toBeNull();
+    expect(toSafeRedirect('\t/books/all')).toBe('/books/all');
+  });
+
+  it('로그인 페이지로 돌려보내지 않는다 (무한 왕복 방지)', () => {
+    expect(toSafeRedirect('/login')).toBeNull();
+    expect(toSafeRedirect('/login?redirect=/feed')).toBeNull();
+  });
+});

--- a/apps/page0127/src/shared/lib/auth/safeRedirect.ts
+++ b/apps/page0127/src/shared/lib/auth/safeRedirect.ts
@@ -1,0 +1,35 @@
+/**
+ * 로그인 후 돌아갈 경로를 안전한 내부 경로로만 좁힌다.
+ *
+ * 왜 검증이 필요한가 (오픈 리다이렉트):
+ * - `?redirect=` 값을 그대로 믿고 이동하면, 공격자가 만든 링크
+ *   (`/login?redirect=https://evil.com`)를 누른 사용자가 **로그인 직후** 외부
+ *   사이트로 튕겨나간다. 우리 도메인에서 출발했으므로 사용자는 의심하지 않고,
+ *   그곳의 가짜 로그인 화면에 자격 증명을 넣기 쉽다.
+ * - 그래서 "우리 사이트 안의 경로"만 통과시킨다.
+ *
+ * 막는 형태:
+ * - `https://evil.com` — 절대 URL
+ * - `//evil.com` — 프로토콜 상대 URL. 브라우저가 현재 프로토콜의 외부 주소로 읽는다
+ * - `/\evil.com` — 일부 브라우저가 백슬래시를 슬래시처럼 다룬다
+ * - 앞뒤 공백으로 위 검사를 피하려는 시도
+ * - `/login` — 로그인 페이지로 돌려보내면 왕복만 반복한다
+ *
+ * @returns 안전한 내부 경로, 아니면 null (호출부가 기본 목적지를 정한다)
+ */
+export function toSafeRedirect(
+  value: string | null | undefined
+): string | null {
+  if (!value) return null;
+
+  // 공백을 남겨두면 ' //evil.com' 이 아래 검사를 통과한다
+  const path = value.trim();
+
+  if (!path.startsWith('/')) return null;
+  // '//' 와 '/\' 는 둘 다 외부로 나가는 문이다
+  if (path.startsWith('//') || path.startsWith('/\\')) return null;
+  // 로그인 페이지로 되돌리면 로그인 → 로그인 왕복이 된다
+  if (path === '/login' || path.startsWith('/login?')) return null;
+
+  return path;
+}


### PR DESCRIPTION
## 무엇을

로그인·로그아웃 뒤 이동 경로를 고칩니다. 작업 중 **잠자던 오픈 리다이렉트 취약점**을 발견해 함께 막았습니다.

## 왜

- **로그인하면 늘 본인 서재로만 갔습니다.** 미들웨어가 `/login`으로 보낼 때 원래 경로를 남기지 않아, 하려던 일을 잃었습니다.
- **로그아웃하면 무조건 홈으로 갔습니다.** 책 소개·남의 서재를 구경하다 로그아웃했다고 쫓아낼 이유가 없습니다.
- `app/auth/callback/route.ts`는 **이미 `next` 파라미터를 읽어 이동하고 있었는데 검증이 없었습니다.** 아무도 채워주지 않아 잠자던 코드였지만, `/auth/callback?next=https://evil.com`을 직접 열면 그대로 외부로 나갔습니다. 복귀 체인을 잇기 전에 이것부터 막아야 했습니다 — 안 그러면 취약점을 활성화하는 셈이었습니다.

## 어떻게

### 1. 오픈 리다이렉트 방어 (`5938384`)

`shared/lib/auth/safeRedirect.ts`의 `toSafeRedirect`가 내부 경로만 통과시킵니다.

| 막는 형태 | 이유 |
|---|---|
| `https://evil.com` | 절대 URL |
| `//evil.com` | 프로토콜 상대 URL — 브라우저가 외부 주소로 읽음 |
| `/\evil.com` | 일부 브라우저가 백슬래시를 슬래시처럼 다룸 |
| ` //evil.com` | 공백으로 위 검사 우회 |
| `/login` | 로그인 → 로그인 왕복 |

### 2. 로그인 후 복귀 (`acc9162`)

끊겨 있던 체인을 잇습니다: **미들웨어**가 `?redirect=`를 남기고 → **로그인 페이지**가 읽어 버튼에 내리고 → **OAuth**가 콜백에 `?next=`로 전달.

검증은 클라이언트와 콜백 **양쪽**에서 합니다. 콜백 URL은 사용자가 직접 만들어 열 수 있어 클라이언트 검증만으로는 못 막습니다.

`redirect`는 Server Component인 페이지에서 읽습니다 — `useSearchParams`를 쓰면 Suspense 경계가 필요해지는데 그럴 이유가 없습니다.

### 3. 로그아웃 목적지 (`2d77400`)

공개 페이지면 **그 자리에 머물고**, 보호 페이지에 있었을 때만 홈으로 보냅니다.

이를 위해 경로 판정(`PROTECTED_PREFIXES`·`PUBLIC_EXCEPTIONS`)을 미들웨어에서 `shared/lib/auth/protectedRoutes.ts`로 옮겨 양쪽이 같은 함수를 쓰게 했습니다. 목록이 두 벌이면 한쪽만 고쳐져 "로그아웃했더니 못 보는 페이지에 남는" 어긋남이 생깁니다.

## 검증

- `tsc --noEmit` 0 · `eslint` 0 · **vitest 181개 통과**(신규 13개)
- 로컬 수동 확인 4항목 — 로그인 복귀 / 로그아웃 제자리 / 보호 페이지에서 홈 이동 / **`?redirect=https://example.com` 차단**

## 리뷰 포인트

- `toSafeRedirect`가 막아야 할 형태를 빠뜨리지 않았는지 (`safeRedirect.test.ts` 8케이스)
- `isProtectedPath`의 공개 예외 우선순위 — `/books/info/xxx`는 `/books`로 시작하지만 공개여야 합니다
