### PR TITLE
🐛 Fix: 궁합 결과의 user1/user2 노출 + 알림 실시간 구독 마이그레이션

### DIFF
--- a/apps/page0127/src/entities/compatibility/lib/replaceUserLabels.test.ts
+++ b/apps/page0127/src/entities/compatibility/lib/replaceUserLabels.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { replaceUserLabels } from './replaceUserLabels';
+
+// 내가 user1인 경우
+const asFirst = { first: '나', second: '강혜진 님' };
+// 내가 user2인 경우
+const asSecond = { first: '강혜진 님', second: '나' };
+
+describe('replaceUserLabels', () => {
+  it('받침 없는 이름 뒤 조사를 맞춘다 — 나은(X) 나는(O)', () => {
+    expect(replaceUserLabels('user1은 역사에 관심이 많아요', asFirst)).toBe(
+      '나는 역사에 관심이 많아요'
+    );
+  });
+
+  it('받침 있는 이름 뒤 조사를 맞춘다 — 님는(X) 님은(O)', () => {
+    expect(replaceUserLabels('user2는 소설을 좋아해요', asFirst)).toBe(
+      '강혜진 님은 소설을 좋아해요'
+    );
+  });
+
+  it("'나' + 주격조사는 '내가'가 된다", () => {
+    expect(replaceUserLabels('user1이 더 많이 읽었어요', asFirst)).toBe(
+      '내가 더 많이 읽었어요'
+    );
+    expect(replaceUserLabels('user2가 추천했어요', asSecond)).toBe(
+      '내가 추천했어요'
+    );
+  });
+
+  it('받침 유무를 타지 않는 조사는 그대로 이어붙는다', () => {
+    expect(replaceUserLabels('user1의 기술적 관심을 넓혀줘요', asFirst)).toBe(
+      '나의 기술적 관심을 넓혀줘요'
+    );
+    expect(replaceUserLabels('user1에게 건네고 싶은 책이에요', asFirst)).toBe(
+      '나에게 건네고 싶은 책이에요'
+    );
+  });
+
+  it('한 문장에 여러 라벨이 있어도 각각 바뀐다', () => {
+    expect(
+      replaceUserLabels(
+        'user1은 소설과 역사를, user2는 프로그래밍을 좋아해요',
+        asSecond
+      )
+    ).toBe('강혜진 님은 소설과 역사를, 나는 프로그래밍을 좋아해요');
+  });
+
+  it('내가 user2일 때 매핑이 뒤집힌다', () => {
+    expect(replaceUserLabels('user1은 역사, user2는 기술', asSecond)).toBe(
+      '강혜진 님은 역사, 나는 기술'
+    );
+  });
+
+  it('영문·숫자로 끝나는 닉네임은 받침 있음으로 처리한다', () => {
+    expect(
+      replaceUserLabels('user1은 책을 좋아해요', {
+        first: 'deer2',
+        second: '나',
+      })
+    ).toBe('deer2은 책을 좋아해요');
+  });
+
+  it('라벨이 없으면 원문 그대로 둔다', () => {
+    const text = '두 분 모두 깊이 있는 독서를 즐겨요.';
+    expect(replaceUserLabels(text, asFirst)).toBe(text);
+  });
+
+  it('user3처럼 정의되지 않은 라벨은 건드리지 않는다', () => {
+    expect(replaceUserLabels('user3은 누구인가요', asFirst)).toBe(
+      'user3은 누구인가요'
+    );
+  });
+});

