### PR TITLE
🐛 Fix: 도서 검색 입력창이 자동 검색 중 포커스를 잃는다

### DIFF
--- a/apps/page0127/src/features/book/api/useBookSearch.ts
+++ b/apps/page0127/src/features/book/api/useBookSearch.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useReducer } from 'react';
+import { useCallback, useReducer, useRef } from 'react';
 
 import { searchBooks } from '@/shared/api/aladin';
 
@@ -90,14 +90,23 @@ export const useBookSearch = () => {
 
   const ITEMS_PER_PAGE = 10;
 
+  // 마지막으로 시작한 요청의 번호. 입력창을 검색 중에도 열어두면서
+  // (disabled 를 걸면 브라우저가 포커스를 뺏는다 — BookSearchInput 주석 참조)
+  // 요청이 여러 개 겹칠 수 있게 됐다. 먼저 보낸 요청이 늦게 도착하면
+  // 최신 검색어의 결과를 덮어써 버리므로, 마지막 요청의 응답만 반영한다.
+  const requestIdRef = useRef(0);
+
   // useCallback으로 함수를 메모이제이션 → 매 렌더마다 새 함수가 생기는 것을 방지
   // (BookSearchInput의 useEffect가 onSearch를 의존성으로 참조하는데,
   //  참조가 매번 바뀌면 effect가 계속 재실행 → 무한 루프로 이어짐)
   const search = useCallback(async (query: string, page = 1) => {
     if (!query.trim()) {
+      requestIdRef.current += 1; // 진행 중인 응답이 초기화를 되돌리지 못하게 한다
       dispatch({ type: 'SEARCH_CLEAR' });
       return;
     }
+
+    const requestId = (requestIdRef.current += 1);
 
     // 검색 시작: loading ON, 쿼리/페이지 저장
     dispatch({ type: 'SEARCH_START', query, page });
@@ -107,6 +116,7 @@ export const useBookSearch = () => {
         page,
         maxResults: ITEMS_PER_PAGE,
       });
+      if (requestId !== requestIdRef.current) return; // 뒤늦게 온 옛 응답 — 버린다
       const items = response.item || [];
 
       // 검색 성공: 결과 저장, loading OFF
@@ -116,6 +126,7 @@ export const useBookSearch = () => {
         totalResults: response.totalResults,
       });
     } catch (err) {
+      if (requestId !== requestIdRef.current) return;
       // 검색 실패: 에러 저장, loading OFF
       dispatch({ type: 'SEARCH_ERROR' });
       console.error(err);

--- a/apps/page0127/src/features/book/api/useBookSearch.ts
+++ b/apps/page0127/src/features/book/api/useBookSearch.ts
@@ -26,12 +26,10 @@ type SearchState = {
 // SEARCH_START  → 검색 시작 (loading ON, 이전 에러 초기화)
 // SEARCH_SUCCESS → 검색 성공 (결과 저장, loading OFF)
 // SEARCH_ERROR  → 검색 실패 (에러 저장, loading OFF)
-// SEARCH_CLEAR  → 입력 비움 (초기화)
 type SearchAction =
   | { type: 'SEARCH_START'; query: string; page: number }
   | { type: 'SEARCH_SUCCESS'; books: AladinBook[]; totalResults: number }
-  | { type: 'SEARCH_ERROR' }
-  | { type: 'SEARCH_CLEAR' };
+  | { type: 'SEARCH_ERROR' };
 
 // ─── 초기 상태 ────────────────────────────────────────────────────
 const initialState: SearchState = {
@@ -69,9 +67,6 @@ function searchReducer(state: SearchState, action: SearchAction): SearchState {
         isLoading: false,
         error: '도서 검색 중 오류가 발생했습니다.',
       };
-    case 'SEARCH_CLEAR':
-      // 초기 상태로 완전 리셋
-      return initialState;
     default:
       return state;
   }
@@ -100,11 +95,14 @@ export const useBookSearch = () => {
   // (BookSearchInput의 useEffect가 onSearch를 의존성으로 참조하는데,
   //  참조가 매번 바뀌면 effect가 계속 재실행 → 무한 루프로 이어짐)
   const search = useCallback(async (query: string, page = 1) => {
-    if (!query.trim()) {
-      requestIdRef.current += 1; // 진행 중인 응답이 초기화를 되돌리지 못하게 한다
-      dispatch({ type: 'SEARCH_CLEAR' });
-      return;
-    }
+    // 빈 검색어로 알라딘 API 를 때리지 않기 위한 방어선. 호출처(BookSearchInput)가
+    // 모두 trim 검사를 하고 있어 실제로 도달하지 않지만, 그 계약을 여기서도 지킨다.
+    //
+    // 결과 목록은 일부러 지우지 않는다 — 검색어를 다 지우는 건 "결과를 버리겠다"가
+    // 아니라 "다시 치겠다"의 중간 단계라, 그때마다 목록이 사라지면 목록 → 빈 화면 →
+    // 로딩 → 새 목록으로 화면이 두 번 요동친다. 결과가 페이지 본문인 검색 UI
+    // (구글·알라딘 등)는 입력창을 비워도 이전 결과를 유지한다.
+    if (!query.trim()) return;
 
     const requestId = (requestIdRef.current += 1);
 

--- a/apps/page0127/src/features/book/ui/BookSearchInput.tsx
+++ b/apps/page0127/src/features/book/ui/BookSearchInput.tsx
@@ -89,6 +89,13 @@ export const BookSearchInput = ({
   return (
     <div className='relative'>
       <form onSubmit={handleSubmit} className='flex gap-2'>
+        {/*
+          입력창에는 disabled 를 걸지 않는다.
+          400ms 디바운스 자동 검색이 타이핑 도중에 걸리는데, 그때 input 이 disabled 가 되면
+          브라우저가 포커스를 강제로 떼어낸다(그리고 다시 돌려주지 않는다).
+          → 사용자 체감: "치다가 멈추고 포커스가 사라진다".
+          로딩 표시는 버튼에서만 한다.
+        */}
         <Input
           ref={ref}
           type='text'
@@ -97,7 +104,6 @@ export const BookSearchInput = ({
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setTimeout(() => setIsFocused(false), 150)}
-          disabled={isLoading}
           className='flex-1'
         />
         <Button type='submit' disabled={isLoading || !query.trim()}>


### PR DESCRIPTION
## 문제

`/books/add` 에서 검색어를 입력하다 보면 **입력이 끊기고 포커스가 사라진다.**

## 원인

`BookSearchInput` 입력창에 `disabled={isLoading}` 이 걸려 있었다.

1. 타이핑 → 400ms 멈춤(`useDebounce`) → 자동 검색 시작
2. `isLoading = true` → **input 이 `disabled` 로 바뀜**
3. 브라우저는 disabled 된 요소에서 **포커스를 강제로 제거**한다 (게다가 `disabled:pointer-events-none`)
4. 응답이 와서 `disabled` 가 풀려도 **포커스는 돌아오지 않는다**

즉 타이핑 도중 잠깐 멈출 때마다 입력창이 죽었다 살아나며, 그 사이 누른 키가 씹힌다.

## 수정

**1. 입력창에서 `disabled` 제거** — 로딩 표시는 검색 버튼에서만 한다.

**2. 요청 번호 가드 추가 (`useBookSearch`)** — 입력창이 검색 중에도 살아있게 되면서 요청이 겹칠 수 있다. 먼저 보낸 요청이 늦게 도착해 최신 검색어의 결과를 덮어쓰지 않도록, 마지막 요청의 응답만 반영한다.

**3. 죽은 코드 `SEARCH_CLEAR` 제거** — `onSearch` 호출처 3곳이 모두 빈 검색어를 걸러내고 있어 dispatch 될 수 없는 액션이었다. "입력 비움 → 초기화" 라는 주석이 사실이 아니었으므로 코드를 사실에 맞춘다.

## 하지 않은 것

**검색어를 다 지웠을 때 결과 목록 초기화** — 검토했으나 의도적으로 두었다.

- 결과가 페이지 본문인 검색 UI(구글·네이버·알라딘 등)는 입력창을 비워도 이전 결과를 유지한다. 결과가 사라지는 건 입력창에 붙은 오버레이형(Spotlight, 커맨드 팔레트, 자동완성) 패턴이다.
- 텍스트를 다 지우는 건 "결과를 버리겠다"가 아니라 "다시 치겠다"의 중간 단계다. 지울 때마다 목록 → 빈 화면 → 로딩 → 새 목록으로 화면이 두 번 요동친다.

근거는 `useBookSearch` 의 빈 검색어 가드에 주석으로 남겼다.

## 검증

- [x] `tsc --noEmit` 통과
- [x] 변경 파일 `eslint` 통과
- [x] 로컬에서 `/books/add` 타이핑 — 포커스 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
