### PR TITLE
🐛 Fix: 과금 없이 거절된 AI 호출 환불 + 알림·팔로우 낙관적 업데이트

### DIFF
--- a/apps/page0127/app/api/compatibility/analyze/route.ts
+++ b/apps/page0127/app/api/compatibility/analyze/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/shared/config/supabase/admin';
 import { createClient } from '@/shared/config/supabase/server';
 import {
+  isUnbilledOpenAiFailure,
   refundUsage,
   reserveUsage,
   USAGE_LIMIT_EXCEEDED_ERROR,
@@ -32,10 +33,12 @@ export const maxDuration = 60;
  * Body: { targetUserId: string, force?: boolean }
  */
 export async function POST(request: NextRequest) {
-  // 예약된 usage 행 id — OpenAI 요청 전 실패 시에만 환불(삭제)한다.
+  // 예약된 usage 행 id — 환불(삭제) 대상.
   let reservedUsageId: string | null = null;
   // OpenAI 요청을 시작하면 비용이 발생할 수 있으므로 이후 실패는 환불하지 않는다.
   let aiRequestStarted = false;
+  // 단, OpenAI가 과금 없이 반려한 경우(잘못된 키·한도 초과 등)는 예외적으로 환불한다.
+  let refundableRejection = false;
 
   try {
     // 1. 인증 확인
@@ -258,15 +261,18 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('궁합 분석 실패:', error);
+    refundableRejection = isUnbilledOpenAiFailure(error);
     return NextResponse.json(
       { error: '궁합 분석 중 오류가 발생했습니다.' },
       { status: 500 }
     );
   } finally {
-    // 슬롯 예약 후 OpenAI 요청을 시작하기 전에 실패한 경우에만 환불한다.
-    // 요청을 시작한 뒤에는 비용이 발생했을 수 있으므로 실패해도 사용량을 유지한다.
+    // 환불 조건 두 가지:
+    // (1) OpenAI 요청을 시작하기 전에 실패한 경우
+    // (2) OpenAI가 토큰을 쓰지 않고 반려한 경우 (401·429·400 등)
+    // 그 밖의 실패는 비용이 발생했을 수 있으므로 사용량을 유지한다.
     // 환불 정리가 응답을 깨뜨리지 않도록 자체 try로 감싼다.
-    if (!aiRequestStarted && reservedUsageId) {
+    if ((!aiRequestStarted || refundableRejection) && reservedUsageId) {
       try {
         await refundUsage(createAdminClient(), reservedUsageId);
       } catch (refundError) {

--- a/apps/page0127/app/api/taste-analysis/analyze/route.ts
+++ b/apps/page0127/app/api/taste-analysis/analyze/route.ts
@@ -3,6 +3,7 @@ import { after, NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/shared/config/supabase/admin';
 import { createClient } from '@/shared/config/supabase/server';
 import {
+  isUnbilledOpenAiFailure,
   refundUsage,
   reserveUsage,
   USAGE_LIMIT_EXCEEDED_ERROR,
@@ -33,10 +34,12 @@ export const maxDuration = 60;
  * POST /api/taste-analysis/analyze
  */
 export async function POST(_request: NextRequest) {
-  // 예약된 usage 행 id — OpenAI 요청 전 실패 시에만 환불(삭제)한다.
+  // 예약된 usage 행 id — 환불(삭제) 대상.
   let reservedUsageId: string | null = null;
   // OpenAI 요청을 시작하면 비용이 발생할 수 있으므로 이후 실패는 환불하지 않는다.
   let aiRequestStarted = false;
+  // 단, OpenAI가 과금 없이 반려한 경우(잘못된 키·한도 초과 등)는 예외적으로 환불한다.
+  let refundableRejection = false;
 
   try {
     // 1. 인증 확인
@@ -244,15 +247,18 @@ export async function POST(_request: NextRequest) {
     });
   } catch (error) {
     console.error('취향 분석 실패:', error);
+    refundableRejection = isUnbilledOpenAiFailure(error);
     return NextResponse.json(
       { error: '취향 분석 중 오류가 발생했습니다.' },
       { status: 500 }
     );
   } finally {
-    // 슬롯 예약 후 OpenAI 요청을 시작하기 전에 실패한 경우에만 환불한다.
-    // 요청을 시작한 뒤에는 비용이 발생했을 수 있으므로 실패해도 사용량을 유지한다.
+    // 환불 조건 두 가지:
+    // (1) OpenAI 요청을 시작하기 전에 실패한 경우
+    // (2) OpenAI가 토큰을 쓰지 않고 반려한 경우 (401·429·400 등)
+    // 그 밖의 실패는 비용이 발생했을 수 있으므로 사용량을 유지한다.
     // 환불 정리가 응답을 깨뜨리지 않도록 자체 try로 감싼다.
-    if (!aiRequestStarted && reservedUsageId) {
+    if ((!aiRequestStarted || refundableRejection) && reservedUsageId) {
       try {
         await refundUsage(createAdminClient(), reservedUsageId);
       } catch (refundError) {

--- a/apps/page0127/src/entities/notification/lib/hooks/useDeleteNotification.ts
+++ b/apps/page0127/src/entities/notification/lib/hooks/useDeleteNotification.ts
@@ -3,9 +3,9 @@
  * 알림 삭제 훅
  *
  * 학습 포인트:
- * - useMutation으로 알림 삭제 처리
- * - 삭제 후 캐시 무효화로 목록 자동 업데이트
- * - 읽지 않은 알림 개수도 업데이트
+ * - 읽음 처리와 같은 낙관적 업데이트 구조다. 클릭 즉시 목록에서 지우고,
+ *   실패하면 스냅샷으로 되돌린다.
+ * - 안 읽은 알림을 지우면 종 배지 숫자도 같이 줄어야 한다.
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -13,26 +13,45 @@ import { toast } from 'sonner';
 
 import { deleteNotification } from '../../api/notificationApi';
 import { notificationKeys } from '../../model/queryKeys';
+import {
+  type NotificationCacheSnapshot,
+  patchNotificationLists,
+  patchUnreadCount,
+  restoreNotificationCache,
+  snapshotNotificationCache,
+  wasUnread,
+} from '../optimisticCache';
+
+type Context = { snapshot: NotificationCacheSnapshot };
 
 export function useDeleteNotification() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteNotification,
-    onSuccess: () => {
-      // 알림 목록 캐시 무효화
-      queryClient.invalidateQueries({
-        queryKey: notificationKeys.lists(),
-      });
+    onMutate: async (notificationId: string): Promise<Context> => {
+      await queryClient.cancelQueries({ queryKey: notificationKeys.all });
 
-      // 읽지 않은 알림 개수 캐시 무효화
-      queryClient.invalidateQueries({
-        queryKey: notificationKeys.unreadCount(),
-      });
+      const snapshot = snapshotNotificationCache(queryClient);
+      const shouldDecrement = wasUnread(queryClient, notificationId);
+
+      // null을 반환하면 목록에서 제거된다
+      patchNotificationLists(queryClient, (n) =>
+        n.id === notificationId ? null : n
+      );
+
+      if (shouldDecrement) {
+        patchUnreadCount(queryClient, (count) => count - 1);
+      }
+
+      return { snapshot };
     },
-    // 실패 시 사용자에게 피드백
-    onError: () => {
+    onError: (_error, _notificationId, context) => {
+      if (context) restoreNotificationCache(queryClient, context.snapshot);
       toast.error('알림 삭제에 실패했습니다.');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
     },
   });
 }

--- a/apps/page0127/src/entities/notification/lib/hooks/useMarkAsRead.ts
+++ b/apps/page0127/src/entities/notification/lib/hooks/useMarkAsRead.ts
@@ -1,6 +1,12 @@
 /**
  * useMarkAsRead Hook
  * 알림 읽음 처리 Mutation 훅
+ *
+ * 학습 포인트:
+ * - 낙관적 업데이트: 서버 응답을 기다리지 않고 화면을 먼저 바꾼다.
+ *   예전에는 (1) PATCH 왕복 → (2) 캐시 무효화 → (3) 목록·배지 재조회 왕복을
+ *   모두 기다린 뒤에야 읽음 표시가 반영돼 체감이 1~2초씩 걸렸다.
+ * - 실패하면 onError에서 스냅샷으로 되돌리고, onSettled에서 서버 값과 다시 맞춘다.
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -8,6 +14,16 @@ import { toast } from 'sonner';
 
 import { markAllAsRead, markAsRead } from '../../api/notificationApi';
 import { notificationKeys } from '../../model/queryKeys';
+import {
+  type NotificationCacheSnapshot,
+  patchNotificationLists,
+  patchUnreadCount,
+  restoreNotificationCache,
+  snapshotNotificationCache,
+  wasUnread,
+} from '../optimisticCache';
+
+type Context = { snapshot: NotificationCacheSnapshot };
 
 /**
  * 개별 알림 읽음 처리 훅
@@ -17,13 +33,31 @@ export function useMarkAsRead() {
 
   return useMutation({
     mutationFn: markAsRead,
-    onSuccess: () => {
-      // 알림 목록 및 읽지 않은 개수 캐시 무효화
-      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
+    onMutate: async (notificationId: string): Promise<Context> => {
+      // 진행 중이던 refetch 응답이 낙관적 값을 덮어쓰지 않게 취소한다
+      await queryClient.cancelQueries({ queryKey: notificationKeys.all });
+
+      const snapshot = snapshotNotificationCache(queryClient);
+      const shouldDecrement = wasUnread(queryClient, notificationId);
+
+      patchNotificationLists(queryClient, (n) =>
+        n.id === notificationId ? { ...n, is_read: true } : n
+      );
+
+      // 이미 읽은 알림을 다시 눌렀다면 배지는 그대로 둔다
+      if (shouldDecrement) {
+        patchUnreadCount(queryClient, (count) => count - 1);
+      }
+
+      return { snapshot };
     },
-    // 실패 시 사용자에게 피드백 (다른 mutation과 동일하게 toast)
-    onError: () => {
+    onError: (_error, _notificationId, context) => {
+      if (context) restoreNotificationCache(queryClient, context.snapshot);
       toast.error('알림 읽음 처리에 실패했습니다.');
+    },
+    // 성공이든 실패든 마지막엔 서버 값으로 맞춘다
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
     },
   });
 }
@@ -36,12 +70,22 @@ export function useMarkAllAsRead() {
 
   return useMutation({
     mutationFn: markAllAsRead,
-    onSuccess: () => {
-      // 알림 목록 및 읽지 않은 개수 캐시 무효화
-      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
+    onMutate: async (): Promise<Context> => {
+      await queryClient.cancelQueries({ queryKey: notificationKeys.all });
+
+      const snapshot = snapshotNotificationCache(queryClient);
+
+      patchNotificationLists(queryClient, (n) => ({ ...n, is_read: true }));
+      patchUnreadCount(queryClient, () => 0);
+
+      return { snapshot };
     },
-    onError: () => {
+    onError: (_error, _vars, context) => {
+      if (context) restoreNotificationCache(queryClient, context.snapshot);
       toast.error('알림 읽음 처리에 실패했습니다.');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all });
     },
   });
 }

--- a/apps/page0127/src/entities/notification/lib/optimisticCache.test.ts
+++ b/apps/page0127/src/entities/notification/lib/optimisticCache.test.ts
@@ -1,0 +1,136 @@
+import { QueryClient } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { notificationKeys } from '../model/queryKeys';
+import {
+  patchNotificationLists,
+  patchUnreadCount,
+  restoreNotificationCache,
+  snapshotNotificationCache,
+  transformList,
+  wasUnread,
+} from './optimisticCache';
+
+import type { NotificationWithActor } from '../model/types';
+import type { InfiniteData } from '@tanstack/react-query';
+
+const noti = (
+  id: string,
+  is_read = false
+): NotificationWithActor =>
+  ({
+    id,
+    user_id: 'me',
+    type: 'like',
+    actor_id: 'other',
+    target_id: 'book-1',
+    target_type: 'book',
+    is_read,
+    message: null,
+    created_at: '2026-07-29T00:00:00Z',
+    updated_at: '2026-07-29T00:00:00Z',
+    actor: {
+      id: 'other',
+      nickname: '상대',
+      photo_url: null,
+      username: 'other',
+    },
+  }) as NotificationWithActor;
+
+const listKey = notificationKeys.list({ userId: 'me' });
+const infiniteKey = notificationKeys.infinite('all');
+
+describe('transformList', () => {
+  it('null을 반환한 알림은 목록에서 빠진다', () => {
+    const result = transformList([noti('a'), noti('b')], (n) =>
+      n.id === 'a' ? null : n
+    );
+
+    expect(result.map((n) => n.id)).toEqual(['b']);
+  });
+
+  it('변환된 값으로 교체된다', () => {
+    const result = transformList([noti('a')], (n) => ({ ...n, is_read: true }));
+
+    expect(result[0].is_read).toBe(true);
+  });
+});
+
+describe('알림 캐시 낙관적 조작', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    queryClient.setQueryData(listKey, [noti('a'), noti('b', true)]);
+    queryClient.setQueryData<InfiniteData<NotificationWithActor[]>>(
+      infiniteKey,
+      { pages: [[noti('a')], [noti('b', true)]], pageParams: [0, 1] }
+    );
+    queryClient.setQueryData(notificationKeys.unreadCount(), { count: 1 });
+  });
+
+  it('드롭다운 목록과 무한스크롤 목록에 동시에 적용된다', () => {
+    patchNotificationLists(queryClient, (n) =>
+      n.id === 'a' ? { ...n, is_read: true } : n
+    );
+
+    const list = queryClient.getQueryData<NotificationWithActor[]>(listKey);
+    const infinite =
+      queryClient.getQueryData<InfiniteData<NotificationWithActor[]>>(
+        infiniteKey
+      );
+
+    expect(list?.find((n) => n.id === 'a')?.is_read).toBe(true);
+    expect(infinite?.pages[0][0].is_read).toBe(true);
+  });
+
+  it('삭제는 양쪽 목록에서 모두 빠진다', () => {
+    patchNotificationLists(queryClient, (n) => (n.id === 'a' ? null : n));
+
+    const list = queryClient.getQueryData<NotificationWithActor[]>(listKey);
+    const infinite =
+      queryClient.getQueryData<InfiniteData<NotificationWithActor[]>>(
+        infiniteKey
+      );
+
+    expect(list?.map((n) => n.id)).toEqual(['b']);
+    expect(infinite?.pages[0]).toEqual([]);
+  });
+
+  it('배지 숫자는 0 아래로 내려가지 않는다', () => {
+    patchUnreadCount(queryClient, (c) => c - 5);
+
+    expect(
+      queryClient.getQueryData<{ count: number }>(
+        notificationKeys.unreadCount()
+      )?.count
+    ).toBe(0);
+  });
+
+  it('wasUnread — 안 읽은 알림만 true', () => {
+    expect(wasUnread(queryClient, 'a')).toBe(true);
+    expect(wasUnread(queryClient, 'b')).toBe(false);
+  });
+
+  it('wasUnread — 캐시에 없는 알림은 배지를 건드리지 않도록 false', () => {
+    expect(wasUnread(queryClient, 'unknown')).toBe(false);
+  });
+
+  it('스냅샷으로 되돌리면 목록과 배지가 모두 복원된다', () => {
+    const snapshot = snapshotNotificationCache(queryClient);
+
+    patchNotificationLists(queryClient, (n) => (n.id === 'a' ? null : n));
+    patchUnreadCount(queryClient, () => 0);
+
+    restoreNotificationCache(queryClient, snapshot);
+
+    expect(
+      queryClient.getQueryData<NotificationWithActor[]>(listKey)?.map((n) => n.id)
+    ).toEqual(['a', 'b']);
+    expect(
+      queryClient.getQueryData<{ count: number }>(
+        notificationKeys.unreadCount()
+      )?.count
+    ).toBe(1);
+  });
+});

--- a/apps/page0127/src/entities/notification/lib/optimisticCache.ts
+++ b/apps/page0127/src/entities/notification/lib/optimisticCache.ts
@@ -1,0 +1,115 @@
+/**
+ * 알림 낙관적 업데이트용 캐시 조작 헬퍼
+ *
+ * 알림 캐시는 세 갈래로 나뉘어 있다.
+ * - 드롭다운: notificationKeys.list(options) → 배열
+ * - 알림 페이지: notificationKeys.infinite(filter) → 페이지 배열(InfiniteData)
+ * - 종 배지: notificationKeys.unreadCount() → { count }
+ *
+ * 낙관적 업데이트가 한 갈래만 고치면 화면마다 값이 어긋나므로,
+ * 세 갈래를 항상 같이 다루도록 이 모듈에 모아둔다.
+ */
+
+import { notificationKeys } from '../model/queryKeys';
+
+import type { NotificationWithActor, UnreadCountResponse } from '../model/types';
+import type { InfiniteData, QueryClient } from '@tanstack/react-query';
+
+/** 알림 하나를 어떻게 바꿀지. null을 반환하면 목록에서 제거한다. */
+export type NotificationTransform = (
+  notification: NotificationWithActor
+) => NotificationWithActor | null;
+
+/** 순수 함수 — 목록 하나에 변환을 적용한다 (테스트 대상) */
+export const transformList = (
+  list: NotificationWithActor[],
+  transform: NotificationTransform
+): NotificationWithActor[] =>
+  list
+    .map(transform)
+    .filter((item): item is NotificationWithActor => item !== null);
+
+/**
+ * 두 갈래 목록 캐시(드롭다운·무한스크롤)에 같은 변환을 적용한다.
+ * 진행 중이던 refetch가 낙관적 값을 덮어쓰지 않도록 호출 전에 cancelQueries를 해야 한다.
+ */
+export function patchNotificationLists(
+  queryClient: QueryClient,
+  transform: NotificationTransform
+): void {
+  queryClient.setQueriesData<NotificationWithActor[]>(
+    { queryKey: notificationKeys.lists() },
+    (old) => (old ? transformList(old, transform) : old)
+  );
+
+  queryClient.setQueriesData<InfiniteData<NotificationWithActor[]>>(
+    { queryKey: [...notificationKeys.all, 'infinite'] },
+    (old) =>
+      old && {
+        ...old,
+        pages: old.pages.map((page) => transformList(page, transform)),
+      }
+  );
+}
+
+/** 종 배지 숫자를 갱신한다. 음수로 내려가지 않게 막는다. */
+export function patchUnreadCount(
+  queryClient: QueryClient,
+  next: (current: number) => number
+): void {
+  queryClient.setQueryData<UnreadCountResponse>(
+    notificationKeys.unreadCount(),
+    (old) => (old ? { count: Math.max(0, next(old.count)) } : old)
+  );
+}
+
+/**
+ * 되돌리기용 스냅샷.
+ * 알림 관련 캐시 전체를 통째로 떠 두었다가 실패 시 그대로 복원한다.
+ * (갈래별로 따로 관리하면 복원 누락이 생기기 쉽다)
+ */
+export type NotificationCacheSnapshot = ReturnType<
+  QueryClient['getQueriesData']
+>;
+
+export function snapshotNotificationCache(
+  queryClient: QueryClient
+): NotificationCacheSnapshot {
+  return queryClient.getQueriesData({ queryKey: notificationKeys.all });
+}
+
+export function restoreNotificationCache(
+  queryClient: QueryClient,
+  snapshot: NotificationCacheSnapshot
+): void {
+  snapshot.forEach(([key, data]) => queryClient.setQueryData(key, data));
+}
+
+/** 캐시에 있는 알림이 "안 읽음"이었는지 — 배지 숫자를 줄일지 판단할 때 쓴다 */
+export function wasUnread(
+  queryClient: QueryClient,
+  notificationId: string
+): boolean {
+  const lists = queryClient.getQueriesData<NotificationWithActor[]>({
+    queryKey: notificationKeys.lists(),
+  });
+
+  for (const [, list] of lists) {
+    const found = list?.find((n) => n.id === notificationId);
+    if (found) return !found.is_read;
+  }
+
+  const infinites = queryClient.getQueriesData<
+    InfiniteData<NotificationWithActor[]>
+  >({ queryKey: [...notificationKeys.all, 'infinite'] });
+
+  for (const [, data] of infinites) {
+    for (const page of data?.pages ?? []) {
+      const found = page.find((n) => n.id === notificationId);
+      if (found) return !found.is_read;
+    }
+  }
+
+  // 캐시에 없으면 배지를 건드리지 않는다 (서버 응답 후 invalidate가 바로잡는다)
+  return false;
+}

--- a/apps/page0127/src/features/follow/ui/FollowButton.tsx
+++ b/apps/page0127/src/features/follow/ui/FollowButton.tsx
@@ -37,33 +37,58 @@ export const FollowButton = ({
     queryFn: () => followApi.isFollowing(userId),
   });
 
+  // 버튼 라벨을 서버 왕복 전에 뒤집어 둔다. 실패 시 onError에서 되돌린다.
+  const optimisticToggle = async (next: boolean) => {
+    await queryClient.cancelQueries({
+      queryKey: followKeys.isFollowing(userId),
+    });
+    const previous = queryClient.getQueryData<boolean>(
+      followKeys.isFollowing(userId)
+    );
+    queryClient.setQueryData(followKeys.isFollowing(userId), next);
+    return { previous };
+  };
+
+  const rollbackToggle = (previous: boolean | undefined) => {
+    if (previous !== undefined) {
+      queryClient.setQueryData(followKeys.isFollowing(userId), previous);
+    }
+  };
+
   // 팔로우 Mutation
   const followMutation = useMutation({
     mutationFn: () => followApi.followUser({ following_id: userId }),
+    onMutate: () => optimisticToggle(true),
     onSuccess: () => {
-      // 모든 팔로우 관련 쿼리 무효화 (최신 상태 반영)
-      queryClient.invalidateQueries({ queryKey: followKeys.all });
       // 다른 탭에 팔로우 이벤트 전송
       followBroadcast.sendFollowEvent('follow', userId);
       toast.success('팔로우했습니다.');
     },
-    onError: (error) => {
+    onError: (error, _vars, context) => {
+      rollbackToggle(context?.previous);
       toast.error(getApiErrorMessage(error, '팔로우에 실패했습니다.'));
+    },
+    // 팔로워 수·목록 등 나머지 팔로우 쿼리를 서버 값으로 맞춘다
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: followKeys.all });
     },
   });
 
   // 언팔로우 Mutation
   const unfollowMutation = useMutation({
     mutationFn: () => followApi.unfollowUser(userId),
+    onMutate: () => optimisticToggle(false),
     onSuccess: () => {
-      // 모든 팔로우 관련 쿼리 무효화 (최신 상태 반영)
-      queryClient.invalidateQueries({ queryKey: followKeys.all });
       // 다른 탭에 언팔로우 이벤트 전송
       followBroadcast.sendFollowEvent('unfollow', userId);
       toast.success('언팔로우했습니다.');
     },
-    onError: (error) => {
+    onError: (error, _vars, context) => {
+      rollbackToggle(context?.previous);
       toast.error(getApiErrorMessage(error, '언팔로우에 실패했습니다.'));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: followKeys.all });
     },
   });
 
@@ -92,9 +117,9 @@ export const FollowButton = ({
       onClick={handleClick}
       disabled={isPending}
     >
-      {isPending ? (
-        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-      ) : isFollowing ? (
+      {/* 낙관적 업데이트로 상태가 즉시 뒤집히므로 대기 스피너를 띄우지 않는다.
+          연타 방지는 disabled가 맡는다. */}
+      {isFollowing ? (
         <UserMinus className='mr-2 h-4 w-4' />
       ) : (
         <UserPlus className='mr-2 h-4 w-4' />

--- a/apps/page0127/src/shared/lib/aiUsage.test.ts
+++ b/apps/page0127/src/shared/lib/aiUsage.test.ts
@@ -1,0 +1,44 @@
+import { APIError } from 'openai';
+import { describe, expect, it } from 'vitest';
+
+import { isUnbilledOpenAiFailure } from './aiUsage';
+
+/** OpenAI SDK가 실제로 던지는 형태의 에러를 만든다 */
+const apiError = (status: number | undefined) =>
+  new APIError(status, undefined, 'test error', undefined);
+
+describe('isUnbilledOpenAiFailure', () => {
+  it('잘못된 API 키(401)는 과금이 없으므로 환불 대상이다', () => {
+    expect(isUnbilledOpenAiFailure(apiError(401))).toBe(true);
+  });
+
+  it('잔액 부족·요청 한도(429)는 과금이 없으므로 환불 대상이다', () => {
+    expect(isUnbilledOpenAiFailure(apiError(429))).toBe(true);
+  });
+
+  it('잘못된 요청(400)은 과금이 없으므로 환불 대상이다', () => {
+    expect(isUnbilledOpenAiFailure(apiError(400))).toBe(true);
+  });
+
+  it('요청 타임아웃(408)은 생성 중 끊겼을 수 있어 환불하지 않는다', () => {
+    expect(isUnbilledOpenAiFailure(apiError(408))).toBe(false);
+  });
+
+  it('서버 오류(500)는 토큰이 소비됐을 수 있어 환불하지 않는다', () => {
+    expect(isUnbilledOpenAiFailure(apiError(500))).toBe(false);
+  });
+
+  it('status를 알 수 없는 APIError는 환불하지 않는다', () => {
+    expect(isUnbilledOpenAiFailure(apiError(undefined))).toBe(false);
+  });
+
+  it('OpenAI가 아닌 오류(응답 파싱 실패 등)는 환불하지 않는다', () => {
+    expect(isUnbilledOpenAiFailure(new Error('AI 응답이 없습니다.'))).toBe(
+      false
+    );
+    expect(isUnbilledOpenAiFailure(new SyntaxError('Unexpected token'))).toBe(
+      false
+    );
+    expect(isUnbilledOpenAiFailure(null)).toBe(false);
+  });
+});

--- a/apps/page0127/src/shared/lib/aiUsage.ts
+++ b/apps/page0127/src/shared/lib/aiUsage.ts
@@ -1,3 +1,5 @@
+import { APIError } from 'openai';
+
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /** 무료 사용자 월별 허용 횟수 (기능별 독립 카운트) */
@@ -111,14 +113,37 @@ export async function reserveUsage(
 }
 
 /**
- * 예약했던 슬롯 1건을 되돌린다 (OpenAI 호출 시작 전에 실패했을 때만).
+ * OpenAI가 "과금 없이" 요청을 반려했는지 판정한다.
+ *
+ * 4xx는 요청이 모델에 닿기 전에 반려된 것이라 토큰 비용이 발생하지 않는다.
+ * (잘못된 API 키 401, 잔액 부족·요청 한도 429, 잘못된 파라미터 400 등)
+ * 이런 실패까지 사용 횟수를 차감하면, 서비스 쪽 설정 실수의 대가를 사용자가
+ * 월 한도로 치르게 된다.
+ *
+ * 반대로 5xx·연결 오류·408은 생성이 시작된 뒤 끊겼을 수 있어 환불하지 않는다.
+ * 판정이 애매할 때는 "차감 유지" 쪽이 안전하다 — 잘못 환불하면 유료 호출을
+ * 한도 없이 반복할 수 있기 때문이다.
+ */
+export function isUnbilledOpenAiFailure(error: unknown): boolean {
+  if (!(error instanceof APIError)) return false;
+
+  const { status } = error;
+  if (typeof status !== 'number') return false;
+
+  return status >= 400 && status < 500 && status !== 408;
+}
+
+/**
+ * 예약했던 슬롯 1건을 되돌린다.
+ * (OpenAI 호출 시작 전 실패 또는 위 isUnbilledOpenAiFailure에 해당하는 실패)
  *
  * ⚠️ 반드시 service-role(admin) 클라이언트로 호출해야 한다.
  *   일반 사용자에게 ai_usage_logs 삭제 권한을 열면, 자기 사용 기록을 지워
  *   월 한도를 무한히 리셋할 수 있기 때문이다. 그래서 삭제는 서버 전용
  *   service_role로만 수행하고, 예약한 행의 id로 "그 행만" 정확히 지운다.
  *
- * OpenAI 요청을 시작한 뒤에는 API 비용이 발생했을 수 있으므로 환불하지 않는다.
+ * 토큰 비용이 발생했을 수 있는 실패(5xx·연결 끊김 등)는 호출부에서 걸러내고
+ * 이 함수까지 오지 않게 한다.
  * best-effort: 삭제가 실패해도 throw하지 않는다.
  */
 export async function refundUsage(


### PR DESCRIPTION
## 배경

오픈 전 시나리오 검증(3단계) 중 운영에서 취향 분석이 500으로 실패했는데 **월 사용 횟수는 차감**됐다. Sentry 확인 결과 원인은 만료된 `OPENAI_API_KEY`로 인한 401이었다. 키는 교체해 정상화됐지만, 같은 상황이 실사용자에게 생기면 이유도 모른 채 월 3회 중 1회를 잃는다.

읽음 처리 지연은 4단계(소셜) 검증 중 발견했다.

## 변경 1 — 과금 없이 거절된 AI 호출은 환불 (🐛)

OpenAI가 4xx로 요청을 반려하면 토큰 비용이 발생하지 않는데, 기존 코드는 `aiRequestStarted` 플래그만 보고 무조건 차감했다.

- `isUnbilledOpenAiFailure()`: `APIError` 4xx(408 제외)를 환불 대상으로 판정
- 401(잘못된 키)·429(잔액 부족·한도)·400(잘못된 파라미터) → 환불
- 5xx·연결 오류·408 → 생성 중 끊겼을 수 있어 **기존대로 차감 유지** (잘못 환불하면 유료 호출을 한도 없이 반복할 수 있다)
- 취향 분석·궁합 분석 두 라우트에 동일 적용

## 변경 2 — 알림 읽음·삭제 낙관적 업데이트 (⚡)

체크 버튼을 눌러도 1~2초 뒤에야 읽음 표시가 반영됐다. 서버 왕복 → 캐시 무효화 → 목록·배지 재조회 왕복을 **모두 기다린 뒤** 화면을 바꾸는 구조였기 때문.

- `optimisticCache`: 드롭다운 목록 / 무한스크롤 목록 / 안 읽은 개수 **세 갈래 캐시**를 한 번에 다루는 헬퍼 (한 갈래만 고치면 화면마다 값이 어긋난다)
- 클릭 즉시 반영 → 실패 시 스냅샷 복원 → `onSettled`에서 서버 값과 재동기화
- 이미 읽은 알림을 다시 눌러도 배지가 줄지 않도록 `wasUnread`로 판정

## 변경 3 — 팔로우 버튼 낙관적 업데이트 (⚡)

주석에는 '낙관적 업데이트'라고 적혀 있었지만 실제로는 `onSuccess`에서 무효화만 해, 서버 왕복 동안 스피너가 돌았다. 상태가 즉시 뒤집히므로 대기 스피너를 제거했다(연타 방지는 `disabled`가 담당).

## 낙관적 업데이트 전수 점검 결과

| 대상 | 판정 |
| --- | --- |
| `BookRecordLikeButton` | 이미 적용 (React Query `onMutate`) |
| `BookLikeButton` | 이미 적용 (React 19 `useOptimistic`) |
| 알림 읽음·전체읽음·삭제 | **이번에 적용** |
| `FollowButton` | **이번에 적용** |
| `CommentForm`(작성) | 미적용 유지 — 서버가 id·작성시각을 만들어야 해 임시 데이터를 그리면 깜빡임·중복 위험 |
| `AddToLibraryButton`(책 담기) | 미적용 유지 — 결과가 화면 전환이라 이득이 적고 롤백이 복잡 |
| `CommentItem`(수정·삭제) | 미적용 유지 — 확인 다이얼로그를 거치는 저빈도 동작 |

## 검증

- `tsc --noEmit` 통과
- `vitest` **254건 통과** (신규 15건: 환불 판정 7 + 캐시 헬퍼 8)
- `eslint .` 통과
- 최신 `main`(8198c62) 위로 리베이스 후 재검증

## 남은 확인

낙관적 업데이트는 자동 테스트로 캐시 동작까지만 검증했다. 실제 체감 속도는 Preview 배포 후 알림 체크/삭제, 팔로우 토글로 확인 필요.