### PR TITLE
🧪 Test: 브라우저 소스맵 검증 (머지하지 말 것 — 확인 후 닫습니다)

### DIFF
--- a/apps/page0127/app/(public)/sentry-sourcemap-check/page.tsx
+++ b/apps/page0127/app/(public)/sentry-sourcemap-check/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Button } from '@/shared/ui/button';
+import { PageContainer } from '@/shared/ui/PageContainer';
+
+/**
+ * ⚠️ 브라우저 소스맵 검증용 임시 페이지 — **main 에 머지하지 않는다.**
+ *
+ * 왜 필요한가:
+ * 서버 오류는 Sentry 에서 원본 위치(`app/api/.../route.ts:108`)로 잘 해석되는 것을
+ * 확인했지만, 브라우저 오류는 소스맵 업로드 경로가 달라 따로 확인해야 한다.
+ * 지금까지 쌓인 이슈가 전부 서버 쪽이라 확인할 표본이 없었다.
+ *
+ * 확인 방법:
+ *   1. 이 브랜치로 PR 을 열면 Preview 가 배포된다
+ *   2. Preview 에서 이 페이지의 버튼을 누른다
+ *   3. Sentry(environment=vercel-preview)에 아래 throw 위치가
+ *      `app/(public)/sentry-sourcemap-check/page.tsx:<줄>` 로 찍히면 정상이다
+ *      압축된 청크명(`chunks/1234-abcd.js:1`)이 나오면 소스맵이 안 붙은 것이다
+ *   4. 확인이 끝나면 **PR 을 닫고 브랜치를 지운다** (머지하지 않으므로 운영 무영향)
+ *
+ * 이벤트 핸들러에서 throw 하면 React error boundary 가 아니라 window 로 전파되어
+ * Sentry 전역 핸들러가 잡는다 — 실사용자 오류와 같은 경로다.
+ */
+export default function SentrySourcemapCheckPage() {
+  return (
+    <PageContainer width='content'>
+      <h1 className='heading-1 text-text-strong'>Sentry 소스맵 검증</h1>
+      <p className='mt-2 text-sm text-text-subtle'>
+        아래 버튼을 누르면 브라우저에서 의도적으로 오류가 발생합니다. 화면이
+        깨져 보여도 정상이며, 새로고침하면 돌아옵니다.
+      </p>
+
+      <Button
+        className='mt-6'
+        onClick={() => {
+          throw new Error('소스맵 검증용 브라우저 예외 (임시 페이지)');
+        }}
+      >
+        오류 발생시키기
+      </Button>
+    </PageContainer>
+  );
+}


### PR DESCRIPTION
## ⚠️ 이 PR 은 머지하지 않습니다

Preview 배포를 얻으려고 여는 PR 입니다. 확인이 끝나면 **닫고 브랜치를 지웁니다.** 운영에는 나가지 않습니다.

## 왜 필요한가

오픈 전 검증의 마지막 항목입니다. 배포 시 코드가 압축되기 때문에, 소스맵이 안 붙으면 Sentry 에 `chunks/1234-abcd.js:1` 같은 알 수 없는 위치만 찍힙니다. **오류를 잡아도 어디를 고칠지 모르는** 상태가 됩니다.

이미 쌓인 오류로 확인한 결과는 이렇습니다.

| 항목 | 결과 |
| --- | --- |
| 환경 태깅 | ✅ `vercel-production` / `vercel-preview` 분리됨 |
| 릴리스 추적 | ✅ 커밋 해시 |
| **소스맵 (서버)** | ✅ `app/api/taste-analysis/analyze/route.ts:108 (POST)` |
| **소스맵 (브라우저)** | ⚠️ **표본 없음** — 지금까지 이슈가 전부 서버 쪽 |

서버와 브라우저는 소스맵 업로드 경로가 달라서, 서버가 된다고 브라우저도 된다는 보장이 없습니다. 그래서 오류를 하나 일부러 냅니다.

## 확인 방법

1. 이 PR 의 Preview 주소로 접속 → `/sentry-sourcemap-check`
2. **오류 발생시키기** 버튼 클릭 (화면이 깨져 보여도 정상, 새로고침하면 돌아옵니다)
3. Sentry 에서 `environment:vercel-preview` 로 필터 → 방금 이슈 확인
4. 스택트레이스가 **`app/(public)/sentry-sourcemap-check/page.tsx:<줄>`** 로 보이면 정상
   압축된 청크명이 보이면 브라우저 소스맵이 안 붙은 것입니다

## 왜 이벤트 핸들러에서 throw 하나

React 렌더 중 throw 는 error boundary 가 잡아 다른 경로를 탑니다. 이벤트 핸들러의 throw 는 window 로 전파되어 Sentry 전역 핸들러가 잡는데, **이게 실사용자 브라우저 오류와 같은 경로**입니다.