### PR TITLE
🐛 Fix: 합쳐진 책을 열면 인생책이 아니고, 옛 회독으로 갈 길이 없던 문제

### DIFF
--- a/apps/page0127/app/(public)/[username]/[bookId]/page.tsx
+++ b/apps/page0127/app/(public)/[username]/[bookId]/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from '@/shared/config/supabase/server';
 import { Button } from '@/shared/ui/button';
 import { PageContainer } from '@/shared/ui/PageContainer';
 
+import { getBookReadings } from '@/entities/book/api/getBookReadings';
 import { getPublicBookRecord } from '@/entities/book/api/getPublicBookRecord';
 import { getProfileByUsername } from '@/entities/profile/api/getProfileByUsername';
 import { getPublicProfileByUsername } from '@/entities/profile/api/getPublicProfileByUsername';
@@ -15,6 +16,7 @@ import { DeleteBookButton } from '@/features/book/ui/DeleteBookButton';
 import { ShareButton } from '@/features/share';
 
 import { BookDetailContent } from '@/widgets/book/ui/BookDetailContent';
+import { BookReadingList } from '@/widgets/book/ui/BookReadingList';
 
 import type { Book } from '@/entities/book';
 import type { Metadata } from 'next';
@@ -106,6 +108,10 @@ const BookDetailPage = async ({ params }: PageProps) => {
     notFound();
   }
 
+  // 책장은 회독을 한 권으로 합쳐 최신 회독만 링크한다 → 옛 회독으로 가는 길을
+  // 여기서 되돌려 준다. 방문자에게는 공개된 회독만 보인다.
+  const readings = await getBookReadings(profile.id, book.isbn, isOwner);
+
   return (
     <PageContainer width='content'>
       <div className='mb-6 flex flex-wrap items-center justify-between gap-3'>
@@ -136,6 +142,14 @@ const BookDetailPage = async ({ params }: PageProps) => {
       </div>
 
       <BookDetailContent book={book} isOwner={isOwner} />
+
+      <div className='mt-6'>
+        <BookReadingList
+          readings={readings}
+          currentBookId={book.id}
+          username={username}
+        />
+      </div>
     </PageContainer>
   );
 };

--- a/apps/page0127/app/api/_helpers/syncLifeBookAcrossReadings.ts
+++ b/apps/page0127/app/api/_helpers/syncLifeBookAcrossReadings.ts
@@ -1,0 +1,84 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type SyncArgs = {
+  supabase: SupabaseClient;
+  userId: string;
+  /** 대상 책의 ISBN. 비어 있으면(수기 등록) 묶을 근거가 없어 아무것도 하지 않는다 */
+  isbn: string | null | undefined;
+  /** 맞출 값 */
+  isLifeBook: boolean;
+  /** 이미 저장된 행 — 다시 쓸 필요가 없어 제외한다 */
+  exceptBookId?: string;
+};
+
+/**
+ * 인생책 값을 같은 책의 모든 회독에 맞춘다.
+ *
+ * 인생책은 '회독'이 아니라 **'책'을 꼽은 것**이다. 재독은 books 에 새 행으로
+ * 저장되므로(회독마다 완독일·평점·리뷰가 따로 있어야 한다), 값을 한 행에만 쓰면
+ * 같은 책인데 회독마다 인생책 여부가 갈린다.
+ *
+ * 그러면 책장과 상세가 어긋난다 — 책장은 회독을 한 권으로 합쳐 "인생책"으로
+ * 세우는데, 눌러서 들어가면 최신 회독 행이 열리며 "인생책이 아님"으로 보인다.
+ *
+ * 그래서 쓰기 시점에 같은 책의 모든 회독을 함께 갱신한다.
+ * 기존 데이터는 마이그레이션 20260729000001 이 같은 규칙으로 백필했다.
+ *
+ * 실패해도 **본 요청은 살린다** — 회독 간 동기화가 안 됐다고 사용자가 방금 누른
+ * 수정 자체를 되돌리는 건 과하다. 화면상 어긋남은 다음 저장 때 회복된다.
+ */
+export const syncLifeBookAcrossReadings = async ({
+  supabase,
+  userId,
+  isbn,
+  isLifeBook,
+  exceptBookId,
+}: SyncArgs): Promise<void> => {
+  if (!isbn) return;
+
+  let query = supabase
+    .from('books')
+    .update({ is_life_book: isLifeBook, updated_at: new Date().toISOString() })
+    .eq('user_id', userId)
+    .eq('isbn', isbn)
+    // 이미 같은 값인 행까지 건드리면 updated_at 만 무의미하게 바뀐다
+    .neq('is_life_book', isLifeBook);
+
+  if (exceptBookId) query = query.neq('id', exceptBookId);
+
+  const { error } = await query;
+
+  if (error) {
+    console.error('회독 간 인생책 동기화 실패:', error.message);
+  }
+};
+
+/**
+ * 이 책을 이미 인생책으로 꼽은 적이 있는지 확인한다.
+ *
+ * 재독을 등록할 때 쓴다 — 1회독 때 인생책으로 꼽았다면 2회독 기록도 인생책이어야
+ * 한다. 등록 폼의 체크가 꺼져 있다는 이유로 새 행만 false 로 들어가면
+ * 같은 책의 회독끼리 값이 갈린다.
+ */
+export const hasLifeBookReading = async (
+  supabase: SupabaseClient,
+  userId: string,
+  isbn: string | null | undefined
+): Promise<boolean> => {
+  if (!isbn) return false;
+
+  const { data, error } = await supabase
+    .from('books')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('isbn', isbn)
+    .eq('is_life_book', true)
+    .limit(1);
+
+  if (error) {
+    console.error('인생책 회독 조회 실패:', error.message);
+    return false;
+  }
+
+  return (data?.length ?? 0) > 0;
+};

