### PR TITLE
✨ Feat: Foundation 스토리 — 색·타이포·간격을 눈으로

### DIFF
--- a/apps/page0127/eslint.config.mjs
+++ b/apps/page0127/eslint.config.mjs
@@ -241,6 +241,10 @@ const eslintConfig = defineConfig([
       // .storybook/main.ts·preview.tsx 는 설정을, 스토리 파일은 meta 를 default 로 내보낸다.
       '.storybook/**/*.{ts,tsx}',
       '**/*.stories.{ts,tsx}',
+
+      // 앰비언트 모듈 선언 (Default Export 필수)
+      // 예: Vite 의 `?raw` import 는 문자열을 default 로 내보낸다.
+      '**/*.d.ts',
     ],
     rules: {
       'import/no-default-export': 'off',

--- a/apps/page0127/src/shared/foundations/Colors.stories.tsx
+++ b/apps/page0127/src/shared/foundations/Colors.stories.tsx
@@ -1,0 +1,209 @@
+import { Swatch, SwatchRow } from './Swatch';
+import { darkOverrides, pick, primitiveGroups } from './tokens';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+/**
+ * 색 팔레트. **값은 `packages/design-tokens/dist/*.css` 를 그 자리에서 파싱해 그린다** —
+ * 이 문서에 색을 손으로 적어 둔 곳은 없으므로, 토큰을 고치고 빌드하면 여기도 같이 바뀐다.
+ *
+ * 스와치를 클릭하면 `var(--이름)` 이 복사된다. 코드에 그대로 붙일 수 있는 형태다.
+ *
+ * ## 2층 구조
+ *
+ * - **Primitives** — 화면에 직접 쓰지 않는다. Semantic 이 참조할 "물감"이다.
+ * - **Semantic** — 컴포넌트는 이것만 쓴다. 전부 Primitives 를 참조(alias)하므로
+ *   원색을 바꾸면 함께 움직인다. 스와치의 `→` 표시가 그 참조다.
+ *
+ * ## 색을 고르는 원칙 (07 문서)
+ *
+ * 1. 무채(네이비 잉크)가 지배한다. 유채색은 장식이 아니라 **직무**다 —
+ *    `primary`=브랜드·주 CTA·링크, `rank-up`=순위 상승, `destructive`=삭제·탈퇴.
+ * 2. 입체는 그림자가 아니라 **1px 선**으로 만든다 (`line` · `line-soft`).
+ * 3. 본문을 흐리게 칠하지 않는다. 읽으라고 쓴 글은 `text-strong` · `text-body`.
+ *
+ * ## 명암비
+ *
+ * 텍스트·액션 토큰에는 **흰 배경 기준 WCAG 명암비와 등급**을 함께 표시한다.
+ * 눈으로만 고르면 기준을 못 넘긴 걸 알아채지 못한다 — 실제로 `text/subtle` 이
+ * 4.496 으로 AA(4.5)에 0.004 모자란 채 쓰이고 있었다.
+ * `AA Large` 는 18.66px+bold 또는 24px 이상에서만 통과라는 뜻이라 **본문에는 미달**이다.
+ */
+const meta = {
+  title: 'Foundation/Colors',
+  parameters: {
+    layout: 'fullscreen',
+    // 팔레트는 색 자체가 내용이라 대비 검사를 걸면 스와치 전부가 위반으로 잡힌다.
+    a11y: { disable: true },
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const WHITE = '#ffffff';
+
+/** 화면에 직접 쓰지 않는 원색. Semantic 이 참조할 물감이다. */
+export const Primitives: Story = {
+  render: () => (
+    <div className='p-6'>
+      {primitiveGroups.map((group) => (
+        <SwatchRow key={group.family} title={group.family}>
+          {group.tokens.map((token) => (
+            <Swatch key={token.name} token={token} />
+          ))}
+        </SwatchRow>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * 컴포넌트가 실제로 쓰는 토큰.
+ *
+ * **명암비는 잴 뜻이 있는 곳에만 붙였다.** 면·경계·차트 토큰에까지 텍스트 기준(4.5)을
+ * 들이대면 화면이 빨간 배지로 덮여 진짜 문제가 묻힌다. 전경색은 각자가 실제로 얹히는
+ * 배경 위에서 쟀다 — `primary-foreground` 를 흰 배경에서 재면 1.00 이 나오지만
+ * 그건 아무 뜻도 없는 숫자다.
+ */
+export const Semantic: Story = {
+  render: () => (
+    <div className='p-6'>
+      <SwatchRow
+        title='텍스트 위계'
+        description='흰 배경(background) 기준. text-faint 는 2.50 으로 본문 기준 미달인데, 캡션에만 쓰고 정보를 담지 않는다는 전제로 남겨 둔 값이다 — 읽어야 하는 글에는 쓰지 않는다.'
+      >
+        {pick(
+          '--text-strong',
+          '--text-body',
+          '--text-subtle',
+          '--text-faint'
+        ).map((token) => (
+          <Swatch key={token.name} token={token} contrastAgainst={WHITE} />
+        ))}
+      </SwatchRow>
+
+      <SwatchRow
+        title='직무색'
+        description='유채색은 장식이 아니라 직무다. 흰 배경 기준 — 링크·아이콘 등 전경으로도 쓰이므로 텍스트 기준으로 잰다.'
+      >
+        {pick('--primary', '--rank-up', '--destructive').map((token) => (
+          <Swatch key={token.name} token={token} contrastAgainst={WHITE} />
+        ))}
+      </SwatchRow>
+
+      <SwatchRow
+        title='전경 — 각자의 배경 위에서 잰 값'
+        description='primary-foreground 는 primary 위, accent-foreground 는 accent 위… 실제로 얹히는 짝 위에서 재야 뜻이 있는 숫자가 나온다.'
+      >
+        <Swatch
+          token={pick('--primary-foreground')[0]}
+          contrastAgainst={pick('--primary')[0].value}
+        />
+        <Swatch
+          token={pick('--accent-foreground')[0]}
+          contrastAgainst={pick('--accent')[0].value}
+        />
+        <Swatch
+          token={pick('--secondary-foreground')[0]}
+          contrastAgainst={pick('--secondary')[0].value}
+        />
+        <Swatch
+          token={pick('--muted-foreground')[0]}
+          contrastAgainst={pick('--muted')[0].value}
+        />
+        <Swatch
+          token={pick('--card-foreground')[0]}
+          contrastAgainst={pick('--card')[0].value}
+        />
+      </SwatchRow>
+
+      <SwatchRow
+        title='면'
+        description='배경으로만 쓰이므로 명암비를 재지 않는다. secondary·muted 는 sunken 과 같은 값이다 — 과거 따로 있었으나 육안 구분이 안 되는 밝기 차라 통합했다.'
+      >
+        {pick(
+          '--background',
+          '--card',
+          '--popover',
+          '--sunken',
+          '--secondary',
+          '--muted',
+          '--accent',
+          '--overlay'
+        ).map((token) => (
+          <Swatch key={token.name} token={token} />
+        ))}
+      </SwatchRow>
+
+      <SwatchRow
+        title='경계'
+        description='입체는 그림자가 아니라 1px 선으로 만든다 (07 원칙 2). border·input 은 line 의 별칭이다.'
+      >
+        {pick('--line', '--line-soft', '--border', '--input', '--ring').map(
+          (token) => (
+            <Swatch key={token.name} token={token} />
+          )
+        )}
+      </SwatchRow>
+
+      <SwatchRow
+        title='차트'
+        description='카테고리를 구분하는 용도라 서로 구별되는 것이 기준이다. 텍스트 명암비 대상이 아니다.'
+      >
+        {pick(
+          '--chart-1',
+          '--chart-2',
+          '--chart-3',
+          '--chart-4',
+          '--chart-5',
+          '--chart-6',
+          '--chart-7'
+        ).map((token) => (
+          <Swatch key={token.name} token={token} />
+        ))}
+      </SwatchRow>
+
+      <SwatchRow
+        title='사이드바'
+        description='어드민 레이아웃 전용. 대부분 본체 토큰과 같은 값을 참조한다.'
+      >
+        {pick(
+          '--sidebar',
+          '--sidebar-foreground',
+          '--sidebar-primary',
+          '--sidebar-primary-foreground',
+          '--sidebar-accent',
+          '--sidebar-accent-foreground',
+          '--sidebar-border',
+          '--sidebar-ring'
+        ).map((token) => (
+          <Swatch key={token.name} token={token} />
+        ))}
+      </SwatchRow>
+    </div>
+  ),
+};
+
+/**
+ * 다크에서 값이 덮어써지는 토큰만. 여기 없는 토큰은 라이트 값을 그대로 쓴다.
+ *
+ * 명암비는 다크 배경(`navy/900`) 기준이다. 라이트에서 쓰던 색을 그대로 못 쓰는 경우가
+ * 많아 별도 원색이 필요했다 — `blue/600` 은 다크 배경 위 2.70 이라 primary 로 쓸 수 없다.
+ */
+export const Dark: Story = {
+  parameters: { backgrounds: { disable: true } },
+  render: () => (
+    <div className='p-6' style={{ backgroundColor: '#14294e' }}>
+      <SwatchRow
+        title='다크 오버라이드'
+        description='명암비는 다크 배경(navy/900 #14294e) 기준.'
+      >
+        {darkOverrides.map((token) => (
+          <Swatch key={token.name} token={token} contrastAgainst='#14294e' />
+        ))}
+      </SwatchRow>
+    </div>
+  ),
+};

--- a/apps/page0127/src/shared/foundations/Spacing.stories.tsx
+++ b/apps/page0127/src/shared/foundations/Spacing.stories.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useRef } from 'react';
+
+import { useMeasured } from './useMeasured';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+/**
+ * 간격과 모서리.
+ *
+ * ## 간격은 Tailwind 기본 스케일을 쓴다
+ *
+ * 별도 토큰을 만들지 않았다. 4px 그리드가 이미 Tailwind 에 있고, 한 겹 더 씌우면
+ * `space/4` 와 `p-4` 중 무엇을 쓸지 매번 고민하게 된다. Figma 쪽에만 같은 이름의
+ * 변수를 둬서 디자인에서 임의값이 나오지 않게 막는다.
+ *
+ * ## 모서리는 하나에서 파생된다
+ *
+ * `--radius`(8px)가 기준이고 sm·md·lg·xl 은 여기서 `calc()` 로 갈라진다.
+ * 카드 기준이 lg(=8px)이며, 값을 바꾸려면 `packages/design-tokens` 의 `radius` 하나만
+ * 고치면 전부 따라 움직인다.
+ *
+ * ## 그림자는 쓰지 않는다
+ *
+ * 입체는 그림자가 아니라 **1px 선**으로 만든다(07 원칙 2). 실측 근거가 있다 —
+ * 교보문고 홈이 그림자 2개에 1px 보더 139회, 밀리의서재가 그림자 4개였다.
+ * 그래서 elevation 스케일 자체가 없다. 떠 있어야 하는 것(모달·드롭다운)에만 예외로 준다.
+ */
+const meta = {
+  title: 'Foundation/Spacing & Corner',
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/*
+  클래스 이름을 문자열 보간(`w-${step}`)으로 만들면 안 된다 —
+  Tailwind 는 소스를 훑어 쓰인 클래스만 생성하므로 조립된 이름은 찾지 못하고,
+  스타일이 통째로 빠진 채 조용히 렌더된다. 그래서 전부 적어 둔다.
+*/
+const SPACE_STEPS = [
+  { label: 'p-1', className: 'w-1' },
+  { label: 'p-2', className: 'w-2' },
+  { label: 'p-3', className: 'w-3' },
+  { label: 'p-4', className: 'w-4' },
+  { label: 'p-6', className: 'w-6' },
+  { label: 'p-8', className: 'w-8' },
+  { label: 'p-12', className: 'w-12' },
+  { label: 'p-16', className: 'w-16' },
+] as const;
+
+const CORNER_STEPS = [
+  { label: 'rounded-sm', className: 'rounded-sm' },
+  { label: 'rounded-md', className: 'rounded-md' },
+  { label: 'rounded-lg', className: 'rounded-lg' },
+  { label: 'rounded-xl', className: 'rounded-xl' },
+] as const;
+
+const MEASURED_WIDTH = ['width'];
+const MEASURED_RADIUS = ['border-top-left-radius'];
+
+type StepProps = { label: string; className: string };
+
+/** 막대 하나 — 실제 렌더된 너비를 되읽어 표시한다 */
+const SpaceBar = ({ label, className }: StepProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const measured = useMeasured(ref, MEASURED_WIDTH);
+
+  return (
+    <div className='flex items-center gap-3 py-1.5'>
+      <code className='w-20 shrink-0 text-xs text-text-strong'>{label}</code>
+      <div ref={ref} className={`h-5 bg-primary ${className}`} />
+      <span className='font-mono text-xs text-text-subtle'>
+        {measured.width ?? '…'}
+      </span>
+    </div>
+  );
+};
+
+/** 모서리 상자 — 실제 적용된 반경을 되읽는다 */
+const CornerBox = ({ label, className }: StepProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const measured = useMeasured(ref, MEASURED_RADIUS);
+
+  return (
+    <div className='w-24'>
+      <div
+        ref={ref}
+        className={`h-14 w-full border border-line bg-sunken ${className}`}
+      />
+      <code className='mt-2 block text-xs text-text-strong'>{label}</code>
+      <span className='font-mono text-xs text-text-subtle'>
+        {measured['border-top-left-radius'] ?? '…'}
+      </span>
+    </div>
+  );
+};
+
+/** 4px 그리드. 번호가 곧 Tailwind 클래스다 (`4` = `p-4` = 16px). */
+export const Space: Story = {
+  render: () => (
+    <div className='p-6'>
+      {SPACE_STEPS.map((step) => (
+        <SpaceBar key={step.label} {...step} />
+      ))}
+    </div>
+  ),
+};
+
+/** 전부 `--radius` 하나에서 `calc()` 로 갈라진다. 카드 기준은 lg. */
+export const Corner: Story = {
+  render: () => (
+    <div className='flex flex-wrap gap-4 p-6'>
+      {CORNER_STEPS.map((step) => (
+        <CornerBox key={step.label} {...step} />
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * 책 표지는 스케일 밖의 **도메인 셰이프**다. 왼쪽이 책등이라 각지고 오른쪽만 둥글다
+ * (`2px 6px 6px 2px`). Figma 변수는 비대칭 radius 를 담지 못해 값을 직접 넣었다.
+ *
+ * ⚠️ 이 `.book-cover` CSS 는 `@layer` 밖에 있어 **모든 Tailwind 유틸을 이긴다.**
+ * `rounded-md` 나 `bg-sunken` 으로 덮으려는 시도는 조용히 실패한다.
+ */
+export const BookCoverShape: Story = {
+  render: () => (
+    <div className='flex items-end gap-6 p-6'>
+      <div className='book-cover h-32 w-24 border border-line-soft' />
+      <div className='max-w-sm text-sm text-text-subtle'>
+        표지 이미지가 없을 때 보이는 대체 조판. 그림자로 띄우지 않는다 — 교보는
+        표지 그림자가 <code>16px 16px 16px 0</code>, 밀리는 표지 254개에 그림자
+        0이었다. 책등 음영은 왼쪽 8px 구간의 그라디언트로 만든다.
+      </div>
+    </div>
+  ),
+};

--- a/apps/page0127/src/shared/foundations/Swatch.tsx
+++ b/apps/page0127/src/shared/foundations/Swatch.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+
+import { contrastRatio, gradeOf } from './contrast';
+
+import type { Token } from './tokens';
+
+type SwatchProps = {
+  token: Token;
+  /** 명암비를 잴 배경. 주면 등급 배지가 붙는다 */
+  contrastAgainst?: string;
+  /** 칩 뒤에 깔 배경 — 흰색 계열 토큰이 흰 바탕에 묻히지 않게 한다 */
+  chipBackground?: string;
+};
+
+/** 클릭하면 CSS 변수 표기(`var(--navy-600)`)가 복사된다 — 코드에 그대로 붙일 수 있는 형태 */
+export const Swatch = ({
+  token,
+  contrastAgainst,
+  chipBackground,
+}: SwatchProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const copyText = `var(${token.name})`;
+  const ratio = contrastAgainst
+    ? contrastRatio(token.value, contrastAgainst)
+    : null;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(copyText);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleCopy}
+      title={token.description ?? copyText}
+      className='w-40 shrink-0 rounded-md border border-line-soft bg-card p-2 text-left transition-colors hover:border-line'
+    >
+      {/* 체커보드를 깔아 흰색·반투명 토큰이 흰 바탕에 묻히지 않게 한다 */}
+      <span
+        className='block h-14 w-full rounded-sm border border-line-soft'
+        style={{
+          backgroundColor: token.value,
+          backgroundImage:
+            chipBackground ??
+            'linear-gradient(45deg, #eceff2 25%, transparent 25%, transparent 75%, #eceff2 75%), linear-gradient(45deg, #eceff2 25%, transparent 25%, transparent 75%, #eceff2 75%)',
+          backgroundSize: '12px 12px',
+          backgroundPosition: '0 0, 6px 6px',
+          backgroundBlendMode: 'multiply',
+        }}
+      />
+      <span className='mt-2 block truncate text-xs font-medium text-text-strong'>
+        {token.name.replace(/^--/, '')}
+      </span>
+      <span className='mt-0.5 block font-mono text-xs text-text-subtle'>
+        {copied ? '복사됨' : token.value}
+      </span>
+
+      {/* 별칭이면 무엇을 가리키는지 보여준다 — 원색을 바꿨을 때 무엇이 따라 움직이는지가 보인다 */}
+      {token.isAlias && (
+        <span className='mt-0.5 block truncate font-mono text-xs text-text-faint'>
+          → {token.raw.replace(/var\(|\)/g, '').replace(/^--/, '')}
+        </span>
+      )}
+
+      {ratio !== null && (
+        <span className='mt-1.5 flex items-center gap-1.5'>
+          <span className='font-mono text-xs text-text-subtle'>
+            {ratio.toFixed(2)}
+          </span>
+          <span
+            className={
+              gradeOf(ratio) === '미달'
+                ? 'rounded-sm bg-destructive px-1.5 py-0.5 text-xs text-primary-foreground'
+                : 'rounded-sm bg-accent px-1.5 py-0.5 text-xs text-accent-foreground'
+            }
+          >
+            {gradeOf(ratio)}
+          </span>
+        </span>
+      )}
+    </button>
+  );
+};
+
+type SwatchRowProps = {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+};
+
+export const SwatchRow = ({
+  title,
+  description,
+  children,
+}: SwatchRowProps) => (
+  <section className='mb-8'>
+    <h3 className='text-base font-medium text-text-strong'>{title}</h3>
+    {description && (
+      <p className='mt-1 text-sm text-text-subtle'>{description}</p>
+    )}
+    <div className='mt-3 flex flex-wrap gap-2'>{children}</div>
+  </section>
+);

--- a/apps/page0127/src/shared/foundations/TypeSpecimen.tsx
+++ b/apps/page0127/src/shared/foundations/TypeSpecimen.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRef } from 'react';
+
+import { useMeasured } from './useMeasured';
+
+const MEASURED = ['font-size', 'line-height', 'font-weight'];
+
+type TypeSpecimenProps = {
+  /** 이 단계를 쓰는 방법 — 실제 클래스 이름 */
+  className: string;
+  /** 언제 쓰는지 */
+  usage: string;
+  /** 보여줄 문장 */
+  sample: string;
+};
+
+/**
+ * 타이포 한 단계. 왼쪽에 쓰는 법, 오른쪽에 실제로 그려진 모습.
+ * 크기는 적어 두지 않고 렌더된 것을 되읽는다 — 창을 좁히면 숫자가 같이 바뀐다.
+ */
+export const TypeSpecimen = ({
+  className,
+  usage,
+  sample,
+}: TypeSpecimenProps) => {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const measured = useMeasured(ref, MEASURED);
+
+  const size = measured['font-size']?.replace('px', '');
+  const leading = measured['line-height']?.replace('px', '');
+  const weight = measured['font-weight'];
+
+  return (
+    <div className='flex flex-wrap items-baseline gap-x-6 gap-y-1 border-b border-line-soft py-4'>
+      <div className='w-52 shrink-0'>
+        <code className='text-xs text-text-strong'>{className}</code>
+        <p className='mt-1 font-mono text-xs text-text-subtle'>
+          {size && leading ? `${size}/${leading} · w${weight}` : '측정 중…'}
+        </p>
+        <p className='mt-0.5 text-xs text-text-faint'>{usage}</p>
+      </div>
+      <p ref={ref} className={className}>
+        {sample}
+      </p>
+    </div>
+  );
+};

--- a/apps/page0127/src/shared/foundations/Typography.stories.tsx
+++ b/apps/page0127/src/shared/foundations/Typography.stories.tsx
@@ -1,0 +1,117 @@
+import { TypeSpecimen } from './TypeSpecimen';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+/**
+ * 타이포 스케일. **크기는 이 문서에 적혀 있지 않고 렌더된 값을 되읽는다** —
+ * 툴바의 뷰포트를 바꾸면 숫자가 같이 움직인다(768px 에서 제목이 24 → 28 로 뛴다).
+ *
+ * 본문 서체는 **Pretendard**. `letter-spacing` 은 건드리지 않는다 — 자간이 이미
+ * 최적화돼 있고, 밀리의서재도 전 요소 `normal` 이다.
+ *
+ * ## 제목은 클래스를 쓴다
+ *
+ * `text-2xl sm:text-3xl` 처럼 손으로 조합하지 말고 **`.heading-1` · `.heading-2`**
+ * 유틸을 쓴다. 반응형 분기와 줄간격이 그 안에 들어 있고, 손으로 쓰면 화면마다 값이
+ * 갈린다. 이 유틸은 `app/globals.css` 에 있고 24개 파일이 쓴다.
+ *
+ * 줄간격을 비율이 아니라 px 로 못 박은 이유: 비율(1.35)로 두면 28px 에서 37.8px 이
+ * 나와 스펙(40)과 어긋나고 Figma Text Style 과도 값이 맞지 않는다.
+ *
+ * ## 크기 단계는 5개뿐이다
+ *
+ * 07 문서가 제안한 caption(13px)은 만들지 않았다 — 실사용이 0곳이고 12 와 14 사이에
+ * 한 단을 더 끼우면 위계가 흐려진다. 단계를 늘리기 전에 **정말 새 단계가 필요한지**
+ * 먼저 의심한다.
+ *
+ * ## 한글 줄간격
+ *
+ * Tailwind 기본 줄간격(14/20, 12/16)은 한글 다행 텍스트에 좁다. 크기는 그대로 두고
+ * 줄간격만 넓혔다(14/22, 12/18). 클래스 이름이 안 바뀌므로 `text-sm`·`text-xs` 를
+ * 쓰는 345곳을 손대지 않아도 된다.
+ */
+const meta = {
+  title: 'Foundation/Typography',
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 제목 2단 + 본문 3단. 창을 좁히면 제목 크기가 바뀐다. */
+export const Scale: Story = {
+  render: () => (
+    <div className='p-6'>
+      <TypeSpecimen
+        className='heading-1'
+        usage='페이지 제목'
+        sample='책장을 보면, 그 사람이 보인다'
+      />
+      <TypeSpecimen
+        className='heading-2'
+        usage='섹션 제목'
+        sample='이번 주 많이 읽은 책'
+      />
+      <TypeSpecimen
+        className='text-base'
+        usage='본문·책 제목'
+        sample='아무튼, 계속'
+      />
+      <TypeSpecimen
+        className='text-sm'
+        usage='가장 많이 쓴다 (236곳)'
+        sample='읽는 일에 대해 오래 생각해온 사람의 기록이다.'
+      />
+      <TypeSpecimen
+        className='text-xs'
+        usage='캡션·메타'
+        sample='3일 전 · 완독 12명'
+      />
+    </div>
+  ),
+};
+
+/**
+ * 굵기는 **500 으로 통일**했다. 07 이 지켜지지 않은 게 아니라 07 이 현실과 안 맞아서
+ * 코드 78곳을 기준으로 다시 정한 값이다. 제목(`.heading-*`)만 700 이다.
+ */
+export const Weight: Story = {
+  render: () => (
+    <div className='p-6'>
+      <TypeSpecimen
+        className='text-base font-normal'
+        usage='기본 본문'
+        sample='읽는 일에 대해 오래 생각해온 사람의 기록이다.'
+      />
+      <TypeSpecimen
+        className='text-base font-medium'
+        usage='강조 — 버튼·라벨·책 제목'
+        sample='읽는 일에 대해 오래 생각해온 사람의 기록이다.'
+      />
+      <TypeSpecimen
+        className='heading-2'
+        usage='제목 (700)'
+        sample='읽는 일에 대해 오래 생각해온 사람의 기록이다.'
+      />
+    </div>
+  ),
+};
+
+/**
+ * 위계는 크기가 아니라 **색**으로도 만든다. 같은 14px 이라도 무엇을 읽히고 싶은지에
+ * 따라 색이 다르다 — 읽으라고 쓴 글을 흐리게 칠하지 않는다.
+ */
+export const Hierarchy: Story = {
+  render: () => (
+    <div className='max-w-md p-6'>
+      <p className='heading-2 text-text-strong'>아무튼, 계속</p>
+      <p className='mt-2 text-base text-text-body'>
+        읽는 일에 대해 오래 생각해온 사람의 기록이다. 책을 좋아한다는 말로는
+        부족한, 읽기라는 습관 그 자체에 대한 이야기.
+      </p>
+      <p className='mt-3 text-sm text-text-subtle'>김미소 · 코난북스</p>
+      <p className='mt-1 text-xs text-text-faint'>3일 전 · 완독 12명</p>
+    </div>
+  ),
+};

--- a/apps/page0127/src/shared/foundations/contrast.ts
+++ b/apps/page0127/src/shared/foundations/contrast.ts
@@ -1,0 +1,62 @@
+/**
+ * WCAG 명암비 계산.
+ *
+ * 색을 눈으로만 고르면 "충분히 진해 보이는데" 기준을 못 넘기는 일이 생긴다.
+ * 실제로 `text/subtle` 이 4.496 으로 AA(4.5)에 0.004 모자란 채 오래 쓰이고 있었다
+ * (Storybook addon-a11y 가 잡았다). 그래서 팔레트 문서가 수치를 같이 보여준다.
+ */
+
+/** sRGB 채널을 선형 값으로 되돌린다 (감마 역보정) */
+const toLinear = (channel: number): number => {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+};
+
+/** `#rgb` · `#rrggbb` 만 받는다. rgba() 같은 건 계산 대상이 아니다 */
+export const parseHex = (value: string): [number, number, number] | null => {
+  const hex = value.trim().replace(/^#/, '');
+  const full =
+    hex.length === 3
+      ? hex
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : hex;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return null;
+  return [
+    parseInt(full.slice(0, 2), 16),
+    parseInt(full.slice(2, 4), 16),
+    parseInt(full.slice(4, 6), 16),
+  ];
+};
+
+/** 상대 휘도 (WCAG 정의) */
+export const luminance = (hex: string): number | null => {
+  const rgb = parseHex(hex);
+  if (!rgb) return null;
+  const [r, g, b] = rgb.map(toLinear);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+/** 두 색의 명암비 (1 ~ 21). 계산할 수 없으면 null */
+export const contrastRatio = (fg: string, bg: string): number | null => {
+  const a = luminance(fg);
+  const b = luminance(bg);
+  if (a === null || b === null) return null;
+  const [hi, lo] = a > b ? [a, b] : [b, a];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+export type ContrastGrade = 'AAA' | 'AA' | 'AA Large' | '미달';
+
+/**
+ * 일반 텍스트(14px 안팎) 기준 등급.
+ * 'AA Large' 는 18.66px+bold 또는 24px 이상에서만 통과라는 뜻이라,
+ * 본문에 쓰면 미달이다.
+ */
+export const gradeOf = (ratio: number): ContrastGrade => {
+  if (ratio >= 7) return 'AAA';
+  if (ratio >= 4.5) return 'AA';
+  if (ratio >= 3) return 'AA Large';
+  return '미달';
+};

--- a/apps/page0127/src/shared/foundations/css-raw.d.ts
+++ b/apps/page0127/src/shared/foundations/css-raw.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Vite 의 `?raw` 접미사 import 타입.
+ * Foundation 스토리가 토큰 CSS 를 문자열로 읽어 그 자리에서 파싱하는 데 쓴다
+ * (값을 손으로 옮겨 적으면 토큰이 바뀔 때 문서만 조용히 낡는다).
+ *
+ * `.storybook/` 안에 두면 안 된다 — TypeScript 의 `**\/*` glob 은 점으로 시작하는
+ * 디렉터리를 건너뛰므로 tsconfig 의 include 에 걸리지 않는다(실제로 그렇게 만들었다가
+ * `tsc` 가 모듈을 못 찾았다). 쓰는 곳 옆에 둔다.
+ */
+declare module '*.css?raw' {
+  const content: string;
+  export default content;
+}

--- a/apps/page0127/src/shared/foundations/tokens.ts
+++ b/apps/page0127/src/shared/foundations/tokens.ts
@@ -1,0 +1,127 @@
+import { parseCssVars, resolveVar } from '@repo/design-tokens/css-vars';
+import lightCss from '@repo/design-tokens/tokens.css?raw';
+import darkCss from '@repo/design-tokens/tokens-dark.css?raw';
+
+/**
+ * Foundation 스토리가 쓰는 토큰 목록.
+ *
+ * 값을 손으로 옮겨 적지 않고 생성물(dist/*.css)을 그 자리에서 파싱한다.
+ * 문서가 토큰보다 낡는 일을 구조적으로 막기 위해서다 — 토큰을 고치고
+ * 빌드하면 이 페이지도 같이 바뀐다.
+ */
+
+export type Token = {
+  /** CSS 변수명 (`--navy-600`) */
+  name: string;
+  /** 선언된 그대로. 별칭이면 `var(--navy-600)` */
+  raw: string;
+  /** var() 를 끝까지 따라간 최종 값 */
+  value: string;
+  /** 토큰 JSON 의 $description — 왜 이 값인지 */
+  description?: string;
+  /** 다른 토큰을 참조하는가 */
+  isAlias: boolean;
+};
+
+/**
+ * 값 뒤에 붙은 `/** … *\/` 주석을 변수명에 대응시킨다.
+ * parseCssVars 는 값만 뽑고 주석을 버리므로 여기서 따로 훑는다.
+ */
+const parseDescriptions = (css: string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  const re = /--([a-zA-Z0-9-]+)\s*:\s*[^;]+;\s*\/\*\*([\s\S]*?)\*\//g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(css)) !== null) {
+    out[`--${m[1]}`] = m[2].trim();
+  }
+  return out;
+};
+
+const lightVars = parseCssVars(lightCss);
+const darkVars = parseCssVars(darkCss);
+const lightDescriptions = parseDescriptions(lightCss);
+const darkDescriptions = parseDescriptions(darkCss);
+
+/**
+ * 다크는 라이트를 덮어쓰는 관계다 — 다크에 없는 이름은 라이트 값을 그대로 쓴다.
+ * 그래서 다크 토큰의 최종 값을 구하려면 두 맵을 겹친 것으로 참조를 따라가야 한다.
+ * (다크의 `--text-subtle: var(--navy-300)` 은 navy/300 이 라이트에만 있다)
+ */
+const mergedForDark = { ...lightVars, ...darkVars };
+
+const toToken = (
+  name: string,
+  vars: Record<string, string>,
+  scope: Record<string, string>,
+  descriptions: Record<string, string>
+): Token => {
+  const raw = vars[name];
+  return {
+    name,
+    raw,
+    value: resolveVar(scope, name),
+    description: descriptions[name],
+    isAlias: raw.startsWith('var('),
+  };
+};
+
+const NAMED_STEP_RE = /^--[a-z]+-\d+$/;
+
+/**
+ * 원색인가. 이름 형태(`--계열-숫자`)만으로는 갈라지지 않는다 —
+ * `--chart-1` 도 그 형태지만 `var(--blue-600)` 을 가리키는 직무 토큰이다.
+ * 원색의 진짜 조건은 **다른 토큰을 참조하지 않고 값을 직접 들고 있다**는 것이다.
+ */
+const isPrimitive = (name: string) =>
+  NAMED_STEP_RE.test(name) && !lightVars[name].startsWith('var(');
+
+export const primitives: Token[] = Object.keys(lightVars)
+  .filter(isPrimitive)
+  .map((name) => toToken(name, lightVars, lightVars, lightDescriptions));
+
+/** 원색을 색 계열별로 묶는다 (`--blue-600` → `blue`) */
+export const primitiveGroups: { family: string; tokens: Token[] }[] =
+  primitives.reduce<{ family: string; tokens: Token[] }[]>((groups, token) => {
+    const family = token.name.replace(/^--/, '').replace(/-\d+$/, '');
+    const found = groups.find((g) => g.family === family);
+    if (found) found.tokens.push(token);
+    else groups.push({ family, tokens: [token] });
+    return groups;
+  }, []);
+
+/** 색 토큰인지 — 폰트 크기·반경 같은 치수 토큰을 스와치에서 걸러낸다 */
+const isColor = (value: string) =>
+  value.startsWith('#') || value.startsWith('rgb') || value.startsWith('hsl');
+
+/** 직무 토큰 — 컴포넌트가 실제로 쓰는 것들 */
+export const semanticColors: Token[] = Object.keys(lightVars)
+  .filter((name) => !isPrimitive(name))
+  .map((name) => toToken(name, lightVars, lightVars, lightDescriptions))
+  .filter((token) => isColor(token.value));
+
+/** 다크에서 값이 덮어써진 토큰만 */
+export const darkOverrides: Token[] = Object.keys(darkVars)
+  .map((name) => toToken(name, darkVars, mergedForDark, darkDescriptions))
+  .filter((token) => isColor(token.value));
+
+/** 치수 토큰 (반경·폰트 크기) */
+export const dimensions: Token[] = Object.keys(lightVars)
+  .filter((name) => !isPrimitive(name))
+  .map((name) => toToken(name, lightVars, lightVars, lightDescriptions))
+  .filter((token) => !isColor(token.value));
+
+/** 다크 최종 값 조회 — 없으면 라이트를 따른다는 뜻이라 null */
+export const darkValueOf = (name: string): string | null =>
+  name in darkVars ? resolveVar(mergedForDark, name) : null;
+
+/**
+ * 이름으로 골라 온다. 팔레트 문서가 토큰을 "전부 나열"하는 대신
+ * 의미 단위로 묶어 보여주기 위한 것 — 명암비 수치는 재는 대상이 정해져야 뜻이 생긴다.
+ * 없는 이름은 조용히 빠뜨리지 않고 바로 터뜨린다(문서가 낡으면 알아야 한다).
+ */
+export const pick = (...names: string[]): Token[] =>
+  names.map((name) => {
+    const token = semanticColors.find((t) => t.name === name);
+    if (!token) throw new Error(`없는 토큰: ${name}`);
+    return token;
+  });

--- a/apps/page0127/src/shared/foundations/useMeasured.ts
+++ b/apps/page0127/src/shared/foundations/useMeasured.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * 실제로 렌더된 값을 브라우저에서 되읽는다.
+ *
+ * 크기를 문서에 손으로 적으면 스케일을 고쳤을 때 문서만 조용히 낡는다.
+ * 게다가 타이포는 `@media` 로 값이 갈리므로(768px 에서 24→28) 적어 둔 숫자는
+ * 어느 한쪽에서 반드시 틀리다. 그래서 화면에 그린 것을 그대로 읽어 보여준다.
+ *
+ * 창 크기를 바꾸면 다시 잰다 — Storybook 뷰포트 도구로 분기를 넘나들며 볼 수 있다.
+ */
+export const useMeasured = <T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  properties: string[]
+): Record<string, string> => {
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const measure = () => {
+      const node = ref.current;
+      if (!node) return;
+      const computed = getComputedStyle(node);
+      setValues(
+        Object.fromEntries(
+          properties.map((prop) => [prop, computed.getPropertyValue(prop)])
+        )
+      );
+    };
+
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+    // properties 는 스토리마다 고정 배열이라 참조가 매번 바뀌어도 내용은 같다.
+    // 문자열로 굳혀 비교해야 매 렌더마다 리스너를 다시 걸지 않는다.
+  }, [ref, properties.join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return values;
+};


### PR DESCRIPTION
토큰이 79개인데 값을 보려면 JSON 을 열어야 했다. Foundation 스토리 3종을 붙여
색·타이포·간격을 눈으로 보고 클릭해서 가져갈 수 있게 했다.

| 스토리 | 내용 |
|---|---|
| `Foundation/Colors` | Primitives · Semantic · Dark, 명암비와 등급 |
| `Foundation/Typography` | 스케일 · 굵기 · 색 위계 |
| `Foundation/Spacing & Corner` | 4px 그리드 · 모서리 4단 · 책 표지 셰이프 |

## 값을 손으로 옮겨 적은 곳이 한 군데도 없다

색은 `dist/*.css` 를 `?raw` 로 읽어 그 자리에서 파싱하고, 크기는 렌더된 요소를
`getComputedStyle` 로 되읽는다. 토큰이나 스케일을 고치면 이 문서도 같이 바뀐다 —
문서가 코드보다 낡는 일을 구조로 막으려는 것이다.

타이포는 특히 적어 두면 안 된다. `@media` 로 값이 갈리므로(768px 에서 제목이
24 → 28) **적어 둔 숫자는 어느 한쪽에서 반드시 틀리다.** 뷰포트를 바꾸면 표시된
숫자가 같이 움직인다.

## 명암비는 잴 뜻이 있는 곳에만

처음엔 semantic 전체에 흰 배경 대비를 붙였더니 면·경계·차트까지 텍스트 기준(4.5)에
걸려 화면이 빨간 "미달" 배지로 덮였다. 그러면 진짜 문제가 노이즈에 묻힌다. 그래서:

- 텍스트 위계 · 직무색 → 흰 배경 기준
- 전경(`*-foreground`) → **각자가 실제로 얹히는 짝 배경 위에서** 측정
  (`primary-foreground` 를 흰 배경에서 재면 1.00 인데 아무 뜻도 없는 숫자다)
- 면 · 경계 · 차트 · 사이드바 → 수치 없이 스와치만

## 이 과정에서 드러난 것

- **`--chart-1` 이 원색으로 잘못 분류되고 있었다.** 이름 형태(`--계열-숫자`)만 보고
  갈랐는데 `chart-1` 도 그 형태다. 실제 조건은 "다른 토큰을 참조하지 않고 값을 직접
  들고 있는가"다. `pick()` 이 없는 이름에 즉시 터지도록 만들어 둔 덕에 잡혔다.
- **`.storybook/` 안의 `.d.ts` 를 `tsc` 가 못 본다** — TypeScript 의 `**/*` glob 은
  점으로 시작하는 디렉터리를 건너뛴다. 쓰는 곳 옆으로 옮겼다.
- **클래스 이름을 문자열 보간으로 만들면 안 된다** — `w-${step}` 은 Tailwind 가
  소스에서 찾지 못해 스타일이 통째로 빠진 채 조용히 렌더된다.

## 별건으로 남긴 것

`rank-up` 이 흰 배경 **4.30 (AA Large)** 이다. "▲ 12" 처럼 작은 텍스트로 쓰이면
본문 기준 미달이다. 이번 PR 범위 밖이라 손대지 않았다.

## 검증

lint 0 · `tsc --noEmit` 0 · 테스트 292 통과 · 5개 스토리 렌더와 측정값 육안 확인
(`heading-1` 28/40 w700, `text-sm` 14/22, `rounded-*` 4/6/8/12px,
space 4~64px 전부 스펙과 일치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