--- a/apps/page0127/src/entities/compatibility/lib/replaceUserLabels.ts
+++ b/apps/page0127/src/entities/compatibility/lib/replaceUserLabels.ts
@@ -1,0 +1,67 @@
+/**
+ * AI 응답에 남은 익명 라벨(user1/user2)을 화면에 보여줄 이름으로 바꾼다.
+ *
+ * 왜 필요한가:
+ * 궁합 프롬프트는 두 사람을 user1/user2로 지칭한다(실명을 외부 모델에 보내지
+ * 않기 위해서다). 그런데 AI가 만든 자유 문장 안에 그 라벨이 그대로 남아
+ * "user1은 역사에 관심이 많아요" 같은 문장이 사용자에게 노출됐다.
+ *
+ * reading_patterns 처럼 키가 user1/user2인 값은 호출부에서 매핑할 수 있지만,
+ * 문장 속에 박힌 라벨은 이렇게 치환할 수밖에 없다.
+ *
+ * 한국어 조사 처리:
+ * 단순 치환은 "user1은" → "나은"이 되어버린다. 앞말의 받침 유무에 따라
+ * 은/는·이/가·을/를·과/와를 골라준다. 1인칭 '나'는 주격에서 '내가'로 바뀌는
+ * 예외가 있어 따로 처리한다.
+ */
+
+/** 치환에 쓸 이름 — 정렬된 쌍 기준으로 user1, user2에 각각 대응한다 */
+export type UserLabelNames = {
+  first: string;
+  second: string;
+};
+
+/** 받침 유무에 따라 형태가 갈리는 조사쌍: [받침 있음, 받침 없음] */
+const JOSA_PAIRS: Record<string, [string, string]> = {
+  은: ['은', '는'],
+  는: ['은', '는'],
+  이: ['이', '가'],
+  가: ['이', '가'],
+  을: ['을', '를'],
+  를: ['을', '를'],
+  과: ['과', '와'],
+  와: ['과', '와'],
+};
+
+const SUBJECT_JOSA = new Set(['이', '가']);
+
+/** 한글 음절의 받침 유무 — 유니코드 조합 규칙상 (코드 - 0xAC00) % 28 이 0이면 받침이 없다 */
+const hasBatchim = (word: string): boolean => {
+  const last = word.trim().at(-1);
+  if (!last) return false;
+
+  const code = last.charCodeAt(0);
+  if (code < 0xac00 || code > 0xd7a3) {
+    // 한글이 아니면(영문·숫자로 끝나는 닉네임 등) 판단할 수 없다.
+    // 받침 있음으로 보면 '은/이/을'이 붙어 어색함이 덜하다.
+    return true;
+  }
+
+  return (code - 0xac00) % 28 !== 0;
+};
+
+export const replaceUserLabels = (
+  text: string,
+  names: UserLabelNames
+): string =>
+  text.replace(/user([12])(은|는|이|가|을|를|과|와)?/g, (_match, index, josa) => {
+    const name = index === '1' ? names.first : names.second;
+
+    if (!josa) return name;
+
+    // '나' + 주격조사는 '내가'가 된다 ('나가'가 아니다)
+    if (name === '나' && SUBJECT_JOSA.has(josa)) return '내가';
+
+    const [withBatchim, withoutBatchim] = JOSA_PAIRS[josa];
+    return name + (hasBatchim(name) ? withBatchim : withoutBatchim);
+  });

--- a/apps/page0127/src/features/compatibility/ui/CompatibilityView.tsx
+++ b/apps/page0127/src/features/compatibility/ui/CompatibilityView.tsx
@@ -37,6 +37,7 @@ import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { PageContainer } from '@/shared/ui/PageContainer';
 
