### PR TITLE
🐛 Fix: 스키마 계약이 못 잡던 구멍 + E2E 레이트 리밋 격리

### DIFF
--- a/apps/page0127/app/api/_helpers/schemaContract.test.ts
+++ b/apps/page0127/app/api/_helpers/schemaContract.test.ts
@@ -5,6 +5,7 @@ import {
   SCHEMA_CONTRACT,
   UNDEFINED_COLUMN,
   UNDEFINED_TABLE,
+  UNDEFINED_TABLE_POSTGREST,
 } from './schemaContract';
 
 /**
@@ -57,6 +58,26 @@ describe('스키마 계약', () => {
     );
     expect(failures).toHaveLength(1);
     expect(failures[0].code).toBe(UNDEFINED_TABLE);
+  });
+
+  it('테이블이 없을 때 PostgREST 가 주는 PGRST205 도 잡는다', async () => {
+    // 42P01 만 보던 시절 이걸 놓쳤다. 2026-07-29 개발 DB 에 user_daily_visits 가
+    // 통째로 없었는데 헬스체크는 정상으로 떴다 — PostgREST 는 스키마 캐시에
+    // 테이블이 없으면 쿼리를 실행하지 않고 PGRST205 로 끊기 때문이다.
+    const failures = await checkSchemaContract(async (table) =>
+      table === 'user_daily_visits'
+        ? {
+            code: UNDEFINED_TABLE_POSTGREST,
+            message:
+              "Could not find the table 'public.user_daily_visits' in the schema cache",
+          }
+        : null
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].table).toBe('user_daily_visits');
+    expect(failures[0].code).toBe(UNDEFINED_TABLE_POSTGREST);
+    expect(failures[0].breaks).toContain('재방문');
   });
 
   it('스키마와 무관한 실패(연결 끊김 등)는 계약 위반으로 보지 않는다', async () => {

--- a/apps/page0127/app/api/_helpers/schemaContract.ts
+++ b/apps/page0127/app/api/_helpers/schemaContract.ts
@@ -45,8 +45,27 @@ export const SCHEMA_CONTRACT: SchemaProbe[] = [
 
 /** PostgREST 가 "컬럼 없음" 으로 주는 코드. 다른 실패와 구분해야 원인이 드러난다. */
 export const UNDEFINED_COLUMN = '42703';
-/** 테이블 자체가 없을 때 */
+/** 테이블 자체가 없을 때 (Postgres 가 그대로 올려보내는 경우) */
 export const UNDEFINED_TABLE = '42P01';
