### PR TITLE
🐛 Fix: 취향분석 추천 섹션이 비어 보이던 문제

### DIFF
--- a/apps/page0127/app/(protected)/dashboard/taste-analysis/[id]/page.tsx
+++ b/apps/page0127/app/(protected)/dashboard/taste-analysis/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 import { createClient } from '@/shared/config/supabase/server';
 
 import { getProfile } from '@/entities/profile/api/getProfile';
+import { groupRecommendationsByType } from '@/entities/taste-analysis/model/recommendations';
 
 import { TasteAnalysisResult } from '@/features/taste-analysis/ui/TasteAnalysisResult';
 
@@ -54,21 +55,8 @@ const TasteAnalysisDetailPage = async ({ params }: PageProps) => {
     .order('recommendation_type')
     .order('display_order');
 
-  // 타입별로 그룹화 (표지가 있는 책만 필터링)
-  const groupedRecommendations = {
-    match:
-      recommendations?.filter(
-        (r) => r.recommendation_type === 'match' && r.cover_image !== null
-      ) || [],
-    expand:
-      recommendations?.filter(
-        (r) => r.recommendation_type === 'expand' && r.cover_image !== null
-      ) || [],
-    challenge:
-      recommendations?.filter(
-        (r) => r.recommendation_type === 'challenge' && r.cover_image !== null
-      ) || [],
-  };
+  // 타입별로 그룹화 (노출 상한까지만)
+  const groupedRecommendations = groupRecommendationsByType(recommendations);
 
   const analysisWithRecommendations = {
     ...analysis,

--- a/apps/page0127/app/(protected)/dashboard/taste-analysis/page.tsx
+++ b/apps/page0127/app/(protected)/dashboard/taste-analysis/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/shared/config/supabase/server';
 
 import { getProfile } from '@/entities/profile/api/getProfile';
+import { groupRecommendationsByType } from '@/entities/taste-analysis/model/recommendations';
 
 import { TasteAnalysisResult } from '@/features/taste-analysis/ui/TasteAnalysisResult';
 
@@ -51,21 +52,8 @@ const TasteAnalysisPage = async () => {
     .order('recommendation_type')
     .order('display_order');
 
-  // 타입별로 그룹화 (표지가 있는 책만 필터링)
-  const groupedRecommendations = {
-    match:
-      recommendations?.filter(
-        (r) => r.recommendation_type === 'match' && r.cover_image !== null
-      ) || [],
-    expand:
-      recommendations?.filter(
-        (r) => r.recommendation_type === 'expand' && r.cover_image !== null
-      ) || [],
-    challenge:
-      recommendations?.filter(
-        (r) => r.recommendation_type === 'challenge' && r.cover_image !== null
-      ) || [],
-  };
+  // 타입별로 그룹화 (노출 상한까지만)
+  const groupedRecommendations = groupRecommendationsByType(recommendations);
 
   const analysisWithRecommendations = {
     ...analysis,

--- a/apps/page0127/app/api/taste-analysis/analyze/route.ts
+++ b/apps/page0127/app/api/taste-analysis/analyze/route.ts
@@ -13,6 +13,7 @@ import { createTasteAnalysisPrompt } from '@/shared/lib/openai/prompts/taste-ana
 
 import { isRated } from '@/entities/book';
 import { READING_PERSONALITY_TYPES } from '@/entities/taste-analysis/model/personalityTypes';
+import { RECOMMENDATIONS_REQUEST_COUNT } from '@/entities/taste-analysis/model/recommendations';
 
 import type { Book } from '@/entities/book';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -101,7 +102,8 @@ export async function POST(_request: NextRequest) {
         description: book.description,
         toc: book.toc,
       })),
-      READING_PERSONALITY_TYPES
+      READING_PERSONALITY_TYPES,
+      RECOMMENDATIONS_REQUEST_COUNT
     );
 
     aiRequestStarted = true;
@@ -274,6 +276,17 @@ function calculateCost(promptTokens: number, completionTokens: number): number {
   return Math.ceil(cost * 100); // 센트 단위
 }
 
+/** 알라딘 ItemSearch 응답 중 실제로 쓰는 필드만 추린 타입 */
+type AladinItem = {
+  isbn?: string;
+  isbn13?: string;
+  title: string;
+  author: string;
+  cover?: string;
+  publisher?: string;
+  categoryName?: string;
+};
+
 /**
  * 알라딘 API로 추천 도서 정보 보강 (표지, ISBN, 출판사)
  *
@@ -305,37 +318,52 @@ async function enrichRecommendationsWithAladinData(
     return;
   }
 
+  /** 알라딘 검색 1회 — 결과가 없으면 null */
+  const searchAladin = async (
+    query: string,
+    queryType: 'Title' | 'Keyword'
+  ): Promise<AladinItem | null> => {
+    const params = new URLSearchParams({
+      ttbkey: ALADIN_API_KEY,
+      Query: query,
+      QueryType: queryType,
+      MaxResults: '3',
+      start: '1',
+      SearchTarget: 'Book',
+      output: 'js',
+      Version: '20131101',
+      // 기본값은 저해상도 썸네일 — Big으로 지정해야 큰 사이즈 표지를 받는다
+      Cover: 'Big',
+    });
+
+    const url = `${ALADIN_API_BASE_URL}?${params.toString()}`;
+    // 같은 추천 키워드로 알라딘 검색 시 24시간 동안 캐시 재사용
+    const response = await fetch(url, { next: { revalidate: 86400 } });
+
+    if (!response.ok) {
+      console.error(`알라딘 API 실패 (${query}/${queryType}):`, response.status);
+      return null;
+    }
+
+    const data = await response.json();
+    // 검색 결과에서 첫 번째 책 사용 (제목이 가장 유사)
+    return (data.item?.[0] as AladinItem | undefined) ?? null;
+  };
+
   for (const rec of recommendations) {
     try {
-      // 제목으로 알라딘 API 검색
-      const params = new URLSearchParams({
-        ttbkey: ALADIN_API_KEY,
-        Query: rec.title,
-        QueryType: 'Title',
-        MaxResults: '3',
-        start: '1',
-        SearchTarget: 'Book',
-        output: 'js',
-        Version: '20131101',
-        // 기본값은 저해상도 썸네일 — Big으로 지정해야 큰 사이즈 표지를 받는다
-        Cover: 'Big',
-      });
+      // 1차: 제목 검색. 실패하면 키워드 검색으로 한 번 더 시도한다.
+      //   AI가 부제를 붙이거나 띄어쓰기를 다르게 쓰면 Title 검색은 0건이 나오는데,
+      //   그걸 "존재하지 않는 책"으로 단정하고 지우면 섹션이 빈 채로 남는다.
+      let matchedBook = await searchAladin(rec.title, 'Title');
 
-      const url = `${ALADIN_API_BASE_URL}?${params.toString()}`;
-      // 같은 추천 키워드로 알라딘 검색 시 24시간 동안 캐시 재사용
-      const response = await fetch(url, {
-        next: { revalidate: 86400 },
-      });
-
-      if (!response.ok) {
-        console.error(`알라딘 API 실패 (${rec.title}):`, response.status);
-        continue;
+      if (!matchedBook) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const fallbackQuery = rec.author
+          ? `${rec.title} ${rec.author}`
+          : rec.title;
+        matchedBook = await searchAladin(fallbackQuery, 'Keyword');
       }
-
-      const data = await response.json();
-
-      // 검색 결과에서 첫 번째 책 사용 (제목이 가장 유사)
-      const matchedBook = data.item?.[0];
 
       if (matchedBook) {
         // DB 업데이트 (알라딘 정보로 덮어쓰기)

--- a/apps/page0127/app/api/taste-analysis/latest/route.ts
+++ b/apps/page0127/app/api/taste-analysis/latest/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { createClient } from '@/shared/config/supabase/server';
 
+import { groupRecommendationsByType } from '@/entities/taste-analysis/model/recommendations';
+
 /**
  * 최신 독서 취향 분석 결과 조회 API
  *
@@ -54,12 +56,8 @@ export async function GET(_request: NextRequest) {
       return NextResponse.json({ error: '추천 도서를 불러올 수 없습니다.' }, { status: 500 });
     }
 
-    // 4. 타입별로 그룹화
-    const groupedRecommendations = {
-      match: recommendations?.filter((r) => r.recommendation_type === 'match') || [],
-      expand: recommendations?.filter((r) => r.recommendation_type === 'expand') || [],
-      challenge: recommendations?.filter((r) => r.recommendation_type === 'challenge') || [],
-    };
+    // 4. 타입별로 그룹화 (노출 상한까지만 — 화면 3곳이 같은 규칙을 쓴다)
+    const groupedRecommendations = groupRecommendationsByType(recommendations);
 
     // 5. 성공 응답
     return NextResponse.json({

--- a/apps/page0127/src/entities/taste-analysis/model/recommendations.test.ts
+++ b/apps/page0127/src/entities/taste-analysis/model/recommendations.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  groupRecommendationsByType,
+  RECOMMENDATIONS_DISPLAY_LIMIT,
+  RECOMMENDATIONS_REQUEST_COUNT,
+} from './recommendations';
+
+import type { BookRecommendation } from '../types';
+
+/** 테스트용 추천 행 — 검증에 쓰는 필드만 지정하고 나머지는 기본값 */
+const makeRecommendation = (
+  overrides: Partial<BookRecommendation> & {
+    recommendation_type: BookRecommendation['recommendation_type'];
+    display_order: number;
+  }
+): BookRecommendation => ({
+  id: `${overrides.recommendation_type}-${overrides.display_order}`,
+  taste_analysis_id: 'analysis-1',
+  isbn: '9788901234567',
+  title: '테스트 도서',
+  author: '테스트 저자',
+  publisher: null,
+  cover_image: 'https://image.aladin.co.kr/cover.jpg',
+  category: null,
+  reason: '추천 이유',
+  created_at: '2026-07-29T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('groupRecommendationsByType', () => {
+  it('타입별로 나누고 노출 상한까지만 자른다', () => {
+    const rows = (['match', 'expand', 'challenge'] as const).flatMap((type) =>
+      [1, 2, 3, 4].map((order) =>
+        makeRecommendation({ recommendation_type: type, display_order: order })
+      )
+    );
+
+    const grouped = groupRecommendationsByType(rows);
+
+    expect(grouped.match).toHaveLength(RECOMMENDATIONS_DISPLAY_LIMIT);
+    expect(grouped.expand).toHaveLength(RECOMMENDATIONS_DISPLAY_LIMIT);
+    expect(grouped.challenge).toHaveLength(RECOMMENDATIONS_DISPLAY_LIMIT);
+  });
+
+  it('display_order가 뒤섞여 들어와도 순서대로 앞에서 자른다', () => {
+    const rows = [4, 2, 1, 3].map((order) =>
+      makeRecommendation({ recommendation_type: 'match', display_order: order })
+    );
+
+    expect(
+      groupRecommendationsByType(rows).match.map((r) => r.display_order)
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('표지가 아직 없는 추천도 노출한다', () => {
+    // 이 assertion 이 잠그는 버그: 표지는 분석 응답을 보낸 뒤 백그라운드에서
+    // 채워진다. 표지 없는 행을 걸러내면 분석 직후 들어온 사용자에게는
+    // "추천 도서가 없습니다" 만 보인다 — 실제로 발생했던 증상이다.
+    const rows = [
+      makeRecommendation({
+        recommendation_type: 'expand',
+        display_order: 1,
+        cover_image: null,
+      }),
+    ];
+
+    expect(groupRecommendationsByType(rows).expand).toHaveLength(1);
+  });
+
+  it('추천이 없으면 세 타입 모두 빈 배열이다', () => {
+    const grouped = groupRecommendationsByType(null);
+
+    expect(grouped).toEqual({ match: [], expand: [], challenge: [] });
+  });
+});
+
+describe('추천 권수 상수', () => {
+  it('AI 요청 권수는 노출 상한보다 크다', () => {
+    // 알라딘에 없는 책은 삭제되므로 여유분 없이 받으면 상한을 못 채운다
+    expect(RECOMMENDATIONS_REQUEST_COUNT).toBeGreaterThan(
+      RECOMMENDATIONS_DISPLAY_LIMIT
+    );
+  });
+});

--- a/apps/page0127/src/entities/taste-analysis/model/recommendations.ts
+++ b/apps/page0127/src/entities/taste-analysis/model/recommendations.ts
@@ -1,0 +1,48 @@
+/**
+ * 추천 도서 노출 규칙
+ *
+ * 학습 포인트:
+ * - "AI에게 몇 권 받을지"와 "화면에 몇 권 보여줄지"는 다른 숫자다
+ * - 조회 지점이 3곳(대시보드·상세·API)이라 그룹화 로직을 한 곳에 모은다
+ */
+
+import type { BookRecommendation } from '../types';
+
+/** 타입별로 화면에 노출하는 추천 권수 상한 */
+export const RECOMMENDATIONS_DISPLAY_LIMIT = 3;
+
+/**
+ * AI에게 요청하는 타입별 추천 권수.
+ *
+ * 노출 상한보다 1권 많게 받는다 — AI가 실재하지 않는 책을 섞어 보내면
+ * 알라딘 대조 단계에서 그 행이 삭제되기 때문에, 딱 맞춰 받으면
+ * 섹션이 상한을 못 채운 채로 보인다.
+ */
+export const RECOMMENDATIONS_REQUEST_COUNT = RECOMMENDATIONS_DISPLAY_LIMIT + 1;
+
+/**
+ * 추천 도서를 타입별로 그룹화하고 노출 상한까지 자른다.
+ *
+ * 표지(cover_image) 유무로 거르지 않는다. 표지는 분석 응답을 보낸 뒤
+ * 백그라운드에서 채워지므로, 여기서 걸러내면 분석 직후에 들어온 사용자에게는
+ * 섹션이 통째로 비어 보인다.
+ */
+export function groupRecommendationsByType(
+  recommendations: BookRecommendation[] | null
+): {
+  match: BookRecommendation[];
+  expand: BookRecommendation[];
+  challenge: BookRecommendation[];
+} {
+  const pick = (type: BookRecommendation['recommendation_type']) =>
+    (recommendations ?? [])
+      .filter((r) => r.recommendation_type === type)
+      .sort((a, b) => a.display_order - b.display_order)
+      .slice(0, RECOMMENDATIONS_DISPLAY_LIMIT);
+
+  return {
+    match: pick('match'),
+    expand: pick('expand'),
+    challenge: pick('challenge'),
+  };
+}

--- a/apps/page0127/src/shared/lib/openai/prompts/taste-analysis.ts
+++ b/apps/page0127/src/shared/lib/openai/prompts/taste-analysis.ts
@@ -40,7 +40,13 @@ const SCORE_MAX = 5;
  */
 export function createTasteAnalysisPrompt(
   books: BookForAnalysis[],
-  personalityTypes: PersonalityTypeOption[]
+  personalityTypes: PersonalityTypeOption[],
+  /**
+   * 타입별로 요청할 추천 권수.
+   * 화면에 노출할 권수보다 크게 잡는다 — 실재하지 않는 책은 서점 대조 단계에서
+   * 탈락하므로, 여유분 없이 딱 맞춰 받으면 섹션이 비어 보인다.
+   */
+  recommendationsPerType: number
 ): string {
   // 평가 안 함(score = null)은 높은 점수도 낮은 점수도 아니다 → 두 목록에서 모두 뺀다.
   // 전에는 0점 책이 "낮은 점수를 준 책들"로 모델에 전달돼 취향을 거꾸로 읽혔다.
@@ -63,9 +69,6 @@ export function createTasteAnalysisPrompt(
   const personalityTypeList = personalityTypes
     .map((t) => `- "${t.name}": ${t.criteria}`)
     .join('\n');
-
-  // 추천 도서 출간 시기 하한선 — 매 요청마다 "최근 3년"을 계산
-  const recentYearThreshold = new Date().getFullYear() - 3;
 
   return `당신은 독서 취향 분석 전문가입니다. 사용자의 독서 기록을 분석하여 깊이 있는 인사이트를 제공해주세요.
 
@@ -109,21 +112,24 @@ ${formatBooks(lowRatedBooks)}
       "reason": "추천 이유 (왜 이 책이 사용자의 취향에 맞는지 구체적으로 설명)",
       "display_order": 1
     }
-    // ... match 5권, expand 5권, challenge 5권 (총 15권)
+    // ... match ${recommendationsPerType}권, expand ${recommendationsPerType}권, challenge ${recommendationsPerType}권 (총 ${recommendationsPerType * 3}권)
   ]
 }
 
 ## 추천 도서 생성 지침 ⚠️ 매우 중요
 - **반드시 실제로 존재하는 한국 출판 도서**만 추천하세요
 - 제목과 저자를 정확하게 기재하세요 (오타 금지)
-- 각 타입별로 정확히 5권씩 추천 (총 15권)
-  - type: "match" - 기존 취향에 완벽히 맞는 책 5권
-  - type: "expand" - 비슷하지만 새로운 영역 5권
-  - type: "challenge" - 전혀 다르지만 좋아할 만한 책 5권
-- display_order는 각 타입 내에서 1부터 5까지
+- 각 타입별로 정확히 ${recommendationsPerType}권씩 추천 (총 ${recommendationsPerType * 3}권)
+  - type: "match" - 기존 취향에 완벽히 맞는 책
+  - type: "expand" - 비슷하지만 새로운 영역
+  - type: "challenge" - 전혀 다르지만 좋아할 만한 책
+- display_order는 각 타입 내에서 1부터 ${recommendationsPerType}까지
 - reason은 구체적이고 개인화된 추천 이유 (100-150자)
-- **출간 시기 제한**: ${recentYearThreshold}년 이후 출간된 책 위주로 추천하세요.
-  그보다 오래된 책은 지금도 꾸준히 읽히는 베스트셀러·스테디셀러급이 아니면 추천하지 마세요.
+- **실재 확인이 최우선**: 제목과 저자를 확실히 아는 책만 쓰세요.
+  조금이라도 확신이 없으면 그 자리를 확실히 아는 다른 책으로 바꾸세요.
+  추천한 책은 실제 서점 데이터로 대조하므로, 지어낸 제목은 그대로 탈락합니다.
+- **제목은 표지에 적힌 그대로**: 부제·시리즈명·번역서 원제를 임의로 덧붙이거나 줄이지 마세요.
+- 최신간을 억지로 고르지 마세요. 지금도 서점에서 구할 수 있는 책이면 출간 연도는 상관없습니다.
 
 ## 성향 타입 목록 ⚠️ 매우 중요
 personality_type은 반드시 아래 목록 중 하나를 **이름 그대로(글자 하나 바꾸지 말 것)** 선택하세요:


### PR DESCRIPTION
## 문제

취향분석 결과에서 "성향 확장 추천"·"챌린지 추천"이 **"추천 도서가 없습니다"** 로 비어 보였다.
원인이 두 겹이었다.

1. **표지 보강 전에 화면에서 사라짐** — 표지는 분석 응답을 보낸 뒤 `after()` 백그라운드에서
   채워지는데, 조회 지점 3곳이 `cover_image === null` 인 행을 걸러내고 있었다.
   그래서 분석 직후 결과를 연 사용자에게는 섹션이 통째로 비어 보이고, 새로고침해야 나타났다.
2. **서점 대조에서 대량 탈락** — AI가 준 15권 중 알라딘 제목 검색으로 못 찾은 책은 행이 삭제된다.
   프롬프트가 "최근 3년 출간" 을 강제하고 있었는데, 이는 gpt-4o 가 거의 모르는 구간이라
   지어낸 제목이 늘고 그만큼 삭제됐다. 실제로 15권 중 1권만 살아남은 사례가 있었다.

## 변경

- 타입별 **노출 상한 3권**, **AI 요청 4권** 을 `entities/taste-analysis/model/recommendations.ts`
  한 곳에 정의. 여유 1권이 대조 단계 탈락분을 메운다.
- 조회 3곳(대시보드·상세·latest API)이 `groupRecommendationsByType` 하나를 쓰도록 통일하고,
  **표지 유무로 거르지 않는다.** 표지가 아직 없어도 제목·저자·이유는 보인다.
- 알라딘 제목 검색이 0건이면 **`제목 + 저자` 키워드 검색으로 한 번 더 시도** 한 뒤에야 삭제한다.
- 프롬프트에서 출간 시기 강제를 빼고, 실재 확인과 "제목은 표지 그대로" 지침을 넣었다.

## 검증

- 단위 테스트 추가 (`recommendations.test.ts` 5건) — 표지 없는 추천도 노출되는지, 상한까지
  자르는지, display_order 순서가 지켜지는지.
- `npm run test` 35파일 238건 통과 · `lint` · `tsc --noEmit` 통과.
- **로컬 dev 서버에서 실제 분석 1회 실행** (OpenAI 실호출, 13초):
  AI가 준 12권 **전부 알라딘 매칭 성공, 삭제 0건.** 세 섹션 모두 3권씩 채워졌고
  "추천 도서가 없습니다" 문구는 나오지 않았다.

## 확인 부탁

Preview 에서 취향분석을 한 번 돌려, 세 섹션이 모두 채워지는지 봐주세요.
