### PR TITLE
🔧 Chore: ESLint 메이저 업그레이드를 Dependabot 무시 목록에 넣는다

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,16 @@ updates:
       - dependency-name: typescript
         update-types:
           - version-update:semver-major
+      # ESLint 10 은 규칙 컨텍스트에서 `context.getFilename()` 을 제거했는데
+      # eslint-plugin-react 가 아직 그 API 에 의존한다. 올리면 lint 가 통째로 죽는다:
+      #   TypeError: Error while loading rule 'react/display-name':
+      #   contextOrFilename.getFilename is not a function
+      # (PR #73 에서 실측 — Lint 작업이 47초 만에 exit 2)
+      # 플러그인이 ESLint 10 지원을 발표하면 이 항목을 지우고 메이저 업그레이드를
+      # 별도 PR 로 검증한다. typescript 와 같은 이유·같은 처리다.
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
     groups:
       production-minor-patch:
         dependency-type: production


### PR DESCRIPTION
설정 파일 한 곳. 코드 변경 없음.

## 왜

PR #73(eslint 9.39.5 → 10.8.0)이 Lint 에서 **47초 만에 exit 2** 로 죽었다.

```
TypeError: Error while loading rule 'react/display-name':
  contextOrFilename.getFilename is not a function
    at resolveBasedir (eslint-plugin-react/lib/util/version.js:31)
    at detectReactVersion (eslint-plugin-react/lib/util/version.js:85)
```

ESLint 10 이 규칙 컨텍스트에서 `context.getFilename()` 을 제거했는데
`eslint-plugin-react` 가 아직 그 API 에 의존한다. **우리 코드로는 고칠 수 없다** —
플러그인이 대응할 때까지 기다리는 수밖에 없다.

## 무엇을

`typescript` 7 과 **같은 상황이고 같은 처리**를 한다(#69 참조).

```yaml
- dependency-name: eslint
  update-types:
    - version-update:semver-major
```

무시하지 않으면 **매주 월요일마다 같은 PR 이 다시 열리고**, 그때마다 이 로그를
다시 읽고 같은 판단을 반복하게 된다. 이유를 주석으로 박아 두면 다음에 볼 때
"왜 막아 뒀지" 를 다시 조사하지 않아도 된다.

**이 항목이 막는 것은 메이저뿐이다.** 9.x 안의 minor·patch 는 계속 올라온다.

## 언제 풀어야 하나

`eslint-plugin-react` 가 ESLint 10 지원을 발표하면 이 항목을 지우고 메이저
업그레이드를 별도 PR 로 검증한다. typescript 항목도 같은 조건이다
(typescript-eslint·Next.js 가 TS 7 을 지원할 때).

## 검증

`js-yaml` 로 파싱해 `ignore` 목록에 `typescript`·`eslint` 두 항목이 의도대로
들어갔는지 확인했다.

## 머지 후

Dependabot 이 설정 변경을 감지해 재평가하면서 **PR #73 을 자동으로 닫는다**
(#69 머지 때 typescript PR 이 그렇게 정리됐다). 수동으로 닫지 않아도 된다.
