### PR TITLE
✨ Feat: PageHeader · Spinner · Button loading + heading 유틸에 색 통합

### DIFF
--- a/apps/page0127/app/(protected)/books/add/page.tsx
+++ b/apps/page0127/app/(protected)/books/add/page.tsx
@@ -254,7 +254,7 @@ const AddBookPage = () => {
   return (
     <ErrorBoundary>
       <PageContainer width='content'>
-        <h1 className='heading-1 mb-6 text-text-strong'>도서 추가</h1>
+        <h1 className='heading-1 mb-6'>도서 추가</h1>
 
         {saved ? (
           <BookSavedCard

--- a/apps/page0127/app/(protected)/feed/page.tsx
+++ b/apps/page0127/app/(protected)/feed/page.tsx
@@ -1,4 +1,5 @@
 import { PageContainer } from '@/shared/ui/PageContainer';
+import { PageHeader } from '@/shared/ui/PageHeader';
 
 import { ActivityFeed } from '@/widgets/activity';
 
@@ -13,12 +14,10 @@ import { ActivityFeed } from '@/widgets/activity';
 export default function FeedPage() {
   return (
     <PageContainer width='content' className='space-y-8'>
-      <header>
-        <h1 className='heading-1 text-text-strong'>피드</h1>
-        <p className='mt-2 text-sm text-text-subtle'>
-          함께 읽는 사람들의 새로운 독서 기록을 만나보세요.
-        </p>
-      </header>
+      <PageHeader
+        title='피드'
+        description='함께 읽는 사람들의 새로운 독서 기록을 만나보세요.'
+      />
 
       <ActivityFeed />
     </PageContainer>

--- a/apps/page0127/app/(protected)/notifications/page.tsx
+++ b/apps/page0127/app/(protected)/notifications/page.tsx
@@ -1,4 +1,5 @@
 import { PageContainer } from '@/shared/ui/PageContainer';
+import { PageHeader } from '@/shared/ui/PageHeader';
 
 import { NotificationPage } from '@/features/notification/ui/NotificationPage';
 
@@ -14,9 +15,7 @@ import { NotificationPage } from '@/features/notification/ui/NotificationPage';
 export default function Notifications() {
   return (
     <PageContainer width='narrow' className='space-y-6'>
-      <div>
-        <h1 className='heading-1 text-text-strong'>알림</h1>
-              </div>
+      <PageHeader title='알림' />
 
       <NotificationPage />
     </PageContainer>

--- a/apps/page0127/app/(protected)/search/page.tsx
+++ b/apps/page0127/app/(protected)/search/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@/shared/config/supabase/server';
 import { PageContainer } from '@/shared/ui/PageContainer';
+import { PageHeader } from '@/shared/ui/PageHeader';
 
 import { UserSearch } from '@/features/user';
 
@@ -19,12 +20,10 @@ export default async function SearchPage() {
 
   return (
     <PageContainer width='narrow' className='space-y-6'>
-      <div>
-        <h1 className='heading-1 text-text-strong'>사용자 검색</h1>
-        <p className='mt-2 text-sm text-text-subtle'>
-          닉네임이나 아이디로 함께 읽는 사람을 찾아보세요
-        </p>
-      </div>
+      <PageHeader
+        title='사용자 검색'
+        description='닉네임이나 아이디로 함께 읽는 사람을 찾아보세요'
+      />
 
       <UserSearch currentUserId={user?.id} />
     </PageContainer>

--- a/apps/page0127/app/(public)/books/all/page.tsx
+++ b/apps/page0127/app/(public)/books/all/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { createClient } from '@/shared/config/supabase/server';
 import { Button } from '@/shared/ui/button';
 import { PageContainer } from '@/shared/ui/PageContainer';
+import { PageHeader } from '@/shared/ui/PageHeader';
 import {
   Pagination,
   PaginationContent,
@@ -84,18 +85,16 @@ export default async function GlobalBooksPage(props: {
   return (
     <PageContainer width='wide'>
       <div className='mb-8 flex items-center justify-between'>
-        <div>
-          <h1 className='heading-1 text-text-strong'>
-            {q ? `'${q}' 검색 결과` : '전체 도서'}
-          </h1>
-          <p className='mt-1 text-sm text-text-subtle'>
-            {q
+        <PageHeader
+          title={q ? `'${q}' 검색 결과` : '전체 도서'}
+          description={
+            q
               ? `${(booksRes.count ?? 0).toLocaleString()}권을 찾았어요.`
               : booksRes.count
                 ? `${booksRes.count.toLocaleString()}권이 등록돼 있어요.`
-                : '아직 등록된 책이 없어요.'}
-          </p>
-        </div>
+                : '아직 등록된 책이 없어요.'
+          }
+        />
 
         {/* 정렬 옵션 (간단하게 구현) */}
         <div className='flex gap-2'>

--- a/apps/page0127/app/(public)/books/info/[id]/page.tsx
+++ b/apps/page0127/app/(public)/books/info/[id]/page.tsx
@@ -190,7 +190,7 @@ export default async function GlobalBookDetailPage({ params }: PageProps) {
         {/* 책 정보 & 통계 & 메모 */}
         <div className='space-y-6'>
           <div>
-            <h1 className='heading-1 text-text-strong'>{book.title}</h1>
+            <h1 className='heading-1'>{book.title}</h1>
             <p className='mt-2 text-text-body'>{book.author}</p>
             <p className='text-sm text-text-subtle'>
               {book.publisher}
@@ -227,7 +227,7 @@ export default async function GlobalBookDetailPage({ params }: PageProps) {
           {/* 책 소개 — 카드가 아니라 구분선으로 시작하는 본문 섹션 */}
           {book.description && (
             <section className='border-t border-line pt-6'>
-              <h2 className='heading-2 text-text-strong'>책 소개</h2>
+              <h2 className='heading-2'>책 소개</h2>
               <p className='mt-3 whitespace-pre-line break-keep text-base leading-[1.8] text-text-body'>
                 {decodeHtmlEntities(book.description)}
               </p>

--- a/apps/page0127/app/auth/auth-code-error/page.tsx
+++ b/apps/page0127/app/auth/auth-code-error/page.tsx
@@ -10,7 +10,7 @@ const AuthCodeErrorPage = () => {
   return (
     <div className='flex min-h-screen items-center justify-center'>
       <div className='text-center'>
-        <h1 className='heading-1 mb-4 text-text-strong'>인증 오류</h1>
+        <h1 className='heading-1 mb-4'>인증 오류</h1>
         <p className='mb-6 text-muted-foreground'>
           로그인 중 문제가 발생했습니다. 다시 시도해주세요.
         </p>

--- a/apps/page0127/app/auth/suspended/page.tsx
+++ b/apps/page0127/app/auth/suspended/page.tsx
@@ -12,7 +12,7 @@ const SuspendedPage = () => {
   return (
     <div className='flex min-h-screen items-center justify-center'>
       <div className='text-center'>
-        <h1 className='heading-1 mb-4 text-text-strong'>정지된 계정입니다</h1>
+        <h1 className='heading-1 mb-4'>정지된 계정입니다</h1>
         <p className='mb-6 text-muted-foreground'>
           회원님의 계정은 현재 이용이 정지되어 로그인할 수 없습니다.
         </p>

--- a/apps/page0127/app/globals.css
+++ b/apps/page0127/app/globals.css
@@ -135,29 +135,39 @@ body {
    모바일 값은 07 의 데스크톱 비율을 그대로 적용해 구했다 — 07 에 모바일 정의가
    없어 데스크톱 비율(display 40/28≈1.43, heading 30/20=1.5)을 모바일 크기에
    내려 계산했다: 24×1.43≈34, 18×1.5=27. */
-.heading-1 {
-  font-size: var(--font-h1-mobile);
-  font-weight: 700;
-  line-height: 34px;
-}
-
-@media (min-width: 768px) {
+/* @layer components 안에 두는 것이 중요하다.
+   레이어 밖에 두면 이 클래스가 Tailwind 유틸을 이겨서, 제목 색을 다르게 써야 하는
+   자리(어두운 배너 위 text-white 등)에서 유틸이 조용히 무시된다.
+   components 는 utilities 보다 앞이라 유틸로 덮을 수 있다. */
+@layer components {
   .heading-1 {
-    font-size: var(--font-h1-desktop);
-    line-height: 40px;
+    font-size: var(--font-h1-mobile);
+    font-weight: 700;
+    line-height: 34px;
+    /* 21곳 중 19곳이 text-text-strong 과 함께 쓰였다 — 기본값으로 넣어
+       호출부에서 뗀다. 다른 색이 필요하면 text-* 유틸로 덮으면 된다. */
+    color: var(--text-strong);
   }
-}
 
-.heading-2 {
-  font-size: var(--font-h2-mobile);
-  font-weight: 700;
-  line-height: 27px;
-}
+  @media (min-width: 768px) {
+    .heading-1 {
+      font-size: var(--font-h1-desktop);
+      line-height: 40px;
+    }
+  }
 
-@media (min-width: 768px) {
   .heading-2 {
-    font-size: var(--font-h2-desktop);
-    line-height: 30px;
+    font-size: var(--font-h2-mobile);
+    font-weight: 700;
+    line-height: 27px;
+    color: var(--text-strong);
+  }
+
+  @media (min-width: 768px) {
+    .heading-2 {
+      font-size: var(--font-h2-desktop);
+      line-height: 30px;
+    }
   }
 }
 

--- a/apps/page0127/src/features/book/ui/BookSavedCard.tsx
+++ b/apps/page0127/src/features/book/ui/BookSavedCard.tsx
@@ -79,7 +79,7 @@ export const BookSavedCard = ({
             aria-live='polite'
             className='space-y-1'
           >
-            <h2 className='heading-2 text-text-strong'>
+            <h2 className='heading-2'>
               {savedBookMessage(completedCount, readCount)}
             </h2>
             <p className='text-sm text-text-subtle'>{title}</p>

--- a/apps/page0127/src/features/comment/ui/CommentForm.tsx
+++ b/apps/page0127/src/features/comment/ui/CommentForm.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { getApiErrorMessage } from '@/shared/api/getApiErrorMessage';
@@ -99,11 +98,9 @@ export const CommentForm = ({
         <Button
           type='submit'
           size='sm'
-          disabled={createMutation.isPending || !content.trim()}
+          disabled={!content.trim()}
+          loading={createMutation.isPending}
         >
-          {createMutation.isPending && (
-            <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-          )}
           {submitText}
         </Button>
       </div>

--- a/apps/page0127/src/features/comment/ui/CommentList.tsx
+++ b/apps/page0127/src/features/comment/ui/CommentList.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, MessageSquare } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
+
+import { Spinner } from '@/shared/ui/Spinner';
 
 import { commentApi, commentKeys } from '@/entities/comment';
 
@@ -32,9 +34,7 @@ export const CommentList = ({ target }: CommentListProps) => {
 
   if (isLoading) {
     return (
-      <div className='flex justify-center py-8'>
-        <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
-      </div>
+      <Spinner label='댓글을 불러오는 중' className='py-8' />
     );
   }
 

--- a/apps/page0127/src/features/compatibility/ui/CompatibilityView.tsx
+++ b/apps/page0127/src/features/compatibility/ui/CompatibilityView.tsx
@@ -36,6 +36,7 @@ import { BookCover } from '@/shared/ui/BookCover';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { PageContainer } from '@/shared/ui/PageContainer';
+import { PageHeader } from '@/shared/ui/PageHeader';
 
 import { replaceUserLabels } from '@/entities/compatibility/lib/replaceUserLabels';
 import { getCompatibilityTypeByScore } from '@/entities/compatibility/model/compatibilityTypes';
@@ -115,18 +116,18 @@ export const CompatibilityView = ({
 
   return (
     <PageContainer width='content'>
-      {/* 헤더 */}
-      <div className='mb-8'>
-        <Link href={`/${username}`}>
-          <Button variant='outline' size='sm' className='mb-4'>
-            ← {targetName} 님의 서재로
-          </Button>
-        </Link>
-        <h1 className='heading-1 text-text-strong'>독서 궁합</h1>
-        <p className='mt-1 text-sm text-text-subtle'>
-          {targetName} 님과 나, 얼마나 닮은 독서가일까요?
-        </p>
-      </div>
+      <PageHeader
+        className='mb-8'
+        above={
+          <Link href={`/${username}`}>
+            <Button variant='outline' size='sm'>
+              ← {targetName} 님의 서재로
+            </Button>
+          </Link>
+        }
+        title='독서 궁합'
+        description={`${targetName} 님과 나, 얼마나 닮은 독서가일까요?`}
+      />
 
       {analysis ? (
         <CompatibilityResult

--- a/apps/page0127/src/features/compatibility/ui/CompatibilityView.tsx
+++ b/apps/page0127/src/features/compatibility/ui/CompatibilityView.tsx
@@ -201,7 +201,7 @@ const CompatibilityIntro = ({
   <Card>
     <CardContent className='py-12 text-center'>
       <BookCopy className='mx-auto mb-4 h-9 w-9 text-text-subtle' />
-      <h2 className='mb-2 heading-2 text-text-strong'>
+      <h2 className='mb-2 heading-2'>
         두 사람의 책장을 나란히 놓아볼까요?
       </h2>
       <p className='mb-8 text-sm text-text-body'>

--- a/apps/page0127/src/features/follow/ui/FollowButton.tsx
+++ b/apps/page0127/src/features/follow/ui/FollowButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Loader2, UserMinus, UserPlus } from 'lucide-react';
+import { UserMinus, UserPlus } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { getApiErrorMessage } from '@/shared/api/getApiErrorMessage';
@@ -104,9 +104,7 @@ export const FollowButton = ({
 
   if (isLoading) {
     return (
-      <Button variant={variant} size={size} disabled>
-        <Loader2 className='h-4 w-4 animate-spin' />
-      </Button>
+      <Button variant={variant} size={size} loading aria-label='불러오는 중' />
     );
   }
 

--- a/apps/page0127/src/features/follow/ui/FollowListModal.tsx
+++ b/apps/page0127/src/features/follow/ui/FollowListModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
 
 import {
   Dialog,
@@ -9,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/shared/ui/dialog';
+import { Spinner } from '@/shared/ui/Spinner';
 
 import { followApi, followKeys } from '@/entities/follow';
 
@@ -60,9 +60,7 @@ export const FollowListModal = ({
 
         <div className='mt-4 space-y-3'>
           {isLoading ? (
-            <div className='flex items-center justify-center py-8'>
-              <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
-            </div>
+            <Spinner label='목록을 불러오는 중' className='py-8' />
           ) : users.length === 0 ? (
             <div className='py-8 text-center text-sm text-muted-foreground'>
               {type === 'followers'

--- a/apps/page0127/src/features/follow/ui/FollowStats.tsx
+++ b/apps/page0127/src/features/follow/ui/FollowStats.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useEffectEvent } from 'react';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Loader2, Users } from 'lucide-react';
+import { Users } from 'lucide-react';
 
 import { followBroadcast } from '@/shared/lib/broadcastChannel';
+import { Spinner } from '@/shared/ui/Spinner';
 
 import { followApi, followKeys } from '@/entities/follow';
 
@@ -51,9 +52,7 @@ export const FollowStats = ({
 
   if (isLoading) {
     return (
-      <div className='flex items-center gap-4 text-sm text-muted-foreground'>
-        <Loader2 className='h-4 w-4 animate-spin' />
-      </div>
+      <Spinner label='팔로우 정보를 불러오는 중' size='sm' />
     );
   }
 

--- a/apps/page0127/src/features/notification/ui/NotificationPage.tsx
+++ b/apps/page0127/src/features/notification/ui/NotificationPage.tsx
@@ -15,11 +15,11 @@ import { useEffect, useEffectEvent, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
 
 import { apiClient } from '@/shared/api/client';
 import { useLocalStorage } from '@/shared/lib/hooks/useLocalStorage';
 import { Button } from '@/shared/ui/button';
+import { Spinner } from '@/shared/ui/Spinner';
 
 import {
   notificationKeys,
@@ -141,9 +141,7 @@ export const NotificationPage = () => {
 
   if (isLoading) {
     return (
-      <div className='flex items-center justify-center py-12'>
-        <Loader2 className='h-8 w-8 animate-spin text-muted-foreground' />
-      </div>
+      <Spinner label='알림을 불러오는 중' size='lg' className='py-12' />
     );
   }
 
@@ -208,7 +206,7 @@ export const NotificationPage = () => {
           {hasNextPage && (
             <div ref={observerRef} className='flex justify-center py-4'>
               {isFetchingNextPage && (
-                <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
+                <Spinner label='알림을 더 불러오는 중' />
               )}
             </div>
           )}

--- a/apps/page0127/src/features/profile/ui/ProfileSettingsForm.tsx
+++ b/apps/page0127/src/features/profile/ui/ProfileSettingsForm.tsx
@@ -162,7 +162,7 @@ export const ProfileSettingsForm = ({ profile }: ProfileSettingsFormProps) => {
     // onSubmit 대신 action에 Server Action을 연결
     <form action={formAction}>
       {/* 제목은 카드 밖으로 — 카드 안 제목은 폼을 패널처럼 무겁게 만든다 */}
-      <h1 className='heading-1 mb-6 text-text-strong'>설정</h1>
+      <h1 className='heading-1 mb-6'>설정</h1>
 
       <Card className='p-6'>
         <div className='space-y-5'>

--- a/apps/page0127/src/features/stats/ui/ReadingProgressOverview.tsx
+++ b/apps/page0127/src/features/stats/ui/ReadingProgressOverview.tsx
@@ -84,7 +84,7 @@ export const ReadingProgressOverview = ({
                 <BookOpen className='size-4' />
                 {year} 독서 여정
               </p>
-              <h2 className='heading-1 mt-3 break-keep tracking-tight text-text-strong'>
+              <h2 className='heading-1 mt-3 break-keep tracking-tight'>
                 {headline}
               </h2>
               <p className='mt-2 text-sm text-text-subtle'>

--- a/apps/page0127/src/features/taste-analysis/ui/TasteAnalysisResult.tsx
+++ b/apps/page0127/src/features/taste-analysis/ui/TasteAnalysisResult.tsx
@@ -15,6 +15,7 @@ import { BookCover } from '@/shared/ui/BookCover';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { PageContainer } from '@/shared/ui/PageContainer';
+import { PageHeader } from '@/shared/ui/PageHeader';
 
 import { getPersonalityColor } from '@/entities/taste-analysis/model/personalityTypes';
 
@@ -49,19 +50,20 @@ export const TasteAnalysisResult = ({
 
   return (
     <PageContainer width='content'>
-      {/* 헤더 */}
-      <div className='mb-8'>
-        <Link href={`/${username}`}>
-          <Button variant='outline' size='sm' className='mb-4'>
-            <ArrowLeft className='h-4 w-4' />내 서재로
-          </Button>
-        </Link>
-        <h1 className='heading-1 text-text-strong'>독서 취향 분석</h1>
-        <p className='mt-1 text-sm text-text-subtle'>
-          {new Date(analysis.created_at).toLocaleDateString('ko-KR')} 분석 ·
-          완독한 책 {analysis.analyzed_books_count}권을 읽었습니다
-        </p>
-      </div>
+      <PageHeader
+        className='mb-8'
+        above={
+          <Link href={`/${username}`}>
+            <Button variant='outline' size='sm'>
+              <ArrowLeft className='h-4 w-4' />내 서재로
+            </Button>
+          </Link>
+        }
+        title='독서 취향 분석'
+        description={`${new Date(analysis.created_at).toLocaleDateString(
+          'ko-KR'
+        )} 분석 · 완독한 책 ${analysis.analyzed_books_count}권을 읽었습니다`}
+      />
 
       {/* 1. 독서 성향 */}
       <Card className='mb-6'>

--- a/apps/page0127/src/features/user/ui/UserSearch.tsx
+++ b/apps/page0127/src/features/user/ui/UserSearch.tsx
@@ -3,10 +3,11 @@
 import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, Search, X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
+import { Spinner } from '@/shared/ui/Spinner';
 
 import { userApi, userKeys } from '@/entities/user';
 
@@ -84,9 +85,7 @@ export const UserSearch = ({ currentUserId }: UserSearchProps) => {
 
       {/* 로딩 상태 */}
       {isLoading && (
-        <div className='flex items-center justify-center py-8'>
-          <Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
-        </div>
+        <Spinner label='사용자를 찾는 중' className='py-8' />
       )}
 
       {/* 검색 결과 */}

--- a/apps/page0127/src/shared/foundations/Typography.stories.tsx
+++ b/apps/page0127/src/shared/foundations/Typography.stories.tsx
@@ -18,6 +18,11 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
  * 줄간격을 비율이 아니라 px 로 못 박은 이유: 비율(1.35)로 두면 28px 에서 37.8px 이
  * 나와 스펙(40)과 어긋나고 Figma Text Style 과도 값이 맞지 않는다.
  *
+ * **색도 이 유틸이 갖는다**(`text-strong`). 21곳 중 19곳이 `text-text-strong` 과 함께
+ * 쓰이고 있어 기본값으로 넣었다 — 이제 호출부에서 색을 다시 적지 않는다.
+ * 다른 색이 필요하면 `text-white` 처럼 유틸로 덮으면 된다. `@layer components` 안에
+ * 있어서 유틸이 이긴다(레이어 밖에 두면 유틸이 조용히 무시된다).
+ *
  * ## 크기 단계는 5개뿐이다
  *
  * 07 문서가 제안한 caption(13px)은 만들지 않았다 — 실사용이 0곳이고 12 와 14 사이에
@@ -105,7 +110,7 @@ export const Weight: Story = {
 export const Hierarchy: Story = {
   render: () => (
     <div className='max-w-md p-6'>
-      <p className='heading-2 text-text-strong'>아무튼, 계속</p>
+      <p className='heading-2'>아무튼, 계속</p>
       <p className='mt-2 text-base text-text-body'>
         읽는 일에 대해 오래 생각해온 사람의 기록이다. 책을 좋아한다는 말로는
         부족한, 읽기라는 습관 그 자체에 대한 이야기.

--- a/apps/page0127/src/shared/ui/PageHeader.stories.tsx
+++ b/apps/page0127/src/shared/ui/PageHeader.stories.tsx
@@ -1,0 +1,118 @@
+import { ArrowLeft } from 'lucide-react';
+
+import { Button } from '@/shared/ui/button';
+import { PageHeader } from '@/shared/ui/PageHeader';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+/**
+ * 페이지 제목과 설명.
+ *
+ * ## 왜 컴포넌트인가
+ *
+ * 같은 조합(`heading-1 text-text-strong` + `text-sm text-text-subtle`)이 8곳에서 손으로
+ * 쓰이다 **간격이 `mt-1` 과 `mt-2` 로 갈렸다.** 어느 쪽이 맞는지 아무도 모르는 상태가
+ * 컴포넌트가 필요하다는 신호였다. 여기서 **8px(`mt-2`)로 통일**한다 — 제목이 28px
+ * (데스크톱)라 4px 는 붙어 보인다.
+ *
+ * ## `<h1>` 은 페이지당 하나
+ *
+ * 이 컴포넌트가 `<h1>` 을 만든다. 한 페이지에 두 번 쓰지 않는다 —
+ * 스크린리더 사용자가 제목 목록으로 페이지를 훑을 때 최상위가 둘이면 구조를 못 읽는다.
+ * 섹션 제목은 `.heading-2` 를 직접 쓴다.
+ *
+ * ## `above` 는 무엇인가
+ *
+ * 목록으로 돌아가는 링크처럼 **제목보다 먼저 읽혀야 하는 것**을 놓는 자리다.
+ * "어디서 왔는지"가 "무엇을 보고 있는지"보다 앞에 오는 편이 자연스럽다.
+ * 뒤로가기와 제목 사이는 16px 로, 제목과 설명 사이(8px)보다 넓다 — 성격이 다른
+ * 요소라 같은 간격이면 한 덩어리로 읽힌다.
+ *
+ * ## 쓰지 않는 자리
+ *
+ * 책 상세(`books/info`)와 문서 페이지(`DocPage`)는 이 컴포넌트를 쓰지 않는다.
+ * 전자는 설명이 두 줄이고 색이 다르며(저자는 `text-body`, 출판사는 `text-subtle`),
+ * 후자는 아래 구분선과 갱신일이 붙는 별도 레이아웃이다.
+ * **비슷해 보인다고 억지로 맞추면 prop 이 늘어나 결국 아무것도 강제하지 못한다.**
+ */
+const meta = {
+  title: 'UI/PageHeader',
+  component: PageHeader,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: '<h1> 으로 렌더된다. 페이지당 하나.',
+      table: { category: 'Content' },
+    },
+    description: {
+      control: 'text',
+      description: '제목 아래 한 줄 설명. 없으면 렌더하지 않는다.',
+      table: { category: 'Content' },
+    },
+    above: {
+      description: '제목 위에 놓을 것 — 뒤로가기 링크 등.',
+      table: { category: 'Content' },
+    },
+    className: {
+      control: 'text',
+      description: '바깥 <header> 에 붙는다. 아래 여백은 여기서.',
+      table: { category: 'Appearance' },
+    },
+  },
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 가장 흔한 형태 — 제목 + 설명. */
+export const Default: Story = {
+  args: {
+    title: '피드',
+    description: '함께 읽는 사람들의 새로운 독서 기록을 만나보세요.',
+  },
+};
+
+/** 설명이 없을 때. 제목만 남고 여백이 따라 붙지 않는다. */
+export const TitleOnly: Story = {
+  args: { title: '알림' },
+};
+
+/** 목록으로 돌아가는 링크가 있을 때. */
+export const WithBackLink: Story = {
+  args: {
+    above: (
+      <Button variant='outline' size='sm'>
+        <ArrowLeft className='h-4 w-4' />내 서재로
+      </Button>
+    ),
+    title: '독서 취향 분석',
+    description: '2026년 7월 30일 분석 · 완독한 책 42권을 읽었습니다',
+  },
+};
+
+/** 제목이 길어져도 줄바꿈된다. 설명은 그 아래로 밀린다. */
+export const LongTitle: Story = {
+  args: {
+    title: "'우리가 빛의 속도로 갈 수 없다면' 검색 결과",
+    description: '12권을 찾았어요.',
+  },
+};
+
+/**
+ * 오른쪽에 조작을 두는 화면. `PageHeader` 는 그 배치를 맡지 않는다 —
+ * 감싸는 쪽에서 `flex justify-between` 을 준다. 헤더가 레이아웃까지 떠안으면
+ * 화면마다 다른 요구가 prop 으로 쌓인다.
+ */
+export const WithSideAction: Story = {
+  args: { title: '전체 도서', description: '1,204권이 등록돼 있어요.' },
+  render: (args) => (
+    <div className='flex items-center justify-between gap-4'>
+      <PageHeader {...args} />
+      <Button variant='outline' size='sm'>
+        정렬
+      </Button>
+    </div>
+  ),
+};

--- a/apps/page0127/src/shared/ui/PageHeader.tsx
+++ b/apps/page0127/src/shared/ui/PageHeader.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/shared/lib/utils';
+
+type PageHeaderProps = {
+  /** 페이지 제목. `<h1>` 으로 렌더된다 — 페이지당 하나만 둔다 */
+  title: React.ReactNode;
+  /** 제목 아래 한 줄 설명 */
+  description?: React.ReactNode;
+  /**
+   * 제목 위에 놓을 것. 목록으로 돌아가는 링크 같은 것에 쓴다.
+   * (제목보다 위에 있어야 "어디서 왔는지"가 먼저 읽힌다)
+   */
+  above?: React.ReactNode;
+  className?: string;
+};
+
+/**
+ * 페이지 제목 + 설명
+ *
+ * 학습 포인트:
+ * - 같은 조합이 8곳에서 손으로 쓰이다 **간격이 mt-1 과 mt-2 로 갈렸다.**
+ *   어느 쪽이 맞는지 아무도 모르는 상태가 컴포넌트가 필요하다는 신호였다.
+ * - 여기서 8px(mt-2)로 통일한다. 제목이 28px(데스크톱)라 4px 는 붙어 보인다.
+ * - `<h1>` 을 이 컴포넌트가 만든다. 페이지마다 하나만 두고, 섹션 제목은
+ *   `.heading-2` 를 직접 쓴다.
+ */
+export const PageHeader = ({
+  title,
+  description,
+  above,
+  className,
+}: PageHeaderProps) => (
+  <header className={className}>
+    {above}
+    {/* 뒤로가기와 제목 사이는 제목·설명 사이보다 넓게 둔다 — 성격이 다른 요소라
+        같은 간격이면 한 덩어리로 읽힌다 */}
+    <h1 className={cn('heading-1 text-text-strong', above && 'mt-4')}>
+      {title}
+    </h1>
+    {description && (
+      <p className='mt-2 text-sm text-text-subtle'>{description}</p>
+    )}
+  </header>
+);

--- a/apps/page0127/src/shared/ui/PageHeader.tsx
+++ b/apps/page0127/src/shared/ui/PageHeader.tsx
@@ -33,7 +33,8 @@ export const PageHeader = ({
     {above}
     {/* 뒤로가기와 제목 사이는 제목·설명 사이보다 넓게 둔다 — 성격이 다른 요소라
         같은 간격이면 한 덩어리로 읽힌다 */}
-    <h1 className={cn('heading-1 text-text-strong', above && 'mt-4')}>
+    {/* 색은 `.heading-1` 이 갖는다 — text-text-strong 을 여기서 다시 주지 않는다 */}
+    <h1 className={cn('heading-1', above && 'mt-4')}>
       {title}
     </h1>
     {description && (

--- a/apps/page0127/src/shared/ui/Spinner.stories.tsx
+++ b/apps/page0127/src/shared/ui/Spinner.stories.tsx
@@ -1,0 +1,108 @@
+import { Card, CardContent } from '@/shared/ui/card';
+import { Spinner } from '@/shared/ui/Spinner';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+/**
+ * 영역이 채워지기를 기다리는 표시.
+ *
+ * ## `label` 은 필수다
+ *
+ * 돌아가는 아이콘은 **눈으로 보는 사람에게만** "기다리는 중"이다. 스크린리더 사용자는
+ * 화면이 비었는지 고장 났는지 알 수 없다. 그래서 `role='status'` + `sr-only` 문구를
+ * 컴포넌트가 항상 붙인다 — 손으로 `Loader2` 를 놓던 5곳에는 전부 그게 없었다.
+ *
+ * 문구는 **무엇을** 불러오는지 밝힌다. "로딩 중"만으로는 화면에 여러 영역이 동시에
+ * 로딩될 때 구분이 안 된다.
+ *
+ * ## Skeleton 과 언제 갈리나
+ *
+ * | | 쓰는 자리 |
+ * | --- | --- |
+ * | `Skeleton` | **모양을 아는** 것을 기다릴 때 — 목록·카드·문단. 자리를 잡아 두어 레이아웃이 안 튄다 |
+ * | `Spinner` | **모양을 모르거나 자리가 이미 있는** 것을 기다릴 때 — 목록 더 불러오기, 모달 안 첫 로딩, 검색 결과 |
+ *
+ * 첫 화면을 그릴 때는 대개 `Skeleton` 이 낫다. Spinner 는 "이미 있는 자리에서 무언가
+ * 진행 중"임을 알리는 데 강하다.
+ *
+ * ## 버튼 안에서는 쓰지 않는다
+ *
+ * `Button` 의 `loading` 을 쓴다. 버튼은 이미 자기 이름을 갖고 있어서 `role='status'` 를
+ * 또 두면 스크린리더가 두 번 읽는다.
+ *
+ * ## 크기
+ *
+ * 손으로 놓을 때 `h-4`·`h-6`·`h-8` 세 종류로 갈려 있었다. 여기서 3단으로 못 박는다 —
+ * `sm`(20px) · `md`(24px, 기본) · `lg`(32px).
+ */
+const meta = {
+  title: 'UI/Spinner',
+  component: Spinner,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description:
+        '스크린리더가 읽는 문구. 무엇을 불러오는지 밝힌다("로딩 중"만으로는 부족).',
+      table: { category: 'Accessibility' },
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'sm 20px · md 24px · lg 32px',
+      table: { category: 'Appearance', defaultValue: { summary: 'md' } },
+    },
+    className: {
+      control: 'text',
+      description: '감싸는 영역에 붙는다. 여백(py-8 등)은 여기서.',
+      table: { category: 'Appearance' },
+    },
+  },
+  args: { label: '불러오는 중' },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** 세 크기. 목록 안은 sm, 영역은 md, 화면 전체는 lg. */
+export const Sizes: Story = {
+  render: (args) => (
+    <div className='flex items-center gap-8'>
+      <Spinner {...args} size='sm' label='작은 영역 불러오는 중' />
+      <Spinner {...args} size='md' label='영역 불러오는 중' />
+      <Spinner {...args} size='lg' label='화면 불러오는 중' />
+    </div>
+  ),
+};
+
+/** 영역 안에서. 여백은 `className` 으로 준다. */
+export const InArea: Story = {
+  render: (args) => (
+    <Card className='w-80'>
+      <CardContent>
+        <Spinner {...args} label='댓글을 불러오는 중' className='py-8' />
+      </CardContent>
+    </Card>
+  ),
+};
+
+/**
+ * 목록 더 불러오기. 이미 내용이 있고 그 아래에서 진행 중임을 알린다 —
+ * 이 자리에 Skeleton 을 놓으면 "새 항목이 이만큼 온다"는 잘못된 예고가 된다.
+ */
+export const LoadingMore: Story = {
+  render: (args) => (
+    <div className='w-80 divide-y divide-line-soft'>
+      {['아무튼, 계속', '읽었습니다'].map((title) => (
+        <div key={title} className='py-3'>
+          <p className='text-sm font-medium text-text-strong'>{title}</p>
+          <p className='mt-0.5 text-xs text-text-subtle'>완독 · 3일 전</p>
+        </div>
+      ))}
+      <Spinner {...args} label='더 불러오는 중' className='py-4' />
+    </div>
+  ),
+};

--- a/apps/page0127/src/shared/ui/Spinner.tsx
+++ b/apps/page0127/src/shared/ui/Spinner.tsx
@@ -1,0 +1,45 @@
+import { Loader2 } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils';
+
+type SpinnerProps = {
+  /** 무엇을 불러오는지. 스크린리더가 이것을 읽는다 */
+  label: string;
+  /** sm 20px · md 24px(기본) · lg 32px */
+  size?: 'sm' | 'md' | 'lg';
+  /** 감싸는 영역에 붙일 클래스. 가운데 정렬·여백은 여기서 */
+  className?: string;
+};
+
+const SIZE = {
+  sm: 'size-5',
+  md: 'size-6',
+  lg: 'size-8',
+} as const;
+
+/**
+ * 영역이 채워지기를 기다리는 표시
+ *
+ * 학습 포인트:
+ * - **`role='status'` 와 `label` 이 이 컴포넌트의 존재 이유다.** 돌아가는 아이콘은
+ *   눈으로 보는 사람에게만 "기다리는 중"이고, 스크린리더 사용자는 화면이 비었는지
+ *   고장 났는지 알 수 없다. 손으로 `Loader2` 를 놓던 5곳에는 전부 그게 없었다.
+ * - 아이콘은 `aria-hidden` 이다. 읽을 것은 옆의 `sr-only` 문구 하나뿐이어야 한다.
+ * - **크기가 3종으로 갈려 있었다**(h-4/h-6/h-8). 여기서 3단으로 못 박는다.
+ *
+ * 버튼 안에서 도는 로딩은 이걸 쓰지 않는다 — `Button` 의 `loading` 을 쓴다.
+ * 버튼은 이미 자기 이름을 갖고 있어서 `role='status'` 를 또 두면 두 번 읽힌다.
+ */
+export const Spinner = ({ label, size = 'md', className }: SpinnerProps) => (
+  <div
+    role='status'
+    aria-live='polite'
+    className={cn('flex items-center justify-center', className)}
+  >
+    <Loader2
+      aria-hidden
+      className={cn('animate-spin text-text-subtle', SIZE[size])}
+    />
+    <span className='sr-only'>{label}</span>
+  </div>
+);

--- a/apps/page0127/src/shared/ui/button.stories.tsx
+++ b/apps/page0127/src/shared/ui/button.stories.tsx
@@ -82,6 +82,12 @@ const meta = {
       description: '비활성. 투명도 50% + 포인터 이벤트 차단.',
       table: { category: 'State', defaultValue: { summary: 'false' } },
     },
+    loading: {
+      control: 'boolean',
+      description:
+        '요청 진행 중. 스피너를 앞에 붙이고 버튼을 잠근다(aria-busy).',
+      table: { category: 'State', defaultValue: { summary: 'false' } },
+    },
     asChild: {
       control: 'boolean',
       description:
@@ -182,6 +188,30 @@ export const WithIcon: Story = {
         <Trash2 />
         삭제
       </Button>
+    </div>
+  ),
+};
+
+/**
+ * 요청이 진행 중일 때. `loading` 이 스피너를 붙이고 버튼을 잠근다.
+ *
+ * **버튼 안 로딩에는 `Spinner` 컴포넌트를 쓰지 않는다** — 버튼은 이미 자기 이름을
+ * 갖고 있어서 `role='status'` 를 또 두면 스크린리더가 두 번 읽는다.
+ * 여기서는 `aria-busy` 로 "이 버튼이 일하는 중"만 알린다.
+ *
+ * 글자가 없는 버튼(아래 세 번째)은 `aria-label` 이 필요하다 — 스피너만 남으면
+ * 읽을 이름이 사라진다.
+ */
+export const Loading: Story = {
+  render: (args) => (
+    <div className='flex flex-wrap items-center gap-3'>
+      <Button {...args} loading>
+        저장 중
+      </Button>
+      <Button {...args} variant='outline' loading>
+        불러오는 중
+      </Button>
+      <Button {...args} size='icon' loading aria-label='불러오는 중' />
     </div>
   ),
 };

--- a/apps/page0127/src/shared/ui/button.tsx
+++ b/apps/page0127/src/shared/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import { Loader2 } from "lucide-react"
 
 import { cn } from "@/shared/lib/utils"
 
@@ -43,19 +44,49 @@ function Button({
   variant,
   size,
   asChild = false,
+  loading = false,
+  children,
+  disabled,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
+    /**
+     * 제출·요청이 진행 중. 스피너를 앞에 붙이고 버튼을 잠근다.
+     *
+     * 버튼 안 로딩에 Spinner 컴포넌트를 쓰지 않는 이유: 버튼은 이미 자기 이름을
+     * 갖고 있어서 role='status' 를 또 두면 스크린리더가 두 번 읽는다.
+     * 여기서는 aria-busy 로 "이 버튼이 일하는 중"만 알린다.
+     */
+    loading?: boolean
   }) {
   const Comp = asChild ? Slot : "button"
+
+  // asChild 는 자식 하나를 그대로 쓰는 모드라 스피너를 끼워 넣을 자리가 없다.
+  // 조용히 무시하면 "왜 안 도나"가 되므로 개발 중에만 알린다.
+  if (process.env.NODE_ENV !== "production" && asChild && loading) {
+    console.warn(
+      "Button: asChild 와 loading 은 함께 쓸 수 없다 — 자식 요소에 직접 표시하라."
+    )
+  }
 
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      disabled={asChild ? undefined : disabled || loading}
+      aria-busy={loading || undefined}
       {...props}
-    />
+    >
+      {asChild ? (
+        children
+      ) : (
+        <>
+          {loading && <Loader2 aria-hidden className="animate-spin" />}
+          {children}
+        </>
+      )}
+    </Comp>
   )
 }
 

--- a/apps/page0127/src/widgets/book/ui/BookDetailContent.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookDetailContent.tsx
@@ -57,7 +57,7 @@ export const BookDetailContent = ({
 
             <div className='flex-1 space-y-4'>
               <div>
-                <h1 className='heading-1 mb-2 text-text-strong'>
+                <h1 className='heading-1 mb-2'>
                   {book.title}
                 </h1>
                 <p className='text-lg text-foreground'>{book.author}</p>

--- a/apps/page0127/src/widgets/book/ui/BookEditPageClient.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookEditPageClient.tsx
@@ -215,7 +215,7 @@ export const BookEditPageClient = ({
     return (
       <ErrorBoundary>
         <PageContainer width='content'>
-          <h1 className='heading-1 mb-6 text-text-strong'>책 다시 선택</h1>
+          <h1 className='heading-1 mb-6'>책 다시 선택</h1>
 
           {isLoadingDetail ? (
             <p className='text-center text-muted-foreground'>

--- a/apps/page0127/src/widgets/book/ui/BookRankingError.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookRankingError.tsx
@@ -25,7 +25,7 @@ export const BookRankingError = ({ title }: BookRankingErrorProps) => {
     <section>
       {title && (
         <div className='mb-3'>
-          <h2 className='heading-2 text-text-strong'>{title}</h2>
+          <h2 className='heading-2'>{title}</h2>
         </div>
       )}
       <div className='flex flex-col items-center justify-center gap-3 rounded-2xl bg-sunken py-12'>

--- a/apps/page0127/src/widgets/book/ui/BookRankingList.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookRankingList.tsx
@@ -41,7 +41,7 @@ export const BookRankingList = ({
   return (
     <section>
       <div className='mb-3 flex items-baseline justify-between gap-4'>
-        <h2 className='heading-2 text-text-strong'>{title}</h2>
+        <h2 className='heading-2'>{title}</h2>
         <div className='flex shrink-0 items-baseline gap-3'>
           {meta && <span className='text-xs text-text-subtle'>{meta}</span>}
           <Link

--- a/apps/page0127/src/widgets/book/ui/BookStreamSection.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookStreamSection.tsx
@@ -119,7 +119,7 @@ export const BookStreamSection = ({
 
   return (
     <section className='mt-6'>
-      <h2 className='heading-2 mb-3 text-text-strong'>이 책의 기록</h2>
+      <h2 className='heading-2 mb-3'>이 책의 기록</h2>
 
       {isLoading ? (
         <div className='flex justify-center py-8'>

--- a/apps/page0127/src/widgets/book/ui/GlobalBookCommentSection.tsx
+++ b/apps/page0127/src/widgets/book/ui/GlobalBookCommentSection.tsx
@@ -41,7 +41,7 @@ export const GlobalBookCommentSection = ({
 
   return (
     <section className='border-t border-line pt-6'>
-      <h2 className='heading-2 text-text-strong'>이 책 이야기 {totalCount}</h2>
+      <h2 className='heading-2'>이 책 이야기 {totalCount}</h2>
 
       {isLoading ? (
         <div className='flex justify-center py-8'>

--- a/apps/page0127/src/widgets/book/ui/MyBookMemo.tsx
+++ b/apps/page0127/src/widgets/book/ui/MyBookMemo.tsx
@@ -44,7 +44,7 @@ export const MyBookMemo = async ({ isbn }: MyBookMemoProps) => {
 
   return (
     <section>
-      <h2 className='heading-2 text-text-strong'>나의 기록</h2>
+      <h2 className='heading-2'>나의 기록</h2>
 
       {/* 플랫 sunken 모듈 — 내 기록은 페이지 안의 "메모지" 면 */}
       <div className='mt-3 space-y-4 rounded-2xl bg-sunken p-5 md:p-6'>

--- a/apps/page0127/src/widgets/landing/ui/DocPage.tsx
+++ b/apps/page0127/src/widgets/landing/ui/DocPage.tsx
@@ -27,7 +27,7 @@ export const DocPage = ({
     <>
       <PageContainer width='content'>
         <header className='mb-10 border-b border-line pb-6'>
-          <h1 className='heading-1 text-text-strong'>{title}</h1>
+          <h1 className='heading-1'>{title}</h1>
           {description && <p className='mt-2 text-text-body'>{description}</p>}
           {showUpdatedAt && (
             <p className='mt-3 text-xs text-text-subtle'>
@@ -52,7 +52,7 @@ type DocSectionProps = {
 
 export const DocSection = ({ title, children }: DocSectionProps) => (
   <section>
-    <h2 className='heading-2 mb-3 text-text-strong'>{title}</h2>
+    <h2 className='heading-2 mb-3'>{title}</h2>
     <div className='space-y-3 leading-relaxed text-text-body'>{children}</div>
   </section>
 );

--- a/apps/page0127/src/widgets/public-library/PublicLibraryHeader.tsx
+++ b/apps/page0127/src/widgets/public-library/PublicLibraryHeader.tsx
@@ -150,7 +150,7 @@ export const PublicLibraryHeader = ({
 
           <div className='min-w-0'>
             <p className='mb-1 text-sm font-medium text-primary'>공개 서재</p>
-            <h1 className='heading-1 truncate text-text-strong'>
+            <h1 className='heading-1 truncate'>
               {displayName}님의 서재
             </h1>
             <div className='mt-2 flex flex-wrap items-center gap-x-4 gap-y-2'>


### PR DESCRIPTION
"DS 화할 컴포넌트를 다 만들었나" 를 실측으로 답한 결과, **후보 2개와 유틸 개선 1개**가
남아 있었다. 셋 다 처리한다. 커밋 4개로 나눴다.

## 1. PageHeader — 이미 값이 갈려 있었다

`heading-1 text-text-strong` + `text-sm text-text-subtle` 조합이 8곳. **간격이 `mt-1` 과
`mt-2` 로 갈려** 어느 쪽이 맞는지 아무도 모르는 상태였다 — 그게 컴포넌트가 필요하다는
신호였다. 8px 로 통일했다.

**6곳만 옮겼다.** `books/info`(설명 두 줄, 색 다름)와 `DocPage`(구분선+갱신일)는 그대로
뒀다 — 비슷해 보인다고 억지로 맞추면 prop 이 늘어나 결국 아무것도 강제하지 못한다.

레이아웃은 맡지 않는다. 오른쪽에 조작을 두는 화면은 감싸는 쪽에서 `flex justify-between`
을 준다.

## 2. Spinner — 만든 이유는 크기 통일이 아니다

`Loader2` 를 손으로 놓던 8곳, 크기가 3종(h-4/h-6/h-8)으로 갈려 있었다. 그런데 더 큰
문제는 **그 자리에 `role='status'` 도 문구도 없었다는 것**이다. 돌아가는 아이콘은 눈으로
보는 사람에게만 "기다리는 중"이고, 스크린리더 사용자는 화면이 비었는지 고장 났는지 알 수 없다.

컴포넌트가 항상 붙인다 — `role='status'` + `aria-live` + **무엇을** 불러오는지 밝히는
`sr-only` 문구. 아이콘은 `aria-hidden`.

## 3. Button 의 loading — 버튼 안에는 Spinner 를 쓰지 않는다

`Spinner` 는 `role='status'` 를 갖는데 **버튼은 이미 자기 이름이 있어서** 그 안에 또
두면 스크린리더가 두 번 읽는다. 버튼은 `aria-busy` 로 "일하는 중"만 알린다.

- `disabled || loading` 을 컴포넌트가 합친다 — `CommentForm` 이
  `disabled={isPending || !content.trim()}` 이던 걸 `disabled={!content.trim()}` +
  `loading={isPending}` 으로 나눴다. 의도가 드러난다.
- `asChild` 와는 못 쓴다(자식 하나를 그대로 쓰는 모드). 조용히 무시하면 "왜 안 도나"가
  되므로 개발 중 `console.warn`.

**곁들여**: `h-4` 스피너 3곳 중 하나(`FollowStats`)는 버튼이 아니라 팔로워 수 자리였다 →
`Spinner size='sm'`. 비슷하게 생겼다고 같은 것이 아니다.
`FollowButton` 의 로딩 상태는 아이콘만 있어 **접근 이름이 없었다** → `aria-label` 추가.

## 4. `.heading-*` 가 색까지 갖는다

21곳 중 19곳이 `text-text-strong` 과 함께 쓰여, 유틸에 색을 넣고 호출부에서 뗐다(17개 파일).

**`@layer components` 로 옮긴 것이 핵심이다.** 레이어 밖에 두면 이 클래스가 Tailwind
유틸을 이겨서, 어두운 배너 위 `heading-2 text-white`(1곳)가 조용히 무시된다 —
`.book-cover` 가 `bg-sunken` 을 무력화하던 것과 같은 함정이다. 실측으로 확인했다:

```
heading-2                => rgb(20, 41, 78)     (text-strong)
heading-2 text-white     => rgb(255, 255, 255)  ✅ 유틸이 이긴다
heading-1 text-primary   => rgb(30, 105, 203)   ✅
```

**여기는 컴포넌트를 만들지 않았다.** 제목은 이미 `.heading-1` 이라는 이름이 있고 반복되던
건 색 하나뿐이라, 컴포넌트로 감싸면 prop·스토리·채점이 따라오는데 얻는 게 클래스 하나
제거뿐이다. 반대로 PageHeader 는 제목+설명+간격이라는 **구조**가 반복돼 컴포넌트가 맞았다.

## 후보였지만 만들지 않은 것

`rounded-lg border border-line p-4` 가 9곳에서 반복됐는데 **전부 `admin-quality` 한 폴더
안**이었다. 여러 화면이 아니라 한 기능의 지역 패턴이라, 체크리스트 기준
("다른 화면에도 나타나는가")대로면 DS 가 아니다.

## 검증

lint 0 · `tsc --noEmit` 0 · 앱 테스트 292 · **스토리 94개 a11y 통과** ·
heading 색 우선순위 DOM 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