--- a/apps/page0127/app/api/books/[id]/route.ts
+++ b/apps/page0127/app/api/books/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   notFoundResponse,
   successResponse,
 } from '../../_helpers/response';
+import { syncLifeBookAcrossReadings } from '../../_helpers/syncLifeBookAcrossReadings';
 
 type Params = {
   params: Promise<{ id: string }>;
@@ -74,6 +75,18 @@ export async function PATCH(request: NextRequest, { params }: Params) {
       .single();
 
     if (error) return notFoundResponse('책');
+
+    // 인생책은 '회독'이 아니라 '책'을 꼽은 것이다 → 같은 책의 다른 회독에도 반영한다.
+    // 안 맞추면 책장(회독을 합쳐 인생책으로 표시)과 상세(행 그대로)가 어긋난다.
+    if (typeof body.is_life_book === 'boolean') {
+      await syncLifeBookAcrossReadings({
+        supabase,
+        userId: user.id,
+        isbn: data.isbn,
+        isLifeBook: body.is_life_book,
+        exceptBookId: id,
+      });
+    }
 
     // status가 completed로 변경된 경우 활동 생성
     if (oldBook?.status !== 'completed' && body.status === 'completed') {

--- a/apps/page0127/app/api/books/route.ts
+++ b/apps/page0127/app/api/books/route.ts
@@ -3,6 +3,10 @@ import { NextRequest } from 'next/server';
 import { createActivity } from '../_helpers/activity';
 import { getCurrentUser, getSupabaseClient } from '../_helpers/auth';
 import { errorResponse, successResponse } from '../_helpers/response';
+import {
+  hasLifeBookReading,
+  syncLifeBookAcrossReadings,
+} from '../_helpers/syncLifeBookAcrossReadings';
 
 /**
  * GET /api/books
@@ -96,16 +100,35 @@ export async function POST(request: NextRequest) {
     }
 
     // 2. 사용자 책장에 추가
+    //
+    // 인생책은 '책' 단위 속성이라 재독을 담을 때 양쪽을 맞춰야 한다.
+    // - 1회독 때 꼽아뒀으면 등록 폼 체크가 꺼져 있어도 새 회독은 인생책이다
+    // - 이번에 꼽았으면 아래에서 기존 회독들에도 반영한다
+    const isLifeBook =
+      body.is_life_book === true ||
+      (await hasLifeBookReading(supabase, user!.id, body.isbn));
+
     const { data, error } = await supabase
       .from('books')
       .insert({
         ...body,
+        is_life_book: isLifeBook,
         user_id: user!.id,
       })
       .select()
       .single();
 
     if (error) return errorResponse(error.message);
+
+    if (isLifeBook) {
+      await syncLifeBookAcrossReadings({
+        supabase,
+        userId: user!.id,
+        isbn: data.isbn,
+        isLifeBook: true,
+        exceptBookId: data.id,
+      });
+    }
 
     // 3. 활동 생성
     // 담는 순간 이미 완독이면 "완독했어요"가 사실에 가깝다. 담기와 완독을 둘 다 남기면

--- a/apps/page0127/src/entities/book/api/getBookReadings.ts
+++ b/apps/page0127/src/entities/book/api/getBookReadings.ts
@@ -1,0 +1,65 @@
+import { createClient } from '@/shared/config/supabase/server';
+
+import type { Book } from '../types';
+
+/** 회독 목록 한 줄에 필요한 만큼만 */
+export type BookReading = Pick<
+  Book,
+  | 'id'
+  | 'read_count'
+  | 'status'
+  | 'completed_date'
+  | 'rating'
+  | 'is_life_book'
+  | 'one_line_review'
+  | 'is_public'
+>;
+
+/**
+ * 같은 책의 회독 기록을 모두 가져온다 (Server Component용)
+ *
+ * 왜 필요한가: 재독은 books 에 새 행으로 저장되는데, 책장은 회독을 한 권으로
+ * 합쳐 **최신 회독**만 링크한다. 그래서 합치기를 넣은 뒤로 옛 회독의 평점·한줄평을
+ * 열어볼 길이 사라졌다. 상세 페이지가 이 목록으로 그 길을 되돌려 준다.
+ *
+ * 묶는 기준은 ISBN 이다 — 앱의 다른 곳과 같은 규칙
+ * (entities/book/model/dedupeReadings.ts). ISBN 이 비어 있는 수기 등록 책은
+ * 묶을 근거가 없으므로 자기 자신만 돌려준다.
+ *
+ * @param userId 책장 주인
+ * @param isbn 대상 책의 ISBN
+ * @param includePrivate 소유자 여부. 방문자에게는 공개 기록만 보여준다
+ *        (RLS 는 익명 방문자만 걸러주므로 조건을 코드에서도 명시한다)
+ */
+export const getBookReadings = async (
+  userId: string,
+  isbn: string | null,
+  includePrivate: boolean
+): Promise<BookReading[]> => {
+  if (!isbn) return [];
+
+  const supabase = await createClient();
+
+  let query = supabase
+    .from('books')
+    .select(
+      'id, read_count, status, completed_date, rating, is_life_book, one_line_review, is_public'
+    )
+    .eq('user_id', userId)
+    .eq('isbn', isbn)
+    // 최근에 읽은 회독을 위에 둔다
+    .order('read_count', { ascending: false });
+
+  if (!includePrivate) {
+    query = query.eq('is_public', true);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error('회독 기록 조회 실패:', error.message);
+    return [];
+  }
+
+  return data ?? [];
+};

--- a/apps/page0127/src/widgets/book/ui/BookReadingList.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookReadingList.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link';
+
+import { Lock } from 'lucide-react';
+
+import { isRated } from '@/entities/book';
+
+import type { BookReading } from '@/entities/book/api/getBookReadings';
+
+type BookReadingListProps = {
+  readings: BookReading[];
+
+  /** 지금 보고 있는 기록의 id — 이 줄만 링크 대신 강조로 남긴다 */
+  currentBookId: string;
+
+  /** 회독 링크 계산용 */
+  username: string;
+};
+
+/**
+ * '이 책을 읽은 기록' — 같은 책의 회독을 한 줄씩 보여준다
+ *
+ * 책장은 회독을 한 권으로 합쳐 **최신 회독**만 링크한다. 그래서 옛 회독의
+ * 평점·한줄평을 열어볼 길이 없어지는데, 이 목록이 그 길이다.
+ *
+ * 회독이 하나뿐이면 보여줄 게 없으므로 섹션을 통째로 숨긴다 — 대부분의 책은
+ * 1회독이라, 늘 띄우면 의미 없는 줄이 모든 상세 페이지에 하나씩 붙는다.
+ */
+export const BookReadingList = ({
+  readings,
+  currentBookId,
+  username,
+}: BookReadingListProps) => {
+  if (readings.length <= 1) return null;
+
+  return (
+    <section className='rounded-2xl bg-card p-6'>
+      <h2 className='mb-1 text-base font-medium text-text-strong'>
+        이 책을 읽은 기록{' '}
+        <span className='font-normal text-text-subtle'>
+          {readings.length}번
+        </span>
+      </h2>
+      <p className='mb-4 text-sm text-text-subtle'>
+        회독마다 평점과 한줄평을 따로 남길 수 있어요.
+      </p>
+
+      <ul className='divide-y divide-line-soft'>
+        {readings.map((reading) => {
+          const isCurrent = reading.id === currentBookId;
+
+          const row = (
+            <div className='flex flex-wrap items-center gap-x-3 gap-y-1 py-3'>
+              <span
+                className={
+                  isCurrent
+                    ? 'font-medium text-primary'
+                    : 'font-medium text-text-strong'
+                }
+              >
+                {reading.read_count}회독
+              </span>
+
+              <span className='text-sm text-text-body'>
+                {reading.completed_date ??
+                  (reading.status === 'reading' ? '읽는 중' : '날짜 없음')}
+              </span>
+
+              {/* isRated: 0("평가 안 함")을 걸러낸다. 인생책은 점수가 아니라 이름으로 */}
+              {isRated(reading.rating) && (
+                <span className='text-sm text-text-body'>
+                  {reading.is_life_book ? '인생책' : `${reading.rating}점`}
+                </span>
+              )}
+
+              {!reading.is_public && (
+                <span className='flex items-center gap-1 text-xs text-text-subtle'>
+                  <Lock className='h-3 w-3' />
+                  보관
+                </span>
+              )}
+
+              {/* 한줄평보다 앞에 둔다 — 뒤에 두면 줄바꿈되는 한줄평에 밀려
+                  어느 줄을 가리키는 표시인지 알아보기 어렵다 */}
+              {isCurrent && (
+                <span className='text-xs text-text-subtle'>지금 보는 기록</span>
+              )}
+
+              {reading.one_line_review && (
+                <span className='w-full truncate text-sm text-text-subtle'>
+                  “{reading.one_line_review}”
+                </span>
+              )}
+            </div>
+          );
+
+          return (
+            <li key={reading.id}>
+              {isCurrent ? (
+                row
+              ) : (
+                <Link
+                  href={`/${username}/${reading.id}`}
+                  className='block hover:bg-sunken'
+                >
+                  {row}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};

--- a/supabase/migrations/20260729000001_life_book_per_book.sql
+++ b/supabase/migrations/20260729000001_life_book_per_book.sql
@@ -1,0 +1,36 @@
+-- 인생책을 '회독'이 아니라 '책' 단위 속성으로 맞춘다
+-- 작성일: 2026-07-29
+--
+-- 배경: 재독은 books 에 새 행으로 저장된다(회독마다 완독일·평점·리뷰가 따로
+-- 있어야 하므로). 그래서 1회독 때만 '인생책'을 체크하면 같은 책인데 회독마다
+-- 값이 달라진다. 책장은 회독을 한 권으로 합쳐 "인생책"으로 보여주는데,
+-- 그 책을 눌러 들어가면 최신 회독 행이 열리면서 "인생책이 아님"으로 보였다.
+--
+-- 규칙: 인생책은 그 '책'을 꼽은 것이다. 한 번이라도 인생책으로 꼽았으면
+-- 같은 책의 모든 회독이 인생책이다.
+--
+-- 이 마이그레이션은 기존 데이터를 그 규칙에 맞춘다(백필). 앞으로의 쓰기는
+-- API 라우트(app/api/books)가 같은 규칙으로 함께 갱신한다.
+
+-- 같은 사용자 + 같은 ISBN 묶음에 인생책이 하나라도 있으면 전부 true 로 올린다.
+-- ISBN 이 비어 있는 수기 등록 책은 묶을 근거가 없으므로 건드리지 않는다
+-- (앱의 그룹 키도 같은 규칙 — entities/book/model/dedupeReadings.ts 참고).
+UPDATE books AS target
+SET
+  is_life_book = true,
+  updated_at = now()
+FROM (
+  SELECT
+    user_id,
+    isbn
+  FROM books
+  WHERE
+    is_life_book = true
+    AND isbn IS NOT NULL
+    AND isbn <> ''
+  GROUP BY user_id, isbn
+) AS life
+WHERE
+  target.user_id = life.user_id
+  AND target.isbn = life.isbn
+  AND target.is_life_book = false;


### PR DESCRIPTION
#45(회독 합치기) 후속. 합치기를 넣으면서 생긴 구멍 두 개를 막는다.

## 구멍 1 — 인생책 책장에 있는데 열어보면 인생책이 아니다

책장은 "회독 중 하나라도 인생책이면 인생책"으로 합쳐 세우는데, 그건 **표시용
파생값**이었다. 상세 페이지는 실제 행을 보므로, 1회독만 인생책으로 꼽은 책을
누르면 최신 회독 행이 열리며 "4점"으로 보였다.

**인생책은 '회독'이 아니라 '책'을 꼽은 것**으로 정리했다. 한 번이라도 꼽았으면
그 책의 모든 회독이 인생책이다.

- 마이그레이션 `20260729000001` — 기존 데이터 백필 (같은 user_id+isbn 에 true 가
  하나라도 있으면 전부 올린다). ISBN 이 빈 수기 등록 책은 묶을 근거가 없어 제외
- 쓰기 경로(등록·수정 API)도 같은 규칙으로 함께 갱신 — 백필만 하면 다음 저장에
  또 어긋난다

## 구멍 2 — 옛 회독으로 갈 길이 없다

합치기 전엔 표지 두 장이 각각 링크였는데, 이제 최신 회독만 링크된다. 1회독의
평점·한줄평을 고치려면 URL을 직접 쳐야 했다.

상세 페이지에 **'이 책을 읽은 기록'** 목록을 넣어 각 회독으로 갈 수 있게 했다.
회독이 하나뿐이면 섹션을 숨긴다 — 대부분의 책은 1회독이라 늘 띄우면 의미 없는
줄이 모든 상세에 붙는다.

## 검증

로컬(Docker Supabase)에서 실제 API·화면으로 확인했다.

| 시나리오 | 결과 |
|---|---|
| 마이그레이션 적용 | 어긋난 1건 보정, 재실행 시 `UPDATE 0` (멱등) |
| 최신 회독에서 인생책 해제 | 모든 회독이 함께 풀림 |
| 옛 회독에서 인생책 지정 | 모든 회독에 함께 반영 |
| 체크 없이 3회독 등록 | 새 회독도 인생책으로 들어감 |
| 상세 헤더 | "완독 · 2회독 · **인생책**" (전에는 "4점") |
| 회독 목록 | 소유자·방문자 모두 1·2회독 표시 |
| 1회독 줄 클릭 | 그 회독 상세로 이동, 수정 링크도 그 회독 |

단위 테스트 279개 통과, `tsc --noEmit`·eslint 통과.

## 배포 시 주의

**마이그레이션을 먼저 적용해야 한다.** 백필 없이 코드만 나가면 기존에 어긋난
데이터(1회독만 인생책)가 그대로 남아 책장과 상세가 계속 다르게 보인다.
`schemaVersion` 도 `20260729000001` 로 올렸으므로, 적용 전에는 품질 대시보드에
drift 로 잡힌다.
