### PR TITLE
🐛 Fix: Chromatic 이 dependabot PR 에서 토큰 없이 도는 것을 막는다

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,9 +26,18 @@ jobs:
     name: Visual regression · Storybook 배포
     runs-on: ubuntu-latest
 
-    # 토큰이 없는 포크·dependabot PR 에서는 건너뛴다. GitHub 은 그런 PR 에
-    # repository secrets 를 전달하지 않아 실행해도 인증에서 실패할 뿐이다.
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    # secrets 가 오지 않는 PR 에서는 건너뛴다 — 실행해도 인증에서 실패할 뿐이다.
+    #
+    # 두 경우를 **각각** 걸러야 한다. 처음에는 fork 조건만 두었는데,
+    # dependabot 은 fork 가 아니라 **같은 레포에 브랜치를 딴다.** 그래서
+    # head.repo 검사를 통과해 job 이 돌았고, 토큰만 빈 값이라
+    # `✖ Missing project token` 으로 죽었다(PR #70~#74 전부 빨간불).
+    #
+    # ci.yml 의 E2E job 이 이미 같은 이유로 dependabot 을 명시적으로 거른다.
+    if: >
+      github.event_name == 'push' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.user.login != 'dependabot[bot]')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
워크플로 조건 한 줄 수정. 코드 변경 없음.

## 증상

dependabot PR #70~#74 가 **전부 빨간불**이었다. 실패하는 체크는 하나뿐이다:

```
Visual regression · Storybook 배포   ✖ Missing project token
```

나머지는 5개 PR 모두 통과한다 — Lint·Type-check·Build, Storybook a11y.
**의존성 업데이트 자체에는 문제가 없다.**

## 원인 — #68 에서 내가 넣은 조건이 틀렸다

```yaml
# 주석: "포크·dependabot PR 에서는 건너뛴다"
if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
```

주석에는 dependabot 을 거른다고 적어 놓고 실제로는 **fork 만** 걸렀다.

dependabot 은 fork 가 아니라 **같은 레포에 브랜치를 딴다.** 그래서
`head.repo.full_name == github.repository` 를 통과해 job 이 실행됐고,
GitHub 은 dependabot PR 에 repository secrets 를 전달하지 않으므로
`CHROMATIC_PROJECT_TOKEN` 만 빈 값이 되어 인증에서 죽었다.

`ci.yml` 의 E2E job 은 이미 같은 이유로 `dependabot[bot]` 을 명시적으로
제외하고 있다(그래서 E2E 는 "skipping" 으로 뜬다). 그 패턴을 따르지 않은 것이
이번 실수다.

## 수정

두 경우를 각각 거른다.

```yaml
if: >
  github.event_name == 'push' ||
  (github.event.pull_request.head.repo.full_name == github.repository &&
   github.event.pull_request.user.login != 'dependabot[bot]')
```

## 검증

`js-yaml` 로 파싱해 `if` 표현식이 의도대로 한 줄로 들어갔는지 확인했다.

## 머지 후 할 일

**이미 열린 PR 은 자동으로 다시 돌지 않는다.** 이 PR 을 머지한 **뒤에**
각 dependabot PR 에 `@dependabot rebase` 댓글을 달면 새 워크플로로 재실행되고,
Chromatic 체크가 빨간불 대신 "skipping" 으로 바뀐다.

순서가 중요하다 — 머지 전에 rebase 하면 여전히 옛 워크플로가 돈다.
