### PR TITLE
🔧 Chore: TypeScript 메이저 업그레이드를 Dependabot 무시 목록에 넣는다

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       time: "00:30"
       timezone: Asia/Seoul
     open-pull-requests-limit: 5
+    # TypeScript 7 은 컴파일러가 Go 로 재작성되면서 기존 JS 컴파일러 API 가 빠졌다.
+    # typescript-eslint(#10940)·Next.js 가 아직 그 API 에 의존해서 TS 7 로 올리면 lint·build 가 통째로 죽는다.
+    # 두 도구가 지원을 발표하면 이 항목을 지우고 메이저 업그레이드를 별도 PR 로 검증한다.
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
     groups:
       production-minor-patch:
         dependency-type: production


### PR DESCRIPTION
## 무엇을 / 왜

Dependabot 이 TypeScript 를 5.9.3 → 7.0.2 로 올린 PR #64 가 CI 전부에서 실패했다.
원인은 우리 코드가 아니라 **TS 7 자체를 생태계가 아직 못 받는 것**이다.
TypeScript 7 은 컴파일러가 Go 로 재작성되면서 기존 JS 컴파일러 API 가 빠졌는데,
typescript-eslint 와 Next.js 가 아직 그 API 에 의존한다.

| 체크 | 에러 |
| --- | --- |
| Lint · Type-check · Build | `typescript-eslint does not support TS 7.0.` → `@repo/icons#lint` exit 2 |
| Storybook a11y | `TypeScript 7.0.2 does not provide the compiler API required by Next.js.` |
| Vercel | 위 빌드와 동일 원인으로 실패 |

추적: [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)

우리가 코드로 고칠 수 있는 게 없는데, 막아두지 않으면 매주 월요일마다 같은 PR 이
다시 열려 CI 를 태운다.

## 어떻게

`.github/dependabot.yml` 의 npm 항목에 `ignore` 규칙을 추가해
`typescript` 의 `version-update:semver-major` 를 차단했다.

PR #64 자체는 `@dependabot ignore this major version` 커맨드로 닫았지만,
그 커맨드는 **7.x 만** 막는다. 이 설정은 그 뒤 메이저(8.0 …)까지 함께 막고,
무엇보다 "왜 TypeScript 를 안 올리는지"를 코드에 남긴다 — 몇 달 뒤에 다시 헤매지 않도록.

해제 조건은 주석으로 파일에 적어 두었다. 두 도구가 지원을 발표하면 항목을 지우고
메이저 업그레이드를 별도 PR 로 검증한다.

## 검증

- `js-yaml` 파싱 → `ignore` 가 npm update 항목 아래 올바른 위치에 들어감을 JSON 으로 확인
- `prettier --check .github/dependabot.yml` → `All matched files use Prettier code style!`
- PR #64 상태 확인 → `state: CLOSED` (2026-08-04 00:17:54, Dependabot 이 커맨드에 반응)

## 리뷰 포인트

- 마이너·패치는 그대로 열린다 (`development-minor-patch` 그룹). 메이저만 막는다.
- `ignore` 는 `groups` 와 독립이라 기존 그룹 동작에는 영향이 없다.
