### PR TITLE
🐛 Fix: 2회독한 책이 서재·인생책에 중복 노출되던 문제

### DIFF
--- a/apps/page0127/src/entities/book/api/getOverallStats.ts
+++ b/apps/page0127/src/entities/book/api/getOverallStats.ts
@@ -1,6 +1,8 @@
 import { createClient } from '@/shared/config/supabase/server';
 import { mapToMainCategory } from '@/shared/lib/categoryMapper';
 
+import { dedupeReadings } from '../model/dedupeReadings';
+
 import type { Book } from '../types';
 import type {
   CategoryReadingData,
@@ -51,21 +53,24 @@ export const getOverallStats = async (
       return getEmptyStats();
     }
 
+    // 재독은 새 row 로 쌓인다 — 여기는 '전체 기간' 통계이므로 전체 범위에서
+    // 같은 책을 한 권으로 센다. (연도별 추이만 연도 안에서 따로 합친다)
+    const allReadings = completedBooks as Book[];
+    const uniqueBooks = dedupeReadings(allReadings);
+
     // 1. 독서 여정 계산
-    const journey = calculateReadingJourney(completedBooks as Book[]);
+    // 시작일만은 합치기 전 목록으로 구한다 — 합치면 대표가 '최신 회독'이라
+    // 2020년에 처음 읽은 책이 2026년 재독 날짜로 바뀌어 시작일이 밀린다
+    const journey = calculateReadingJourney(uniqueBooks, allReadings);
 
     // 2. 최근 5년 독서량 계산
-    const yearlyTrend = calculateYearlyTrend(completedBooks as Book[]);
+    const yearlyTrend = calculateYearlyTrend(allReadings);
 
     // 3. 평점 분포 계산
-    const ratingDistribution = calculateRatingDistribution(
-      completedBooks as Book[]
-    );
+    const ratingDistribution = calculateRatingDistribution(uniqueBooks);
 
     // 4. 전체 카테고리 분포 계산
-    const categoryDistribution = calculateCategoryDistribution(
-      completedBooks as Book[]
-    );
+    const categoryDistribution = calculateCategoryDistribution(uniqueBooks);
 
     return {
       journey,
@@ -86,8 +91,14 @@ export const getOverallStats = async (
  * - 총 읽은 책, 인생책
  * - 총 읽은 쪽수, 하루 평균 쪽수
  * - 독서 기간, 예상 독서 시간
+ *
+ * @param books 회독을 합친 목록 — 권수·쪽수는 서로 다른 책 기준으로 센다
+ * @param allReadings 합치기 전 전체 회독 기록 (완독일 오름차순) — 시작일 계산용
  */
-const calculateReadingJourney = (books: Book[]): ReadingJourney => {
+const calculateReadingJourney = (
+  books: Book[],
+  allReadings: Book[]
+): ReadingJourney => {
   const totalBooks = books.length;
 
   // 인생책 (is_life_book 플래그 — 전에는 rating=10 이라는 매직값이었다)
@@ -101,8 +112,8 @@ const calculateReadingJourney = (books: Book[]): ReadingJourney => {
     0
   );
 
-  // 독서 시작일 (첫 완독일)
-  const firstBook = books[0]; // 이미 completed_date 오름차순 정렬됨
+  // 독서 시작일 (첫 완독일) — 합치기 전 목록이라야 옛 1회독 날짜가 살아 있다
+  const firstBook = allReadings[0]; // 이미 completed_date 오름차순 정렬됨
   const readingSince = firstBook?.completed_date || new Date().toISOString();
 
   // 독서 년수 계산
@@ -147,25 +158,29 @@ const calculateReadingJourney = (books: Book[]): ReadingJourney => {
  * - 완독일 기준으로 연도별 집계
  * - 최근 5년만 표시 (데이터 부족 시 전체)
  * - 오름차순 정렬 (2020 → 2024)
+ *
+ * 회독은 '그 연도 안에서' 합친다. 전체 기준으로 먼저 합치면 옛 회독이 사라져
+ * 지난 연도 막대가 실제보다 낮아진다 — 2020년에 읽은 사실은 남아야 한다.
+ * 그래서 연도 막대의 합이 '총 읽은 책'보다 클 수 있다(해를 걸친 재독).
  */
-const calculateYearlyTrend = (books: Book[]): YearlyTrend[] => {
+const calculateYearlyTrend = (allReadings: Book[]): YearlyTrend[] => {
   const MAX_YEARS = 5;
 
-  // 연도별 카운트 맵 생성
-  const yearMap = new Map<number, number>();
+  // 연도별로 기록을 모은 뒤, 각 연도 안에서 같은 책을 한 권으로 합친다
+  const readingsByYear = new Map<number, Book[]>();
 
-  books.forEach((book) => {
+  allReadings.forEach((book) => {
     if (book.completed_date) {
       const year = new Date(book.completed_date).getFullYear();
-      yearMap.set(year, (yearMap.get(year) || 0) + 1);
+      readingsByYear.set(year, [...(readingsByYear.get(year) ?? []), book]);
     }
   });
 
   // 연도 오름차순 정렬
-  const sortedYears = Array.from(yearMap.entries())
-    .map(([year, count]) => ({
+  const sortedYears = Array.from(readingsByYear.entries())
+    .map(([year, readings]) => ({
       year,
-      count,
+      count: dedupeReadings(readings).length,
     }))
     .sort((a, b) => a.year - b.year);
 
@@ -210,8 +225,14 @@ const calculateRatingDistribution = (books: Book[]): RatingDistribution[] => {
   });
 
   books.forEach((book) => {
+    // 인생책은 점수와 무관하게 '인생책' 칸으로 보낸다. 인생책 버킷의 rating 이
+    // 5 로 고정돼 있어, 두 값을 그대로 키로 쓰면 '4점인데 인생책'인 책이 어느
+    // 칸에도 못 들어가고 조용히 빠진다 — 분포 합이 총 권수보다 적어진다.
+    // 회독을 합치면(1회독 5점 인생책 + 2회독 4점) 이 조합이 실제로 만들어진다.
     // rating 이 null/undefined 거나 버킷에 없는 값이면 key 가 안 맞아 자연히 걸러진다
-    const key = toKey(book.rating ?? NaN, book.is_life_book);
+    const key = book.is_life_book
+      ? toKey(5, true)
+      : toKey(book.rating ?? NaN, false);
     if (ratingMap.has(key)) {
       ratingMap.set(key, (ratingMap.get(key) || 0) + 1);
     }

--- a/apps/page0127/src/entities/book/api/getPublicShelfSummary.ts
+++ b/apps/page0127/src/entities/book/api/getPublicShelfSummary.ts
@@ -21,6 +21,8 @@ export type PublicShelfSummary = {
  * 링크를 눌러 들어간 화면의 통계가 9권이면 둘 중 하나는 거짓말이 된다.
  * 기준: status='completed' + completed_date 있음 + is_public=true
  * (완독일이 없는 책을 통계에서 빼는 것은 getOverallStats 41행의 규칙이다)
+ * 그리고 **재독은 한 권으로 센다** — 서재 화면이 회독을 합쳐 보여주므로
+ * count 로 row 를 세면 2회독한 책 때문에 카드 숫자만 커진다.
  *
  * 조회 실패는 **각각 격리한다** — 인생책 한 줄 때문에 총 권수까지 버리지 않는다.
  * 카드가 깨지는 것보다 빈 선반이 낫지만, 아는 숫자까지 버릴 이유는 없다.
@@ -30,14 +32,24 @@ export const getPublicShelfSummary = async (
 ): Promise<PublicShelfSummary> => {
   const supabase = createAnonClient();
 
+  // count 대신 id·isbn 을 받아 와서 '서로 다른 책' 수를 센다. 카드에 필요한 건
+  // 숫자 두 개뿐이지만, 재독을 걸러내려면 어떤 책인지 알아야 한다.
+  // (한 사람 책장이라 수백 행이어도 짧은 문자열 두 개씩이라 부담이 없다)
   const publicCompleted = () =>
     supabase
       .from('books')
-      .select('id', { count: 'exact', head: true })
+      .select('id, isbn')
       .eq('user_id', userId)
       .eq('status', 'completed')
       .not('completed_date', 'is', null)
       .eq('is_public', true);
+
+  // ISBN 이 비어 있는 수기 등록 책은 서로 합쳐지면 안 된다 → id 로 갈라 센다.
+  // (model/dedupeReadings.ts 의 그룹 키와 같은 규칙. 여기는 한 사람의
+  //  완독 목록만 다루므로 user_id·status 는 이미 쿼리에서 고정돼 있다)
+  const countDistinctBooks = (rows: { id: string; isbn: string | null }[]) =>
+    new Set(rows.map((row) => (row.isbn ? `isbn:${row.isbn}` : `id:${row.id}`)))
+      .size;
 
   const [totalResult, lifeResult] = await Promise.all([
     publicCompleted(),
@@ -53,7 +65,7 @@ export const getPublicShelfSummary = async (
     return { totalBooks: 0, lifeBooks: 0 };
   }
 
-  const totalBooks = totalResult.count ?? 0;
+  const totalBooks = countDistinctBooks(totalResult.data ?? []);
 
   // 인생책만 실패했으면 그 줄만 뺀다. 예전에는 둘 중 하나만 실패해도 0/0 을 돌려줬는데,
   // is_life_book 컬럼이 아직 없던 배포 직후 그 경로를 타면서 155권 읽은 책장이
@@ -64,5 +76,5 @@ export const getPublicShelfSummary = async (
     return { totalBooks, lifeBooks: 0 };
   }
 
-  return { totalBooks, lifeBooks: lifeResult.count ?? 0 };
+  return { totalBooks, lifeBooks: countDistinctBooks(lifeResult.data ?? []) };
 };

--- a/apps/page0127/src/entities/book/index.ts
+++ b/apps/page0127/src/entities/book/index.ts
@@ -31,6 +31,9 @@ export type {
 //       (클라이언트 컴포넌트가 이 배럴을 import 할 때 서버 모듈이 끌려가지 않도록 분리)
 export { bookApi } from './api/bookApi';
 
+// 재독 기록 합치기 — 같은 책의 회독이 책장에 여러 번 서지 않게 한다
+export { dedupeReadings } from './model/dedupeReadings';
+
 // 서재 기간 분류·통계 (서버에서 받은 책 목록을 클라이언트에서도 재사용)
 export {
   calculateBookStats,

--- a/apps/page0127/src/entities/book/model/dedupeReadings.test.ts
+++ b/apps/page0127/src/entities/book/model/dedupeReadings.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import { dedupeReadings } from './dedupeReadings';
+
+import type { Book } from '../types';
+
+const createBook = (overrides: Partial<Book> = {}): Book => ({
+  id: crypto.randomUUID(),
+  user_id: 'user-id',
+  isbn: '9788901234567',
+  title: '어린 왕자',
+  author: null,
+  publisher: null,
+  cover_image: null,
+  spine_image: null,
+  description: null,
+  pub_date: null,
+  category: '소설',
+  page_count: 100,
+  toc: null,
+  status: 'completed',
+  read_count: 1,
+  start_date: null,
+  completed_date: '2026-01-01',
+  rating: 5,
+  is_life_book: false,
+  one_line_review: null,
+  personal_memo: null,
+  tags: null,
+  is_public: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('dedupeReadings', () => {
+  it('같은 책의 회독 기록은 한 권으로 합친다', () => {
+    const books = [
+      createBook({ id: 'first', read_count: 1, completed_date: '2026-01-01' }),
+      createBook({ id: 'second', read_count: 2, completed_date: '2026-06-01' }),
+    ];
+
+    expect(dedupeReadings(books)).toHaveLength(1);
+  });
+
+  it('가장 최근에 완독한 회독을 대표로 남긴다', () => {
+    const books = [
+      createBook({ id: 'first', read_count: 1, completed_date: '2026-01-01' }),
+      createBook({ id: 'second', read_count: 2, completed_date: '2026-06-01' }),
+    ];
+
+    expect(dedupeReadings(books)[0].id).toBe('second');
+  });
+
+  it('완독일이 같으면 회독 수가 큰 쪽을 대표로 남긴다', () => {
+    const books = [
+      createBook({ id: 'second', read_count: 2, completed_date: '2026-01-01' }),
+      createBook({ id: 'first', read_count: 1, completed_date: '2026-01-01' }),
+    ];
+
+    expect(dedupeReadings(books)[0].id).toBe('second');
+  });
+
+  it('완독일이 없으면 등록 시각으로 최신 회독을 고른다', () => {
+    const books = [
+      createBook({
+        id: 'older',
+        completed_date: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+      }),
+      createBook({
+        id: 'newer',
+        completed_date: null,
+        created_at: '2026-06-01T00:00:00.000Z',
+      }),
+    ];
+
+    expect(dedupeReadings(books)[0].id).toBe('newer');
+  });
+
+  it('회독 중 하나라도 인생책이면 합친 결과도 인생책이다', () => {
+    // 1회독 때 인생책으로 꼽고 2회독 기록엔 체크를 안 했더라도
+    // '내 인생책' 책장에서 사라지면 안 된다
+    const books = [
+      createBook({ id: 'first', read_count: 1, is_life_book: true }),
+      createBook({
+        id: 'second',
+        read_count: 2,
+        is_life_book: false,
+        completed_date: '2026-06-01',
+      }),
+    ];
+
+    const [merged] = dedupeReadings(books);
+
+    expect(merged.id).toBe('second');
+    expect(merged.is_life_book).toBe(true);
+  });
+
+  it('회독 수는 기록 중 가장 큰 값을 쓴다', () => {
+    // 옛 기록을 나중에 등록하는 등으로 대표 회독의 read_count 가
+    // 최대가 아닐 수 있다 — 배지는 "몇 번 읽었나"를 말해야 한다
+    const books = [
+      createBook({ id: 'third', read_count: 3, completed_date: '2026-01-01' }),
+      createBook({ id: 'second', read_count: 2, completed_date: '2026-06-01' }),
+    ];
+
+    const [merged] = dedupeReadings(books);
+
+    expect(merged.id).toBe('second');
+    expect(merged.read_count).toBe(3);
+  });
+
+  it('서로 다른 책은 합치지 않고 원래 순서를 지킨다', () => {
+    const books = [
+      createBook({ id: 'a', isbn: '111' }),
+      createBook({ id: 'b', isbn: '222' }),
+      createBook({ id: 'c', isbn: '333' }),
+    ];
+
+    expect(dedupeReadings(books).map((book) => book.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('대표를 고른 뒤에도 목록에서의 원래 자리를 유지한다', () => {
+    // 정렬(완독 최신순 등)은 호출부가 이미 끝낸 상태로 들어온다.
+    // 합치면서 순서를 흐트러뜨리면 책장 정렬이 무너진다.
+    const books = [
+      createBook({ id: 'newer', isbn: '111', completed_date: '2026-06-01' }),
+      createBook({ id: 'other', isbn: '222', completed_date: '2026-03-01' }),
+      createBook({ id: 'older', isbn: '111', completed_date: '2026-01-01' }),
+    ];
+
+    expect(dedupeReadings(books).map((book) => book.id)).toEqual([
+      'newer',
+      'other',
+    ]);
+  });
+
+  it('ISBN 이 없는 책은 서로 다른 책으로 본다', () => {
+    // 수기 등록 등으로 ISBN 이 비어 있으면 제목이 달라도 키가 같아져
+    // 엉뚱한 책끼리 합쳐진다 → id 로 갈라둔다
+    const books = [
+      createBook({ id: 'a', isbn: '', title: '직접 쓴 책 1' }),
+      createBook({ id: 'b', isbn: '', title: '직접 쓴 책 2' }),
+    ];
+
+    expect(dedupeReadings(books)).toHaveLength(2);
+  });
+
+  it('재독 중이면 완독한 회독과 읽는 중인 회독을 합치지 않는다', () => {
+    // 합쳐서 '읽는 중'만 남기면 이미 완독한 기록이 완독 책장에서 사라진다
+    const books = [
+      createBook({ id: 'done', read_count: 1, status: 'completed' }),
+      createBook({
+        id: 'reading',
+        read_count: 2,
+        status: 'reading',
+        completed_date: null,
+      }),
+    ];
+
+    expect(dedupeReadings(books)).toHaveLength(2);
+  });
+
+  it('사용자가 다르면 합치지 않는다', () => {
+    // 공개 서재 목록처럼 여러 사람의 책이 섞인 배열에 쓰여도
+    // 남의 기록과 뭉뚱그려지면 안 된다
+    const books = [
+      createBook({ id: 'mine', user_id: 'me' }),
+      createBook({ id: 'yours', user_id: 'you' }),
+    ];
+
+    expect(dedupeReadings(books)).toHaveLength(2);
+  });
+
+  it('빈 목록은 빈 목록으로 돌려준다', () => {
+    expect(dedupeReadings([])).toEqual([]);
+  });
+});

--- a/apps/page0127/src/entities/book/model/dedupeReadings.ts
+++ b/apps/page0127/src/entities/book/model/dedupeReadings.ts
@@ -1,0 +1,71 @@
+import type { Book } from '../types';
+
+/**
+ * 같은 책의 회독 기록을 한 권으로 합친다.
+ *
+ * 재독은 books 테이블에 '새 행'으로 저장된다 — 회독마다 완독일·평점·리뷰가
+ * 따로 있어야 하기 때문이다. 그래서 책장이 행을 그대로 그리면 2회독한 책이
+ * 표지 두 장으로 늘어나고 권수도 부풀려진다.
+ *
+ * 여기서 정하는 규칙은 하나다:
+ * **화면이 보여주는 범위 안에서 같은 책은 한 권으로 센다.**
+ * 그래서 기간 필터를 끝낸 목록에 적용해야 한다 — 전체 뷰라면 전체 기준으로,
+ * 2026년 뷰라면 2026년에 읽은 기록끼리만 합쳐진다.
+ *
+ * 합칠 때 남기는 값:
+ * - 대표 = 가장 최근에 읽은 회독 (완독일 없으면 등록 시각, 그마저 같으면 회독 수)
+ * - `is_life_book` = 회독 중 하나라도 인생책이면 true
+ *   (1회독 때만 인생책으로 꼽았어도 '내 인생책'에서 사라지면 안 된다)
+ * - `read_count` = 기록 중 최대값 (배지가 "몇 번 읽었나"를 말해야 한다)
+ *
+ * 입력 순서는 그대로 지킨다. 정렬은 호출부가 이미 끝낸 상태로 들어온다.
+ */
+export const dedupeReadings = (books: Book[]): Book[] => {
+  // ISBN 이 비어 있으면(수기 등록 등) 키가 겹쳐 엉뚱한 책끼리 합쳐진다 → id 로 갈라둔다.
+  // 여러 사람의 책이 섞인 목록에도 쓰일 수 있어 user_id 를 키에 포함한다.
+  //
+  // status 도 키다. 재독 중이면 '1회독 완독'과 '2회독 읽는 중'이 동시에 있는데,
+  // 둘을 합치면 책이 '읽는 중' 칸으로 옮겨가면서 완독 책장에서 사라진다.
+  // 같은 책이라도 놓이는 칸이 다르면 별개 항목으로 둔다.
+  const groupKey = (book: Book) =>
+    book.isbn
+      ? `${book.user_id}:${book.status}:${book.isbn}`
+      : `id:${book.id}`;
+
+  // 최신 회독 판정용 시각. 완독일이 없는 기록은 등록 시각으로 대신한다.
+  const readAt = (book: Book) =>
+    new Date(book.completed_date ?? book.created_at).getTime();
+
+  const isNewerReading = (candidate: Book, current: Book) => {
+    const diff = readAt(candidate) - readAt(current);
+    return diff !== 0 ? diff > 0 : candidate.read_count > current.read_count;
+  };
+
+  // 그룹별 대표를 고르면서, 어느 자리에 놓을지(원래 순서)도 함께 기억한다
+  const groups = new Map<string, { order: number; book: Book }>();
+
+  books.forEach((book, index) => {
+    const key = groupKey(book);
+    const group = groups.get(key);
+
+    if (!group) {
+      groups.set(key, { order: index, book });
+      return;
+    }
+
+    const merged: Book = isNewerReading(book, group.book) ? book : group.book;
+
+    groups.set(key, {
+      order: group.order,
+      book: {
+        ...merged,
+        is_life_book: group.book.is_life_book || book.is_life_book,
+        read_count: Math.max(group.book.read_count, book.read_count),
+      },
+    });
+  });
+
+  return Array.from(groups.values())
+    .sort((a, b) => a.order - b.order)
+    .map(({ book }) => book);
+};

--- a/apps/page0127/src/entities/book/model/libraryPeriod.test.ts
+++ b/apps/page0127/src/entities/book/model/libraryPeriod.test.ts
@@ -13,7 +13,10 @@ import type { Book } from '../types';
 const createBook = (overrides: Partial<Book> = {}): Book => ({
   id: crypto.randomUUID(),
   user_id: 'user-id',
-  isbn: 'isbn',
+  // 통계는 같은 ISBN 을 한 책의 회독으로 보고 합친다 → 기본값을 고정 문자열로
+  // 두면 서로 다른 책으로 만든 픽스처가 한 권으로 뭉쳐 권수가 어긋난다.
+  // 재독을 테스트하려면 isbn 을 명시적으로 같게 준다.
+  isbn: crypto.randomUUID(),
   title: '테스트 책',
   author: null,
   publisher: null,
@@ -137,6 +140,96 @@ describe('libraryPeriod', () => {
     // (5 + 4) / 2 = 4.5 — 0을 세면 3.0이 된다
     expect(stats.averageRating).toBe(4.5);
     expect(stats.totalCompletedBooks).toBe(3);
+  });
+
+  it('같은 책을 두 번 읽어도 통계에서는 한 권으로 센다', () => {
+    const books = [
+      createBook({
+        isbn: '9788901234567',
+        read_count: 1,
+        status: 'completed',
+        completed_date: '2026-01-10',
+        rating: 5,
+      }),
+      createBook({
+        isbn: '9788901234567',
+        read_count: 2,
+        status: 'completed',
+        completed_date: '2026-06-10',
+        rating: 5,
+      }),
+    ];
+
+    const stats = calculateBookStats(books, 2026, 2026);
+
+    expect(stats.totalCompletedBooks).toBe(1);
+    // 월별 막대도 한 번만 서야 한다 — 1월·6월에 각각 세면 합계가 2가 된다
+    expect(stats.monthlyReading.reduce((sum, m) => sum + m.count, 0)).toBe(1);
+  });
+
+  it('해가 다른 재독은 각 연도 통계에 그대로 남는다', () => {
+    // 2026년에 한 번, 2027년에 한 번 읽었으면 두 해 모두 1권이어야 한다.
+    // 전체 기준으로 먼저 합치면 옛 연도가 0권이 된다.
+    const books = [
+      createBook({
+        isbn: '9788901234567',
+        read_count: 1,
+        status: 'completed',
+        completed_date: '2026-05-10',
+      }),
+      createBook({
+        isbn: '9788901234567',
+        read_count: 2,
+        status: 'completed',
+        completed_date: '2027-05-10',
+      }),
+    ];
+
+    expect(calculateBookStats(books, 2026, 2027).totalCompletedBooks).toBe(1);
+    expect(calculateBookStats(books, 2027, 2027).totalCompletedBooks).toBe(1);
+  });
+
+  it('1회독 때만 인생책으로 꼽았어도 인생책 수에 남는다', () => {
+    const books = [
+      createBook({
+        isbn: '9788901234567',
+        read_count: 1,
+        status: 'completed',
+        completed_date: '2026-01-10',
+        rating: 5,
+        is_life_book: true,
+      }),
+      createBook({
+        isbn: '9788901234567',
+        read_count: 2,
+        status: 'completed',
+        completed_date: '2026-06-10',
+        rating: 5,
+        is_life_book: false,
+      }),
+    ];
+
+    expect(calculateBookStats(books, 2026, 2026).lifeBookCount).toBe(1);
+  });
+
+  it('5점이 아닌 인생책도 평점 분포에서 빠지지 않는다', () => {
+    // 인생책 버킷의 rating 은 5 로 고정돼 있다. 두 값을 모두 맞춰 찾으면
+    // '4점인데 인생책'인 책이 어느 칸에도 못 들어가 분포 합이 총 권수보다 적어진다.
+    // (1회독 5점 인생책 + 2회독 4점을 합치면 실제로 이 조합이 나온다)
+    const books = [
+      createBook({
+        rating: 4,
+        is_life_book: true,
+        status: 'completed',
+        completed_date: '2026-03-01',
+      }),
+    ];
+
+    const { ratingReading } = calculateBookStats(books, null, 2026);
+    const total = ratingReading.reduce((sum, item) => sum + item.count, 0);
+
+    expect(ratingReading.find((r) => r.is_life_book)?.count).toBe(1);
+    expect(total).toBe(1);
   });
 
   it('5점과 인생책을 다른 항목으로 센다', () => {

--- a/apps/page0127/src/entities/book/model/libraryPeriod.ts
+++ b/apps/page0127/src/entities/book/model/libraryPeriod.ts
@@ -1,4 +1,5 @@
 import { mapToMainCategory } from '../../../shared/lib/categoryMapper';
+import { dedupeReadings } from './dedupeReadings';
 import { averageScore } from './rating';
 
 import type { Book } from '../types';
@@ -148,10 +149,15 @@ const calculateRatingReading = (books: Book[]): RatingReadingData[] => {
   const ratingData = RATING_BUCKETS.map((bucket) => ({ ...bucket, count: 0 }));
 
   books.forEach((book) => {
-    const item = ratingData.find(
-      // 인생책은 rating 이 5 라도 별도 항목이다 — 두 값을 모두 본다
-      (b) => b.rating === book.rating && b.is_life_book === book.is_life_book
-    );
+    // 인생책은 점수와 무관하게 '인생책' 칸에 들어간다.
+    // 전에는 (rating, is_life_book) 두 값이 모두 맞아야 했는데, 인생책 버킷의
+    // rating 이 5 로 고정돼 있어 '4점인데 인생책'인 책이 어느 칸에도 못 들어가고
+    // 조용히 사라졌다 — 분포 합이 총 권수보다 적어진다.
+    // 회독을 합치면(1회독 5점 인생책 + 2회독 4점) 이 조합이 실제로 만들어진다.
+    const item = book.is_life_book
+      ? ratingData.find((b) => b.is_life_book)
+      : ratingData.find((b) => b.rating === book.rating && !b.is_life_book);
+
     if (item) item.count += 1;
   });
 
@@ -167,7 +173,11 @@ export const calculateBookStats = (
   year: number | null,
   currentYear: number
 ): BookStats => {
-  const scopedBooks = filterBooksByLibraryYear(books, year, currentYear);
+  // 기간으로 자른 '뒤에' 회독을 합친다 — 책장이 보여주는 범위와 숫자를 맞추기
+  // 위해서다. 먼저 합치면 옛 회독이 사라져 그 해 통계가 통째로 비어버린다.
+  const scopedBooks = dedupeReadings(
+    filterBooksByLibraryYear(books, year, currentYear)
+  );
   const completedBooks = scopedBooks.filter(
     (book) => book.status === 'completed' && book.completed_date
   );

--- a/apps/page0127/src/widgets/book/ui/PublicBookShelf.module.css
+++ b/apps/page0127/src/widgets/book/ui/PublicBookShelf.module.css
@@ -41,6 +41,36 @@
   transition: all 0.3s;
   /* 위 패딩 제거: flex-end에서 위 패딩은 이미지를 선반 아래로 밀어 선을 덮는다 */
   padding: 0 1px;
+  /* 회독 뱃지를 표지 위에 얹기 위한 기준점 */
+  position: relative;
+}
+
+/* 회독 뱃지 — 책장은 같은 책의 회독을 한 권으로 합쳐 세우므로,
+   "여러 번 읽었다"는 사실은 이 뱃지로만 남는다.
+   뱃지가 클릭을 가로채면 책 링크가 부분적으로 죽는다 → pointer-events 해제 */
+.readCount {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  pointer-events: none;
+}
+
+/* 책등은 폭이 50px뿐이라 "2회독" 뱃지가 들어가지 않는다 → 숫자만 원형으로 */
+.readCountSpine {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .books li a img {
@@ -49,6 +79,14 @@
   border: 1px solid #eee;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   margin: 0 1px;
+}
+
+/* 여러 번 읽은 책은 조금 크게 세운다 — 손때가 탄 책이 책장에서 도드라지듯.
+   li 는 바닥 정렬이라 커진 만큼 위로만 자란다(선반 선은 그대로).
+   +12px 는 줄 간격(gap 31px) 안이라 윗줄과 겹치지 않는다. */
+.books li a.reread img,
+.books li a.reread .noImage {
+  height: 252px;
 }
 
 .books li:hover a {
@@ -115,6 +153,12 @@
 .compact .books li a img,
 .compact .noImage {
   height: 210px;
+}
+
+/* 재독 책은 여기서도 조금 크게 (gap 28px 안이라 윗줄과 안 겹친다) */
+.compact .books li a.reread img,
+.compact .books li a.reread .noImage {
+  height: 221px;
 }
 
 /* li 높이가 클수록 책이 선반에 붙는다 → 218px가 얹힌 지점 */

--- a/apps/page0127/src/widgets/book/ui/PublicBookShelf.tsx
+++ b/apps/page0127/src/widgets/book/ui/PublicBookShelf.tsx
@@ -5,6 +5,8 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { ReadCountBadge } from '@/shared/ui/ReadCountBadge';
+
 import { isTopRated } from '@/entities/book';
 
 import type { Book } from '@/entities/book';
@@ -65,10 +67,16 @@ export const PublicBookShelf = ({
           const isCoverView = isTopRated(book.rating, book.is_life_book);
           const imageUrl = isCoverView ? book.cover_image : book.spine_image;
           const hasImage = !!imageUrl;
+          // 여러 번 읽은 책은 조금 크게 — 뱃지가 잘 안 보이는 책등에서도
+          // "이 책은 다르다"가 실루엣만으로 읽힌다
+          const isReread = book.read_count > 1;
 
           return (
             <li key={book.id}>
-              <Link href={getHref(book)}>
+              <Link
+                href={getHref(book)}
+                className={isReread ? styles.reread : undefined}
+              >
                 {hasImage ? (
                   <Image
                     src={imgSrc[book.id] || imageUrl}
@@ -85,6 +93,24 @@ export const PublicBookShelf = ({
                     <p>{book.title}</p>
                   </div>
                 )}
+
+                {/* 회독 뱃지. 표지는 자리가 있어 "n회독"을 그대로 쓰고,
+                    책등(50px)은 숫자만 원형으로 얹는다 */}
+                {isReread &&
+                  (isCoverView ? (
+                    <ReadCountBadge
+                      readCount={book.read_count}
+                      size='sm'
+                      className={`${styles.readCount} bg-primary text-primary-foreground shadow-sm`}
+                    />
+                  ) : (
+                    <span
+                      className={`${styles.readCountSpine} bg-primary text-primary-foreground shadow-sm`}
+                    >
+                      <span aria-hidden='true'>{book.read_count}</span>
+                      <span className='sr-only'>{book.read_count}회독</span>
+                    </span>
+                  ))}
               </Link>
             </li>
           );

--- a/apps/page0127/src/widgets/public-library/PublicLibraryContent.tsx
+++ b/apps/page0127/src/widgets/public-library/PublicLibraryContent.tsx
@@ -11,6 +11,7 @@ import { PageContainer } from '@/shared/ui/PageContainer';
 
 import {
   calculateBookStats,
+  dedupeReadings,
   filterBooksByLibraryYear,
   getLibraryYears,
 } from '@/entities/book';
@@ -95,13 +96,16 @@ export const PublicLibraryContent = ({
     [books, currentYear, selectedPeriod]
   );
 
+  // 재독은 새 row 로 쌓이므로 그대로 그리면 같은 책이 회독 수만큼 책장에 선다.
+  // 공개/보관을 나눈 뒤에 합친다 — 1회독은 공개, 2회독은 보관처럼 회독마다
+  // 공개 설정이 다를 수 있어, 합치고 나서 나누면 한쪽 칸에서 통째로 사라진다.
   const archivedBooks = useMemo(
-    () => periodBooks.filter((book) => !book.is_public),
+    () => dedupeReadings(periodBooks.filter((book) => !book.is_public)),
     [periodBooks]
   );
 
   const visibleBooks = useMemo(
-    () => periodBooks.filter((book) => book.is_public),
+    () => dedupeReadings(periodBooks.filter((book) => book.is_public)),
     [periodBooks]
   );
 
@@ -112,7 +116,7 @@ export const PublicLibraryContent = ({
 
   // 위시리스트는 내 개인 목록이라 연도·공개여부와 무관하게 전부 모은다
   const wishlistBooks = useMemo(
-    () => books.filter((book) => book.status === 'want_to_read'),
+    () => dedupeReadings(books.filter((book) => book.status === 'want_to_read')),
     [books]
   );
 


### PR DESCRIPTION
## 무엇이 문제였나

같은 책을 두 번 읽으면 '내 인생책'과 '서재 전체'에 표지가 두 장 서고,
권수도 회독 수만큼 부풀어 있었다.

재독은 `books` 테이블에 **새 행**으로 저장된다 — 회독마다 완독일·평점·리뷰가
따로 있어야 하기 때문이다. 책장이 그 행을 그대로 그린 게 원인이다.

## 어떻게 고쳤나

규칙 하나로 통일했다: **화면이 보여주는 범위 안에서 같은 책은 한 권.**

- 대표는 **가장 최근에 읽은 회독**
- 회독 중 하나라도 인생책이면 합친 결과도 인생책
- 회독 수는 기록 중 최대값

범위 안에서 합치므로 연도 뷰는 그대로다 — 2026년에 1회독, 2027년에 2회독이면
두 해 모두 1권으로 남는다.

## 함께 잡은 버그

평점 분포에서 **'5점이 아닌 인생책'이 조용히 빠지고** 있었다. 인생책 버킷의
rating 이 5 로 고정돼 있어 `(4점, 인생책)` 조합이 어느 칸에도 못 들어가
분포 합이 총 권수보다 적었다. 회독을 합치면(1회독 5점 인생책 + 2회독 4점)
이 조합이 실제로 만들어져 함께 고쳤다.

## 화면에 남긴 것

합치면서 "여러 번 읽었다"는 사실이 사라지지 않도록 책장에 표시를 넣었다.

- 표지: `2회독` 뱃지
- 책등(50px): 숫자만 원형으로 (스크린리더에는 "2회독"으로 읽힌다)
- 재독한 책은 높이 5% 크게 — 실루엣만으로 구분된다

## 검증

로컬(Docker Supabase)에 어린왕자 2회독(1회독만 인생책) + 이방인 2회독을
넣고 실제 화면으로 확인했다.

| 항목 | 결과 |
|---|---|
| 내 인생책 | 2권 (어린왕자 1권 + 2회독 뱃지) |
| 내 서재 전체 | 7행 → **6권** |
| 연도 뷰 2026 | 6권 |
| 방문자(로그아웃) 공개 서재 | 6권 |
| 누적 완독 / 인생책 | 6권 / 2권 (33%) |
| 독서 시작일 | 2026년 3월 (첫 회독 날짜 유지) |
| 평점 분포 합 | 6권 (총 권수와 일치) |

단위 테스트 255개 통과, `tsc --noEmit`·eslint 통과.

## 알아두실 점

통계까지 합치므로 `읽은 쪽수`·`예상 독서 시간`도 재독분이 빠진다.
"서로 다른 몇 권을 읽었나"로는 맞지만 "실제로 얼마나 읽었나"로는 과소 집계다.
쪽수·시간만 회독대로 세는 편이 나으면 따로 조정할 수 있다.
