### PR TITLE
🔧 Chore: Sentry 노이즈 차단 — 정상 거절(4xx)과 Node 경고를 이슈에서 뺀다

### DIFF
--- a/apps/page0127/app/api/_helpers/response.test.ts
+++ b/apps/page0127/app/api/_helpers/response.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  errorResponse,
+  internalErrorResponse,
+  notFoundResponse,
+  unauthorizedResponse,
+} from './response';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const spyLogs = () => ({
+  error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+  warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+});
+
+describe('errorResponse 로그 레벨', () => {
+  /**
+   * Sentry 의 captureConsoleIntegration 이 console.error 만 이슈로 만든다.
+   * 이 구분이 무너지면 정상 거절(4xx)이 장애 목록을 채운다.
+   */
+  it('5xx는 console.error로 남긴다 — Sentry 이슈가 되어야 한다', () => {
+    const log = spyLogs();
+
+    errorResponse('서버 오류가 발생했습니다.', 500);
+
+    expect(log.error).toHaveBeenCalledOnce();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('401은 console.warn으로만 남긴다 — 비로그인은 장애가 아니다', () => {
+    const log = spyLogs();
+
+    unauthorizedResponse();
+
+    expect(log.error).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledOnce();
+  });
+
+  it('404·400도 warn이다', () => {
+    const log = spyLogs();
+
+    notFoundResponse('책');
+    errorResponse('잘못된 요청입니다.', 400);
+
+    expect(log.error).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('상태 코드를 생략하면 500으로 보고 error를 남긴다', () => {
+    const log = spyLogs();
+
+    errorResponse('알 수 없는 오류');
+
+    expect(log.error).toHaveBeenCalledOnce();
+  });
+
+  it('internalErrorResponse는 항상 error다', () => {
+    const log = spyLogs();
+
+    internalErrorResponse(new Error('DB 연결 실패'));
+
+    expect(log.error).toHaveBeenCalledOnce();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('errorResponse 응답 본문', () => {
+  it('상태 코드와 메시지를 그대로 싣는다', async () => {
+    spyLogs();
+
+    const response = errorResponse('로그인이 필요합니다.', 401);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: '로그인이 필요합니다.',
+    });
+  });
+});

--- a/apps/page0127/app/api/_helpers/response.ts
+++ b/apps/page0127/app/api/_helpers/response.ts
@@ -17,9 +17,20 @@ export function successResponse<T>(data: T, status = 200) {
 
 /**
  * 에러 응답
+ *
+ * 로그 레벨을 상태 코드로 가른다:
+ * - 5xx → console.error. 서버가 잘못한 것이므로 Sentry 이슈로 올라와야 한다.
+ * - 4xx → console.warn. 비로그인(401)·잘못된 입력(400)·없는 리소스(404)는
+ *   서버 장애가 아니라 **정상적으로 거절한 요청**이다.
+ *
+ * 왜 나누는가: sentry.server.config.ts 의 captureConsoleIntegration 이
+ * console.error 를 전부 이슈로 만든다. 예전에는 4xx도 error 로 찍어서,
+ * 비로그인 방문자가 만드는 `GET /api/auth/me` 401 이 이틀 만에 52건 쌓였다.
+ * 오픈하면 방문자 수만큼 늘어나 **진짜 장애가 그 사이에 묻힌다.**
  */
 export function errorResponse(message: string, status = 500) {
-  console.error(`API Error (${status}):`, message);
+  const log = status >= 500 ? console.error : console.warn;
+  log(`API Error (${status}):`, message);
   return NextResponse.json({ error: message }, { status });
 }
 

--- a/apps/page0127/sentry.edge.config.ts
+++ b/apps/page0127/sentry.edge.config.ts
@@ -5,6 +5,11 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import {
+  extractEventText,
+  isNoiseEvent,
+} from '@/shared/config/sentryNoiseFilter';
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -13,6 +18,11 @@ Sentry.init({
       levels: ['error'],
     }),
   ],
+
+  // 서버 설정과 동일한 노이즈 필터 (미들웨어·엣지 라우트)
+  beforeSend(event) {
+    return isNoiseEvent(extractEventText(event)) ? null : event;
+  },
 
   dataCollection: {
     userInfo: false,

--- a/apps/page0127/sentry.server.config.ts
+++ b/apps/page0127/sentry.server.config.ts
@@ -4,17 +4,31 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import {
+  extractEventText,
+  isNoiseEvent,
+} from '@/shared/config/sentryNoiseFilter';
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // API 라우트가 오류를 잡아 JSON 500으로 바꾸는 경우에도 console.error를
   // Sentry 이슈로 남긴다. 클라이언트 콘솔은 중복·사용자 데이터 위험 때문에
   // 이 통합을 켜지 않는다.
+  //
+  // 주의: 이 통합 때문에 console.error 는 곧 Sentry 이슈다. 정상적으로 거절한
+  // 요청(4xx)까지 error 로 찍으면 장애 목록이 노이즈로 찬다
+  // (app/api/_helpers/response.ts 가 상태 코드로 레벨을 가르는 이유).
   integrations: [
     Sentry.captureConsoleIntegration({
       levels: ['error'],
     }),
   ],
+
+  // 우리가 고칠 수 없고 장애도 아닌 것은 올리지 않는다 (Node 실험 기능 경고 등)
+  beforeSend(event) {
+    return isNoiseEvent(extractEventText(event)) ? null : event;
+  },
 
   dataCollection: {
     userInfo: false,

--- a/apps/page0127/src/shared/config/sentryNoiseFilter.test.ts
+++ b/apps/page0127/src/shared/config/sentryNoiseFilter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractEventText, isNoiseEvent } from './sentryNoiseFilter';
+
+describe('extractEventText', () => {
+  it('콘솔 캡처 이벤트는 message에서 뽑는다', () => {
+    expect(extractEventText({ message: '무언가 실패' })).toBe('무언가 실패');
+  });
+
+  it('예외 이벤트는 exception에서 뽑는다', () => {
+    expect(
+      extractEventText({ exception: { values: [{ value: 'TypeError: x' }] } })
+    ).toBe('TypeError: x');
+  });
+
+  it('둘 다 없으면 빈 문자열', () => {
+    expect(extractEventText({})).toBe('');
+    expect(extractEventText({ exception: { values: [] } })).toBe('');
+  });
+});
+
+describe('isNoiseEvent', () => {
+  it('Node 실험 기능 경고는 걸러낸다', () => {
+    expect(
+      isNoiseEvent(
+        '(node:4) ExperimentalWarning: vm.USE_MAIN_CONTEXT_DEFAULT_LOADER is an experimental feature'
+      )
+    ).toBe(true);
+  });
+
+  it('일반 오류는 통과시킨다 — 필터가 진짜 오류를 삼키면 안 된다', () => {
+    expect(isNoiseEvent('취향 분석 실패: 401 Incorrect API key')).toBe(false);
+    expect(isNoiseEvent('공개 책 기록 조회 실패')).toBe(false);
+    expect(
+      isNoiseEvent('[health] 마이그레이션 미적용: 코드는 20260729000002 를 기대한다')
+    ).toBe(false);
+  });
+
+  it('빈 문자열은 노이즈가 아니다 — 내용을 모르면 올려서 보게 한다', () => {
+    expect(isNoiseEvent('')).toBe(false);
+  });
+});

--- a/apps/page0127/src/shared/config/sentryNoiseFilter.ts
+++ b/apps/page0127/src/shared/config/sentryNoiseFilter.ts
@@ -1,0 +1,27 @@
+/**
+ * Sentry 로 올리지 않을 "노이즈" 판별.
+ *
+ * captureConsoleIntegration 을 켜 두면 콘솔로 나가는 것이 그대로 이슈가 된다.
+ * 그중에는 우리가 손댈 수 없고 장애도 아닌 것들이 섞인다. 이런 게 쌓이면
+ * **진짜 오류가 목록에서 밀려나** 알림의 의미가 사라진다.
+ *
+ * 여기 넣는 기준: (1) 사용자에게 아무 영향이 없고, (2) 우리 코드로 고칠 수
+ * 없으며, (3) 반복적으로 발생하는 것. 셋을 다 만족하지 않으면 넣지 않는다 —
+ * 필터는 늘 "진짜 오류를 놓칠 위험"과 맞바꾸는 선택이다.
+ */
+
+const NOISE_PATTERNS: RegExp[] = [
+  // Node 실험 기능 경고. next/og(satori)가 OG 이미지를 그릴 때 띄운다.
+  // 오류가 아니라 경고이고, 런타임을 우리가 고를 수 없어 없앨 방법이 없다.
+  /ExperimentalWarning/,
+];
+
+/** 이벤트에서 판별에 쓸 문자열을 뽑는다 (콘솔 캡처는 message, 예외는 exception에 담긴다) */
+export const extractEventText = (event: {
+  message?: string;
+  exception?: { values?: { value?: string }[] };
+}): string =>
+  event.message ?? event.exception?.values?.[0]?.value ?? '';
+
+export const isNoiseEvent = (text: string): boolean =>
+  text.length > 0 && NOISE_PATTERNS.some((pattern) => pattern.test(text));


### PR DESCRIPTION
## 문제

오픈 전 검증 마무리에서 Sentry 운영 이슈 목록을 훑다 발견했다.

| 이슈 | 건수 | 정체 |
| --- | --- | --- |
| `API Error (401): 로그인이 필요합니다` — `GET /api/auth/me` | **52** | 비로그인 방문자면 **누구나** 만드는 정상 응답 |
| `(node:4) ExperimentalWarning: vm.USE_MAIN_CONTEXT_DEFAULT_LOADER` | 15 | `next/og` 가 띄우는 Node 경고 |

이틀 만에 67건이다. **오픈하면 방문자 수에 비례해 늘어난다.** 그러면 진짜 장애가 이 사이에 묻혀서, 알림을 켜 둔 의미가 사라진다.

## 원인

[sentry.server.config.ts](apps/page0127/sentry.server.config.ts)의 `captureConsoleIntegration({ levels: ['error'] })` 때문에 **`console.error` 는 곧 Sentry 이슈**다. 그런데 [response.ts](apps/page0127/app/api/_helpers/response.ts)의 `errorResponse` 가 상태 코드와 무관하게 전부 `console.error` 로 찍고 있었다.

```ts
export function errorResponse(message: string, status = 500) {
  console.error(`API Error (${status}):`, message);  // 401도 500도 똑같이
```

401·404·400 은 **서버가 잘못한 게 아니라 정상적으로 거절한 요청**이다.

## 변경

**1. 로그 레벨을 상태 코드로 가른다**

- `5xx` → `console.error` (Sentry 이슈로 올라와야 한다)
- `4xx` → `console.warn` (로컬 디버깅에는 남지만 이슈는 아니다)

**2. `beforeSend` 노이즈 필터** (server·edge 양쪽)

`ExperimentalWarning` 을 제외한다. 런타임을 우리가 고를 수 없어 없앨 방법이 없는 경고다.

필터는 언제나 **"진짜 오류를 놓칠 위험"과 맞바꾸는 선택**이라, 무엇을 넣을지 기준을 주석에 못 박았다 — (1) 사용자에게 영향 없고 (2) 우리 코드로 고칠 수 없으며 (3) 반복 발생하는 것. 그리고 **일반 오류가 필터를 통과하는지**를 테스트로 고정했다(취향 분석 실패·조회 실패·헬스체크 경보가 살아남는지).

## 검증

- `vitest` **292건 통과** (신규 12건 — 레벨 분기 6, 노이즈 필터 6)
- `tsc --noEmit` 통과
- `eslint .` 통과
- **`next build` 통과** — Sentry 설정 파일에서 `@/` alias 가 실제로 해석되는지 확인하려고 돌렸다

## 남는 것

기존에 쌓인 이슈 67건은 자동으로 사라지지 않는다. 배포 후 Sentry 에서 **resolve 처리**하면 새로 올라오지 않는 것으로 확인할 수 있다.