+import { replaceUserLabels } from '@/entities/compatibility/lib/replaceUserLabels';
 import { getCompatibilityTypeByScore } from '@/entities/compatibility/model/compatibilityTypes';
 
 import type {
@@ -304,6 +305,14 @@ const CompatibilityResult = ({
     ? similarity.reading_patterns.user2
     : similarity.reading_patterns.user1;
 
+  // AI가 만든 자유 문장에는 익명 라벨(user1/user2)이 그대로 남아 있다.
+  // 화면에 뿌리기 직전에 보는 사람 기준으로 바꾼다 (저장값은 익명 그대로 둔다 —
+  // 같은 결과를 상대가 열면 '나'가 반대쪽이어야 하기 때문이다)
+  const labelNames = isCurrentUserFirst
+    ? { first: '나', second: `${targetName} 님` }
+    : { first: `${targetName} 님`, second: '나' };
+  const label = (text: string) => replaceUserLabels(text, labelNames);
+
   return (
     <div className='space-y-6'>
       {/* 1. 궁합 점수 */}
@@ -318,7 +327,7 @@ const CompatibilityResult = ({
           </p>
           <p className='mt-2 text-text-subtle'>{typeBand.tagline}</p>
           <p className='mx-auto mt-6 max-w-xl whitespace-pre-wrap text-left leading-relaxed text-text-body'>
-            {analysis.compatibility_description}
+            {label(analysis.compatibility_description)}
           </p>
         </CardContent>
       </Card>
@@ -335,12 +344,14 @@ const CompatibilityResult = ({
           <div className='grid gap-4 md:grid-cols-2'>
             <div className='rounded-lg bg-sunken p-4'>
               <p className='text-sm text-text-subtle'>나</p>
-              <p className='mt-1 font-medium text-text-strong'>{myPattern}</p>
+              <p className='mt-1 font-medium text-text-strong'>
+                {label(myPattern)}
+              </p>
             </div>
             <div className='rounded-lg bg-sunken p-4'>
               <p className='text-sm text-text-subtle'>{targetName} 님</p>
               <p className='mt-1 font-medium text-text-strong'>
-                {targetPattern}
+                {label(targetPattern)}
               </p>
             </div>
           </div>
@@ -356,7 +367,7 @@ const CompatibilityResult = ({
                     key={interest}
                     className='rounded-full border border-line px-3 py-1 text-sm text-text-body'
                   >
-                    {interest}
+                    {label(interest)}
                   </span>
                 ))}
               </div>
@@ -371,7 +382,7 @@ const CompatibilityResult = ({
               </h3>
               <ul className='space-y-1 text-sm text-text-body'>
                 {similarity.commonalities.map((item) => (
-                  <li key={item}>• {item}</li>
+                  <li key={item}>• {label(item)}</li>
                 ))}
               </ul>
             </div>
@@ -382,7 +393,7 @@ const CompatibilityResult = ({
               </h3>
               <ul className='space-y-1 text-sm text-text-body'>
                 {similarity.differences.map((item) => (
-                  <li key={item}>• {item}</li>
+                  <li key={item}>• {label(item)}</li>
                 ))}
               </ul>
             </div>
@@ -396,12 +407,14 @@ const CompatibilityResult = ({
         title={`${targetName} 님의 책장에서 골라온 책`}
         description='상대방이 읽은 책 중, 지금 이어 읽기 좋은 책들이에요.'
         recommendations={recommendationsForMe}
+        label={label}
       />
       <RecommendationList
         icon={<Gift className='h-4.5 w-4.5 text-text-subtle' />}
         title={`내 책장에서 ${targetName} 님에게 건네는 책`}
         description='내가 읽은 책 중, 상대방이 좋아할 만한 책들이에요.'
         recommendations={recommendationsForTarget}
+        label={label}
       />
 
       {/* 4. 재분석 */}
@@ -432,6 +445,8 @@ type RecommendationListProps = {
   title: string;
   description: string;
   recommendations: MutualRecommendation[];
+  /** 추천 이유에도 user1/user2 라벨이 섞여 있어 같은 치환을 거친다 */
+  label: (text: string) => string;
 };
 
 const RecommendationList = ({
@@ -439,6 +454,7 @@ const RecommendationList = ({
   title,
   description,
   recommendations,
+  label,
 }: RecommendationListProps) => {
   if (recommendations.length === 0) return null;
 
@@ -478,7 +494,7 @@ const RecommendationList = ({
                   <p className='text-sm text-text-subtle'>{rec.author}</p>
                 )}
                 <p className='mt-2 text-sm leading-relaxed text-text-body'>
-                  {rec.reason}
+                  {label(rec.reason)}
                 </p>
               </div>
             </div>

--- a/apps/page0127/src/shared/config/schemaVersion.ts
+++ b/apps/page0127/src/shared/config/schemaVersion.ts
@@ -11,7 +11,7 @@
  * 마이그레이션을 추가했다면:
  *   이 값을 새 파일의 앞 14자리 번호로 바꾼다. (예: 20260729000000)
  */
-export const EXPECTED_MIGRATION_VERSION = '20260729000000';
+export const EXPECTED_MIGRATION_VERSION = '20260729000001';
 
 /**
  * 스키마 대조 결과.

--- a/supabase/migrations/20260729000001_enable_realtime_notifications.sql
+++ b/supabase/migrations/20260729000001_enable_realtime_notifications.sql
@@ -1,0 +1,27 @@
+-- 알림 실시간 구독(Realtime) 활성화
+--
+-- useNotificationRealtime 훅이 notifications 테이블의 변경을 WebSocket으로 받아
+-- 종 배지와 목록을 갱신한다. 그런데 Supabase Realtime은 테이블을
+-- supabase_realtime publication 에 넣어야만 이벤트를 내보낸다.
+--
+-- 운영 DB는 대시보드에서 손으로 켜둔 상태였고 개발 DB는 꺼져 있었다.
+-- 그 결과 개발/Preview 에서는 새 알림이 와도 이벤트가 오지 않아,
+-- useUnreadCount 의 staleTime(5분)이 지나거나 새로고침할 때까지 배지가 그대로였다.
+-- (useUnreadCount 는 "Realtime 으로 받으니 폴링 불필요"라며 refetchInterval 을 껐다)
+--
+-- 환경마다 조용히 어긋나지 않도록 마이그레이션으로 남긴다.
+-- 이미 추가된 DB(운영)에서는 중복 추가가 에러가 되므로 존재 여부를 먼저 확인한다.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'notifications'
+  ) then
+    alter publication supabase_realtime add table public.notifications;
+  end if;
+end
+$$;


### PR DESCRIPTION
오픈 전 시나리오 검증 5단계(궁합 분석)에서 나온 두 건.

## 1 — 궁합 결과에 `user1`, `user2`가 그대로 보인다 (🐛)

궁합 프롬프트는 실명을 외부 모델에 보내지 않으려고 두 사람을 `user1`/`user2`로 지칭한다. 그런데 AI가 만든 자유 문장에 그 라벨이 남아 사용자 화면에 그대로 노출됐다.

> "**user1**은 역사에 관심이 많아요", "**user2**는 자기계발서를 즐겨 읽어요"

`reading_patterns`처럼 키가 `user1/user2`인 값은 `isCurrentUserFirst`로 매핑되고 있었지만, **문장 속에 박힌 라벨은 아무도 손대지 않았다.** 실제 검증 데이터에서 추천 이유는 5건 중 5건이 해당됐다.

### 해결

`replaceUserLabels()` — 표시 직전에 `나` / `{상대} 님`으로 치환한다.

- **저장값은 익명 그대로 둔다.** 같은 분석 결과를 상대가 열면 '나'가 반대쪽이어야 하기 때문
- **한국어 조사 보정**: 단순 치환은 "user1은" → "나은"이 된다. 앞말 받침 유무로 은/는·이/가·을/를·과/와를 고르고, 1인칭 주격 예외("user1이" → "내가")를 따로 처리
- 영문·숫자로 끝나는 닉네임은 받침 있음으로 처리 ("deer2은"이 "deer2는"보다 덜 어색)
- 적용 지점: 궁합 설명 · 독서 패턴 · 공통 관심사 · 닮은 점 · 서로를 넓혀줄 부분 · 추천 이유

## 2 — 알림 실시간 구독을 마이그레이션으로 고정 (🔧)

`notifications`가 `supabase_realtime` publication 에 들어 있어야 Realtime 이벤트가 나가는데, **운영은 대시보드에서 손으로 켜둔 상태였고 개발 DB는 꺼져 있었다**(발행 테이블 0개).

[useUnreadCount.ts:20](apps/page0127/src/entities/notification/lib/hooks/useUnreadCount.ts#L20)이 "Realtime으로 받으니 폴링 불필요"라며 `refetchInterval`을 껐고 `staleTime`이 5분이라, Preview에서는 새 알림이 와도 **배지가 5분 늦거나 새로고침해야** 떴다.

- 존재 여부를 먼저 확인해 이미 켜진 DB(운영)에서도 안전하게 통과
- 손으로 켠 설정은 환경을 새로 만들 때마다 조용히 빠진다 → 코드로 고정
- `EXPECTED_MIGRATION_VERSION` 동반 갱신 (`schemaVersion.test.ts`가 강제하는 규칙)

개발 DB에는 이미 적용해 검증했다(발행 목록에 `notifications` 확인, 이력도 기록).

## 검증

- `tsc --noEmit` 통과
- `vitest` **263건 통과** (신규 9건 — 조사 보정·양방향 매핑·미정의 라벨 무시)
- `eslint .` 통과

## 남은 확인

치환 결과는 배포 후 궁합 결과 화면에서 눈으로 봐야 한다. 기존에 저장된 분석 결과에도 소급 적용된다(표시 시점 치환이라 재분석 불필요).