### PR TITLE
fix(share): 인생책 조회가 실패해도 총 권수는 카드에 남긴다

### DIFF
--- a/apps/page0127/src/entities/book/api/getPublicShelfSummary.ts
+++ b/apps/page0127/src/entities/book/api/getPublicShelfSummary.ts
@@ -22,7 +22,8 @@ export type PublicShelfSummary = {
  * 기준: status='completed' + completed_date 있음 + is_public=true
  * (완독일이 없는 책을 통계에서 빼는 것은 getOverallStats 41행의 규칙이다)
  *
- * 조회에 실패하면 0을 돌려준다 — 카드가 깨지는 것보다 빈 선반이 낫다.
+ * 조회 실패는 **각각 격리한다** — 인생책 한 줄 때문에 총 권수까지 버리지 않는다.
+ * 카드가 깨지는 것보다 빈 선반이 낫지만, 아는 숫자까지 버릴 이유는 없다.
  */
 export const getPublicShelfSummary = async (
   userId: string
@@ -38,10 +39,7 @@ export const getPublicShelfSummary = async (
       .not('completed_date', 'is', null)
       .eq('is_public', true);
 
-  const [
-    { count: total, error: totalError },
-    { count: life, error: lifeError },
-  ] = await Promise.all([
+  const [totalResult, lifeResult] = await Promise.all([
     publicCompleted(),
     // 인생책은 books.is_life_book 컬럼이다. 예전에는 rating=10 이라는 매직값이었지만
     // 20260728000005 마이그레이션이 그 행들을 rating=5 + is_life_book=true 로 백필하고
@@ -49,13 +47,22 @@ export const getPublicShelfSummary = async (
     publicCompleted().eq('is_life_book', true),
   ]);
 
-  if (totalError || lifeError) {
-    console.error(
-      '공개 책장 요약 조회 실패:',
-      totalError?.message ?? lifeError?.message
-    );
+  // 총 권수를 못 세면 카드에 쓸 것이 없다 — 빈 선반으로 떨어진다
+  if (totalResult.error) {
+    console.error('공개 책장 권수 조회 실패:', totalResult.error.message);
     return { totalBooks: 0, lifeBooks: 0 };
   }
 
-  return { totalBooks: total ?? 0, lifeBooks: life ?? 0 };
+  const totalBooks = totalResult.count ?? 0;
+
+  // 인생책만 실패했으면 그 줄만 뺀다. 예전에는 둘 중 하나만 실패해도 0/0 을 돌려줬는데,
+  // is_life_book 컬럼이 아직 없던 배포 직후 그 경로를 타면서 155권 읽은 책장이
+  // "빈 선반"으로 나갔다(2026-07-29). 크롤러가 그 카드를 한동안 들고 있으므로,
+  // 한쪽이 죽어도 살아 있는 숫자는 내보낸다.
+  if (lifeResult.error) {
+    console.error('인생책 권수 조회 실패:', lifeResult.error.message);
+    return { totalBooks, lifeBooks: 0 };
+  }
+
+  return { totalBooks, lifeBooks: lifeResult.count ?? 0 };
 };


### PR DESCRIPTION
어제(2026-07-29) 실제로 터진 경로를 막는 작은 방어입니다.

## 무엇이 문제였나

책장 카드는 DB에 두 번 묻습니다.

```
① 이 사람 몇 권 읽었나?   → 155
② 그중 인생책 몇 권인가?   → 12
```

그런데 코드가 이렇게 되어 있었습니다.

```ts
if (totalError || lifeError) {
  return { totalBooks: 0, lifeBooks: 0 };   // 둘 중 하나만 실패해도 둘 다 버린다
}
```

**PR #29 배포 직후 그 경로를 탔습니다.** 트랙 F 코드가 운영에 나갔지만 DB 마이그레이션은
아직 적용되기 전이라 `is_life_book` 컬럼이 없었고, ②만 실패했는데 ①의 답(155권)까지
함께 버려졌습니다. 결과적으로 155권 읽은 책장의 공유 카드가
**"읽은 책이 모여 책장이 됩니다" + 빈 선반**으로 나갔습니다.

장을 보러 가서 두 가지 중 하나를 못 구했다고 이미 산 것까지 두고 온 셈입니다.

## 고친 것

실패를 각각 격리합니다.

| 상황 | 이전 | 이후 |
|---|---|---|
| ① 성공, ② 실패 | 빈 선반 | **"읽은 책 155권"** (인생책 줄만 빠짐) |
| ① 실패 | 빈 선반 | 빈 선반 (동일) |

공유 카드는 크롤러가 받아 한동안 들고 있습니다. 잘못된 "빈 책장" 카드가 캐시되면
링크를 받은 사람에게는 그게 전부라, 아는 숫자까지 버릴 이유가 없습니다.

## 검증

실패를 **실제로 만들어서** 확인했습니다 — 인생책 조회의 컬럼명을 존재하지 않는 것으로
바꿔 렌더한 뒤, 원복하고 다시 렌더했습니다.

| | 결과 |
|---|---|
| 인생책 조회 실패 | **"읽은 책 20권"** + 책등 20권 (인생책 줄만 빠짐) |
| 정상 | **"읽은 책 20권 · 인생책 5권"** — DB 실제 값과 일치 |

임시 코드가 남지 않은 것도 확인했습니다.

`lint` · `type-check` · `test`(221개) · `build` 모두 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
