### PR TITLE
👷 CI: uptime 실패 알림이 원인을 구분해 알린다

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -70,5 +70,26 @@ jobs:
             fi
           done
 
-          echo "::error::헬스체크 실패 — 마지막 응답: HTTP ${code} / ${preview}"
+          # 원인을 나눠서 알린다.
+          #
+          # 왜: 이 알림은 새벽에도 온다. "헬스체크 실패" 한 줄만 오면 받는 사람이
+          # 로그를 열어 본문을 읽고 어느 층이 고장인지 판단해야 한다. 세 경우는
+          # 대응이 완전히 다르다 — 마이그레이션을 올릴 것인가, Supabase 상태를
+          # 볼 것인가, 배포가 죽었는지 볼 것인가.
+          if printf '%s' "$body" | grep -qF '"schema":"drift"'; then
+            echo "::error::스키마 어긋남 — 배포된 코드가 기대하는 마이그레이션이 운영 DB에 없습니다."
+            echo "::error::대응: npx supabase migration list --linked 로 미적용분을 확인하고 올립니다."
+          elif printf '%s' "$body" | grep -qF '"schema":"unknown"'; then
+            # 감지 장치가 고장난 것과 서비스가 고장난 것은 다르다(health route 주석 참조).
+            # 서비스는 살아 있을 수 있으므로 문구를 구분한다.
+            echo "::error::스키마 버전을 읽지 못했습니다 — 서비스가 아니라 감시가 고장났을 수 있습니다."
+            echo "::error::대응: SUPABASE_SERVICE_ROLE_KEY 와 applied_migration_version 함수 권한을 확인합니다."
+          elif printf '%s' "$body" | grep -qF '"database":"down"'; then
+            echo "::error::DB 연결 실패 — Supabase 상태와 자격증명을 확인합니다."
+          else
+            # 200 이 아니거나 본문이 예상과 다른 경우(배포 실패·soft 404 등)
+            echo "::error::헬스체크 실패 — 응답이 예상 형식이 아닙니다."
+          fi
+
+          echo "::error::마지막 응답: HTTP ${code} / ${preview}"
           exit 1


### PR DESCRIPTION
## 무엇을

`uptime.yml` 이 실패할 때 **원인을 나눠서** 알립니다. 지금은 `헬스체크 실패` 한 줄뿐입니다.

## 왜

이 알림은 **새벽에도 옵니다.** 한 줄만 오면 받는 사람이 로그를 열어 본문을 읽고 어느 층이 고장인지 판단해야 합니다.

PR #37 로 `/api/health` 가 스키마 상태까지 알려주게 됐는데, uptime 쪽은 아직 그 정보를 안 씁니다. 세 경우는 **대응이 완전히 다릅니다**:

| 응답 | 무엇이 고장 | 다음 행동 |
|---|---|---|
| `"schema":"drift"` | DB가 코드보다 뒤처짐 | 마이그레이션을 올린다 |
| `"schema":"unknown"` | **감시가 고장** (서비스는 살아 있을 수 있음) | service_role 키·함수 권한 확인 |
| `"database":"down"` | DB 연결 | Supabase 상태·자격증명 확인 |
| 그 외 | 배포 실패·soft 404 등 | 응답 형식부터 본다 |

`unknown` 을 따로 나눈 건 `health/route.ts` 주석의 그 구분을 알림에도 반영한 것입니다:

> 감지 장치가 고장난 것과 서비스가 고장난 것은 다르다.

## 검증

`health` 가 실제로 내는 네 가지 응답으로 분기를 시험했습니다.

| 입력 | 결과 |
|---|---|
| `{"checks":{"database":"ok","schema":"drift"}}` | → 스키마 어긋남 ✅ |
| `{"checks":{"database":"ok","schema":"unknown"}}` | → 감시 고장 ✅ |
| `{"checks":{"database":"down"}}` | → DB 연결 실패 ✅ |
| `<!DOCTYPE html>…` (soft 404) | → 응답 형식 이상 ✅ |

워크플로 파일만 바뀌므로 앱 코드·테스트에는 영향이 없습니다.

## 배경

PR #38 에서 같은 문제를 풀려다 **#37 이 더 나은 방식으로 먼저 해결**한 걸 발견해 그 PR 은 닫았습니다. 거기서 유일하게 main 에 없던 조각만 떼어 왔습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)