+/**
+ * 테이블이 없을 때 PostgREST 가 실제로 주는 코드.
+ *
+ * 42P01 만 보면 **테이블이 통째로 사라져도 검사가 통과한다.** PostgREST 는 요청을
+ * Postgres 로 보내기 전에 자기 스키마 캐시에서 테이블을 찾는데, 거기 없으면
+ * 쿼리를 아예 실행하지 않고 PGRST205 (+ HTTP 404) 로 끊는다. 그래서 42P01 은
+ * 오지 않는다.
+ *
+ * 실제로 겪었다: 2026-07-29 개발 DB 에 user_daily_visits 가 통째로 없었는데
+ * 이 검사는 books 컬럼 하나만 잡고 그 테이블은 정상으로 취급했다.
+ */
+export const UNDEFINED_TABLE_POSTGREST = 'PGRST205';
+
+/** 스키마 이상으로 볼 코드들 — 연결 끊김·일시 오류와 구분한다. */
+const SCHEMA_ERROR_CODES = new Set<string>([
+  UNDEFINED_COLUMN,
+  UNDEFINED_TABLE,
+  UNDEFINED_TABLE_POSTGREST,
+]);
 
 export type ProbeFailure = {
   table: string;
@@ -71,7 +90,7 @@ export async function checkSchemaContract(
     // 스키마 이상(컬럼·테이블 없음)만 계약 위반으로 본다.
     // 연결 끊김이나 일시적 오류는 database 체크가 따로 잡는다.
     const code = error.code ?? null;
-    if (code === UNDEFINED_COLUMN || code === UNDEFINED_TABLE) {
+    if (code !== null && SCHEMA_ERROR_CODES.has(code)) {
       failures.push({
         table: probe.table,
         code,

--- a/apps/page0127/e2e/production-readiness.spec.ts
+++ b/apps/page0127/e2e/production-readiness.spec.ts
@@ -1,9 +1,26 @@
 import { expect, test } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * 레이트 리밋 카운터를 테스트마다 격리한다.
+ *
+ * 왜 필요한가 (2026-07-29):
+ * 레이트 리밋은 인증 검사보다 **앞단**이라, 한도를 넘으면 401 대신 429 가 돌아와
+ * 아래 단언이 깨진다. 그런데 미인증 요청의 식별자는 x-forwarded-for 기반이고,
+ * 그 헤더가 없으면 전부 `ip:unknown` **하나의 카운터를 공유**한다. CI 에는 이
+ * 헤더가 없으니 PR 두 개의 E2E 가 겹치기만 해도 strict 등급(5회/분)을 넘겼다.
+ *
+ * 호출마다 고유한 값을 주면 카운터가 갈라져 이 테스트가 다른 실행에 휘둘리지 않는다.
+ * (식별자는 문자열로만 쓰이므로 IP 형식일 필요는 없다)
+ */
+const isolatedClient = () => ({
+  headers: { 'x-forwarded-for': `e2e-${randomUUID()}` },
+});
 
 test('헬스체크가 앱과 데이터베이스 정상 상태를 반환한다', async ({
   request,
 }) => {
-  const response = await request.get('/api/health');
+  const response = await request.get('/api/health', isolatedClient());
 
   expect(response.status()).toBe(200);
   await expect(response.json()).resolves.toMatchObject({
@@ -15,17 +32,22 @@ test('헬스체크가 앱과 데이터베이스 정상 상태를 반환한다', 
 test('미인증 사용자는 비용 발생 AI API를 호출할 수 없다', async ({
   request,
 }) => {
-  const taste = await request.post('/api/taste-analysis/analyze');
+  const taste = await request.post(
+    '/api/taste-analysis/analyze',
+    isolatedClient()
+  );
   const compatibility = await request.post('/api/compatibility/analyze', {
+    ...isolatedClient(),
     data: { targetUserId: '00000000-0000-0000-0000-000000000001' },
   });
 
+  // 401 이어야 한다 — 429 로 무르면 인증 검사가 망가져도 통과한다.
   expect(taste.status()).toBe(401);
   expect(compatibility.status()).toBe(401);
 });
 
 test('미인증 사용자는 계정을 삭제할 수 없다', async ({ request }) => {
-  const response = await request.delete('/api/auth/account');
+  const response = await request.delete('/api/auth/account', isolatedClient());
 
   expect(response.status()).toBe(401);
 });


### PR DESCRIPTION
PR #40 병합 후 main 에 남아 있던 구멍 두 개를 막는다. 둘 다 "감시가 있는데 엉뚱한 걸 본다" 는
같은 종류의 문제다.

## ① 테이블이 통째로 사라지면 스키마 계약이 못 잡는다

`42P01` 만 보고 있었는데, PostgREST 는 스키마 캐시에 테이블이 없으면 쿼리를 Postgres 로
보내지 않고 **`PGRST205`** 로 끊는다. 그래서 `42P01` 은 애초에 오지 않고, 테이블이 통째로
없어도 헬스체크가 200 으로 떴다.

실제로 그랬다. 2026-07-29 개발 DB 에 `user_daily_visits` 가 없었는데, 검사는 `books` 의
컬럼만 잡고 그 테이블은 정상으로 취급했다.

- `PGRST205` 를 스키마 이상 코드에 추가
- 코드 목록을 `Set` 으로 모아 다음에 늘릴 때 조건문이 길어지지 않게
- 회귀 테스트 추가 — **이 커밋을 되돌리면 새 테스트가 실패하는 것까지 확인했다**

## ② E2E 가 레이트 리밋 때문에 무작위로 깨진다

레이트 리밋은 인증 검사보다 **앞단**이라 한도를 넘으면 401 대신 429 가 온다. 그런데 미인증
요청의 식별자는 `x-forwarded-for` 기반이고, 헤더가 없으면 전부 `ip:unknown` **하나의 카운터를
공유**한다. CI 에는 이 헤더가 없어서, PR 두 개의 E2E 가 겹치기만 해도 strict 등급(5회/분)을
넘겼다. 실제로 PR #38 이 이것 때문에 빨갛게 떴다.

호출마다 고유한 값을 실어 카운터를 갈라놓는다. **401 단언은 그대로 둔다** — `429` 도 허용으로
무르면 인증 검사가 망가져도 통과하기 때문이다.

## 검증

단위 테스트 234개 통과. 레이트 리밋은 개발 서버 + 로컬 DB 로 직접 확인했다:

| 조건 | 결과 |
| --- | --- |
| 헤더 없이 연속 호출 | 6회차부터 **429** (CI 실패 재현) |
| 호출마다 고유 헤더 | 7회 모두 **401** |
| 공유 카운터를 429 까지 소진시킨 상태에서 E2E | **3개 전부 통과** |
