### PR TITLE
fix(share): 책장 카드가 인생책을 새 컬럼(is_life_book)으로 센다

### DIFF
--- a/apps/page0127/src/entities/book/api/getPublicShelfSummary.ts
+++ b/apps/page0127/src/entities/book/api/getPublicShelfSummary.ts
@@ -4,7 +4,7 @@ import { createAnonClient } from '@/shared/config/supabase/anon';
 export type PublicShelfSummary = {
   /** 공개된 완독 권수 */
   totalBooks: number;
-  /** 그중 인생책(rating 10) 권수 */
+  /** 그중 인생책 권수 */
   lifeBooks: number;
 };
 
@@ -43,8 +43,10 @@ export const getPublicShelfSummary = async (
     { count: life, error: lifeError },
   ] = await Promise.all([
     publicCompleted(),
-    // 인생책 = rating 10 (entities/book/model/rating.ts 의 isLifeBook)
-    publicCompleted().eq('rating', 10),
+    // 인생책은 books.is_life_book 컬럼이다. 예전에는 rating=10 이라는 매직값이었지만
+    // 20260728000005 마이그레이션이 그 행들을 rating=5 + is_life_book=true 로 백필하고
+    // CHECK 에서 10 을 뺐다 — 옛 조건을 그대로 두면 조용히 0 만 세게 된다.
+    publicCompleted().eq('is_life_book', true),
   ]);
 
   if (totalError || lifeError) {


### PR DESCRIPTION
트랙 F(#27) 머지 직후 발견한 회귀입니다. **아직 운영에 배포되지 않아 사용자에게 보인 적은 없습니다.**

## 무엇이 문제인가

`20260728000005_split_life_book_from_rating.sql`이 인생책을 매직값에서 컬럼으로 옮겼습니다:

```sql
update public.books set rating = 5, is_life_book = true where rating = 10;
alter table ... add constraint books_rating_check check (rating in (0,1,2,3,4,5));
```

트랙 F는 책 기록 카드(`[bookId]/opengraph-image.tsx`)와 `getPublicBookRecord`를 고쳤지만,
**책장 카드가 쓰는 `getPublicShelfSummary`는 범위 밖**이었습니다 (커밋 5eb936c의 메시지대로,
이 파일들은 트랙 F 착수 뒤 main에 들어와 읽기 경로 감사에 안 잡혔습니다).

거기가 아직 이렇게 세고 있었습니다:

```ts
publicCompleted().eq('rating', 10),
```

마이그레이션 후 `rating = 10`인 행은 **하나도 없습니다.** 따라서 인생책은 항상 0이 되고,
카드는 0이면 "인생책 N권" 줄을 통째로 생략하도록 되어 있어 **에러 없이 조용히 사라집니다.**

전수 grep으로 확인한 결과 이 한 줄이 옛 매직값의 **유일한 잔존 지점**이었습니다.

## 고친 것

```ts
publicCompleted().eq('is_life_book', true),
```

주석에 마이그레이션 번호와 "옛 조건을 두면 조용히 0만 센다"는 이유를 남겼습니다.

## 검증

`lint` · `type-check` · `test`(200개) · `build` 모두 통과.

로컬에서 **새 스키마 시드**(공개 완독 20권, 그중 `is_life_book = true` 6권)를 넣고 카드를
렌더해 **"읽은 책 20권 · 인생책 6권"**을 확인했습니다 — DB 실제 값과 일치합니다.
수정 전이라면 인생책 줄이 나오지 않습니다.

## 타이밍

트랙 F가 아직 Production에 배포되지 않았습니다(운영 카드 URL 해시가 그대로).
이 PR이 같은 배포에 실리면 **인생책 표시가 사라지는 구간 없이** 넘어갑니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
