### PR TITLE
✨ Feat: 완독자 아바타를 눌러 공개 서재로 이동

### DIFF
--- a/apps/page0127/src/widgets/book/ui/ReaderProfiles.tsx
+++ b/apps/page0127/src/widgets/book/ui/ReaderProfiles.tsx
@@ -2,6 +2,7 @@
 // → @/app/api/_helpers/auth의 getSupabaseClient 대신 shared의 createClient 직접 사용
 import { createClient } from '@/shared/config/supabase/server';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import { ProfileLink } from '@/shared/ui/ProfileLink';
 
 type ReaderProfilesProps = {
   isbn: string;
@@ -79,12 +80,17 @@ export const ReaderProfiles = async ({ isbn }: ReaderProfilesProps) => {
 
           return (
             <div key={profile.id} className='relative group' title={name}>
-              <Avatar className='w-10 h-10 border-2 border-card cursor-pointer hover:z-10 hover:scale-110 transition-transform'>
-                <AvatarImage src={profile.photo_url ?? undefined} />
-                <AvatarFallback className='bg-primary/15 text-primary text-xs'>
-                  {name.slice(0, 2)}
-                </AvatarFallback>
-              </Avatar>
+              {/* username 이 없으면 ProfileLink 가 링크 없이 그대로 그린다
+                  (갈 곳 없는 링크를 만들지 않는다 — ProfileLink 주석 참고) */}
+              <ProfileLink username={profile.username} className='block'>
+                <Avatar className='w-10 h-10 border-2 border-card cursor-pointer hover:z-10 hover:scale-110 transition-transform'>
+                  {/* 링크 안이 이미지뿐이면 스크린리더가 읽을 이름이 없다 → alt 로 이름을 준다 */}
+                  <AvatarImage src={profile.photo_url ?? undefined} alt={name} />
+                  <AvatarFallback className='bg-primary/15 text-primary text-xs'>
+                    {name.slice(0, 2)}
+                  </AvatarFallback>
+                </Avatar>
+              </ProfileLink>
             </div>
           );
         })}


### PR DESCRIPTION
## 무엇을

책 상세의 **"이 책을 완독한 사람들"** 아바타를 누르면 그 사람의 공개 서재(`/{username}`)로 이동합니다.

## 왜

아바타에 `cursor-pointer` 가 걸려 있어 누를 수 있는 것처럼 보이는데 실제로는 아무 동작이 없었습니다.

## 어떻게

- 공용 `shared/ui/ProfileLink` 로 아바타를 감쌌습니다. 경로 규칙(`profileHref`)을 새로 만들지 않고 기존 한 곳을 그대로 씁니다.
- `username` 이 없는 계정(탈퇴·미설정)은 ProfileLink 가 링크 없이 그대로 그립니다 — 깨진 링크를 만들지 않습니다.
- 링크 내부가 이미지뿐이라 스크린리더가 읽을 이름이 없어 `AvatarImage` 에 `alt={name}` 을 추가했습니다.

## 검증

- `npx tsc --noEmit` 통과
- `npx eslint src/widgets/book/ui/ReaderProfiles.tsx` 통과
- 브라우저 수동 확인은 리뷰어(작성자) 단계에서 진행 예정

## 범위 밖

아바타 11명 이상일 때 표시되는 `+` 배지는 여전히 동작 없음 — 전체 독자 목록 화면이 없어 별도 작업으로 둡니다.
