### PR TITLE
🐛 Fix: 재독 표시를 저장값이 아니라 기록 수로 센다

### DIFF
--- a/apps/page0127/app/(public)/[username]/[bookId]/page.tsx
+++ b/apps/page0127/app/(public)/[username]/[bookId]/page.tsx
@@ -130,6 +130,12 @@ const BookDetailPage = async ({ params }: PageProps) => {
   // 여기서 되돌려 준다. 방문자에게는 공개된 회독만 보인다.
   const readings = await getBookReadings(profile.id, book.isbn, isOwner);
 
+  // 헤더 배지와 아래 목록이 같은 번호를 말해야 한다 — 저장된 read_count 는
+  // 재독을 놓친 경우 1 로 남아 있어 목록과 어긋난다
+  const readCount =
+    readings.find((reading) => reading.id === book.id)?.reading_number ??
+    book.read_count;
+
   return (
     <PageContainer width='content'>
       <div className='mb-6 flex flex-wrap items-center justify-between gap-3'>
@@ -159,7 +165,7 @@ const BookDetailPage = async ({ params }: PageProps) => {
         </div>
       </div>
 
-      <BookDetailContent book={book} isOwner={isOwner} />
+      <BookDetailContent book={book} isOwner={isOwner} readCount={readCount} />
 
       <div className='mt-6'>
         <BookReadingList

--- a/apps/page0127/src/entities/book/api/getBookReadings.ts
+++ b/apps/page0127/src/entities/book/api/getBookReadings.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@/shared/config/supabase/server';
 
+import { numberReadings } from '../model/numberReadings';
+
 import type { Book } from '../types';
 
 /** 회독 목록 한 줄에 필요한 만큼만 */
@@ -9,11 +11,15 @@ export type BookReading = Pick<
   | 'read_count'
   | 'status'
   | 'completed_date'
+  | 'created_at'
   | 'rating'
   | 'is_life_book'
   | 'one_line_review'
   | 'is_public'
->;
+> & {
+  /** 몇 회독인지 — 저장된 read_count 가 아니라 읽은 순서대로 센 값 */
+  reading_number: number;
+};
 
 /**
  * 같은 책의 회독 기록을 모두 가져온다 (Server Component용)
@@ -25,6 +31,9 @@ export type BookReading = Pick<
  * 묶는 기준은 ISBN 이다 — 앱의 다른 곳과 같은 규칙
  * (entities/book/model/dedupeReadings.ts). ISBN 이 비어 있는 수기 등록 책은
  * 묶을 근거가 없으므로 자기 자신만 돌려준다.
+ *
+ * 회독 번호는 저장된 read_count 가 아니라 읽은 순서대로 센다
+ * (model/numberReadings.ts) — 이유는 그 파일 주석 참고.
  *
  * @param userId 책장 주인
  * @param isbn 대상 책의 ISBN
@@ -40,15 +49,15 @@ export const getBookReadings = async (
 
   const supabase = await createClient();
 
+  // 정렬·번호는 numberReadings 가 맡는다. read_count 로 정렬해 봐야
+  // 재독인데 값이 둘 다 1 이면 순서가 DB 마음대로 정해진다.
   let query = supabase
     .from('books')
     .select(
-      'id, read_count, status, completed_date, rating, is_life_book, one_line_review, is_public'
+      'id, read_count, status, completed_date, created_at, rating, is_life_book, one_line_review, is_public'
     )
     .eq('user_id', userId)
-    .eq('isbn', isbn)
-    // 최근에 읽은 회독을 위에 둔다
-    .order('read_count', { ascending: false });
+    .eq('isbn', isbn);
 
   if (!includePrivate) {
     query = query.eq('is_public', true);
@@ -61,5 +70,5 @@ export const getBookReadings = async (
     return [];
   }
 
-  return data ?? [];
+  return numberReadings(data ?? []);
 };

--- a/apps/page0127/src/entities/book/model/dedupeReadings.test.ts
+++ b/apps/page0127/src/entities/book/model/dedupeReadings.test.ts
@@ -111,6 +111,30 @@ describe('dedupeReadings', () => {
     expect(merged.read_count).toBe(3);
   });
 
+  it('저장된 회독 수가 모두 1이어도 기록이 2개면 2회독으로 센다', () => {
+    // read_count 는 등록 시점에 한 번 정해진다 — 중복 감지(getBookByISBN)가
+    // ISBN 표기 차이로 빗나가면 둘 다 1 로 남는다. 나중에 ISBN 을 맞춰
+    // 합쳐지더라도 그 값은 따라오지 않아 배지가 영영 안 붙는다.
+    // 같은 칸에 같은 책 기록이 2개 있다는 것 자체가 2회독이다.
+    const books = [
+      createBook({ id: 'first', read_count: 1, completed_date: '2025-09-12' }),
+      createBook({ id: 'second', read_count: 1, completed_date: '2026-05-08' }),
+    ];
+
+    const [merged] = dedupeReadings(books);
+
+    expect(merged.id).toBe('second');
+    expect(merged.read_count).toBe(2);
+  });
+
+  it('저장된 회독 수가 기록 수보다 크면 저장된 값을 쓴다', () => {
+    // 재독 다이얼로그로 제대로 등록해 read_count 가 3 인데 그 해에 읽은
+    // 기록만 화면에 남은 경우 — 세는 값(1)으로 덮으면 회독 수가 되레 줄어든다
+    const books = [createBook({ id: 'only', read_count: 3 })];
+
+    expect(dedupeReadings(books)[0].read_count).toBe(3);
+  });
+
   it('서로 다른 책은 합치지 않고 원래 순서를 지킨다', () => {
     const books = [
       createBook({ id: 'a', isbn: '111' }),

--- a/apps/page0127/src/entities/book/model/dedupeReadings.ts
+++ b/apps/page0127/src/entities/book/model/dedupeReadings.ts
@@ -16,7 +16,8 @@ import type { Book } from '../types';
  * - 대표 = 가장 최근에 읽은 회독 (완독일 없으면 등록 시각, 그마저 같으면 회독 수)
  * - `is_life_book` = 회독 중 하나라도 인생책이면 true
  *   (1회독 때만 인생책으로 꼽았어도 '내 인생책'에서 사라지면 안 된다)
- * - `read_count` = 기록 중 최대값 (배지가 "몇 번 읽었나"를 말해야 한다)
+ * - `read_count` = 저장된 최대값과 '합쳐진 기록 수' 중 큰 쪽
+ *   (배지가 "몇 번 읽었나"를 말해야 한다)
  *
  * 입력 순서는 그대로 지킨다. 정렬은 호출부가 이미 끝낸 상태로 들어온다.
  */
@@ -41,26 +42,35 @@ export const dedupeReadings = (books: Book[]): Book[] => {
     return diff !== 0 ? diff > 0 : candidate.read_count > current.read_count;
   };
 
-  // 그룹별 대표를 고르면서, 어느 자리에 놓을지(원래 순서)도 함께 기억한다
-  const groups = new Map<string, { order: number; book: Book }>();
+  // 그룹별 대표를 고르면서, 어느 자리에 놓을지(원래 순서)와
+  // 몇 개가 합쳐졌는지(= 몇 회독인지)도 함께 기억한다
+  const groups = new Map<string, { order: number; count: number; book: Book }>();
 
   books.forEach((book, index) => {
     const key = groupKey(book);
     const group = groups.get(key);
 
     if (!group) {
-      groups.set(key, { order: index, book });
+      groups.set(key, { order: index, count: 1, book });
       return;
     }
 
     const merged: Book = isNewerReading(book, group.book) ? book : group.book;
+    const count = group.count + 1;
 
     groups.set(key, {
       order: group.order,
+      count,
       book: {
         ...merged,
         is_life_book: group.book.is_life_book || book.is_life_book,
-        read_count: Math.max(group.book.read_count, book.read_count),
+        // 저장된 read_count 는 등록 시점에 한 번 정해진다 — 중복 감지가
+        // ISBN 표기 차이(ISBN10/13, 알라딘 상품코드)로 빗나가면 재독인데도
+        // 둘 다 1 로 남는다. 나중에 ISBN 을 맞춰 합쳐져도 그 값은 따라오지
+        // 않아 배지가 영영 안 붙는다. 같은 칸에 같은 책 기록이 n 개 있다는
+        // 것 자체가 n 회독이므로, 합쳐진 개수를 하한으로 쓴다.
+        // 저장값이 더 크면(제대로 등록된 3회독 등) 그쪽을 존중한다.
+        read_count: Math.max(group.book.read_count, book.read_count, count),
       },
     });
   });

--- a/apps/page0127/src/entities/book/model/numberReadings.test.ts
+++ b/apps/page0127/src/entities/book/model/numberReadings.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { numberReadings } from './numberReadings';
+
+type Row = {
+  id: string;
+  read_count: number;
+  completed_date: string | null;
+  created_at: string;
+};
+
+const createRow = (overrides: Partial<Row> = {}): Row => ({
+  id: crypto.randomUUID(),
+  read_count: 1,
+  completed_date: '2026-01-01',
+  created_at: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('numberReadings', () => {
+  it('저장된 회독 수가 모두 1이어도 읽은 순서대로 번호를 매긴다', () => {
+    // 중복 감지가 ISBN 표기 차이로 빗나가면 재독인데도 둘 다 1 로 저장된다.
+    // 목록이 "1회독 / 1회독" 이 되면 어느 쪽이 나중인지 알 수 없다.
+    const rows = [
+      createRow({ id: 'first', completed_date: '2025-09-12' }),
+      createRow({ id: 'second', completed_date: '2026-05-08' }),
+    ];
+
+    expect(
+      numberReadings(rows).map((row) => [row.id, row.reading_number])
+    ).toEqual([
+      ['second', 2],
+      ['first', 1],
+    ]);
+  });
+
+  it('최신 회독을 맨 위에 둔다', () => {
+    const rows = [
+      createRow({ id: 'old', completed_date: '2024-01-01' }),
+      createRow({ id: 'new', completed_date: '2026-01-01' }),
+      createRow({ id: 'mid', completed_date: '2025-01-01' }),
+    ];
+
+    expect(numberReadings(rows).map((row) => row.id)).toEqual([
+      'new',
+      'mid',
+      'old',
+    ]);
+  });
+
+  it('저장된 회독 수가 더 크면 그 값을 존중한다', () => {
+    // 재독 다이얼로그로 제대로 3회독 등록했는데 방문자에게는 그 기록만
+    // 공개된 경우 — 세는 값(1)으로 덮으면 회독 수가 되레 줄어든다
+    const rows = [createRow({ id: 'only', read_count: 3 })];
+
+    expect(numberReadings(rows)[0].reading_number).toBe(3);
+  });
+
+  it('번호는 항상 뒤로 갈수록 커진다', () => {
+    // 저장값과 순번이 섞여도 같은 번호가 두 줄에 붙으면 안 된다
+    const rows = [
+      createRow({ id: 'a', read_count: 2, completed_date: '2024-01-01' }),
+      createRow({ id: 'b', read_count: 1, completed_date: '2025-01-01' }),
+      createRow({ id: 'c', read_count: 1, completed_date: '2026-01-01' }),
+    ];
+
+    expect(
+      numberReadings(rows).map((row) => [row.id, row.reading_number])
+    ).toEqual([
+      ['c', 4],
+      ['b', 3],
+      ['a', 2],
+    ]);
+  });
+
+  it('완독일이 없으면 등록 시각으로 순서를 정한다', () => {
+    // 읽는 중인 회독은 완독일이 없다 — 등록 시각이 그 자리를 대신한다
+    const rows = [
+      createRow({
+        id: 'reading',
+        completed_date: null,
+        created_at: '2026-06-01T00:00:00.000Z',
+      }),
+      createRow({
+        id: 'done',
+        completed_date: '2026-01-01',
+        created_at: '2026-01-01T00:00:00.000Z',
+      }),
+    ];
+
+    expect(
+      numberReadings(rows).map((row) => [row.id, row.reading_number])
+    ).toEqual([
+      ['reading', 2],
+      ['done', 1],
+    ]);
+  });
+
+  it('원본 배열을 바꾸지 않는다', () => {
+    const rows = [
+      createRow({ id: 'old', completed_date: '2024-01-01' }),
+      createRow({ id: 'new', completed_date: '2026-01-01' }),
+    ];
+
+    numberReadings(rows);
+
+    expect(rows.map((row) => row.id)).toEqual(['old', 'new']);
+  });
+
+  it('빈 목록은 빈 목록으로 돌려준다', () => {
+    expect(numberReadings([])).toEqual([]);
+  });
+});

--- a/apps/page0127/src/entities/book/model/numberReadings.ts
+++ b/apps/page0127/src/entities/book/model/numberReadings.ts
@@ -1,0 +1,45 @@
+/** 회독 번호를 매기는 데 필요한 최소 정보 */
+type Readable = {
+  read_count: number;
+  completed_date: string | null;
+  created_at: string;
+};
+
+/**
+ * 회독 목록에 "몇 회독인지" 번호를 매기고 최신 회독을 맨 위로 올린다.
+ *
+ * 왜 저장된 `read_count` 를 그대로 쓰지 않는가:
+ * 그 값은 등록 시점에 딱 한 번 정해진다 — 중복 감지(getBookByISBN)가
+ * ISBN 표기 차이(ISBN10/13, 알라딘 상품코드)로 빗나가면 재독인데도 새 책으로
+ * 등록돼 둘 다 1 로 남는다. 나중에 ISBN 을 맞춰 같은 책이 되어도 그 값은
+ * 따라오지 않아 목록이 "1회독 / 1회독" 이 된다.
+ *
+ * 그래서 읽은 순서대로 세어 번호를 매긴다. 책장(model/dedupeReadings.ts)이
+ * 합쳐진 기록 수를 회독 수로 쓰는 것과 같은 규칙이다.
+ *
+ * 다만 저장값이 더 크면 그쪽을 존중한다 — 재독 다이얼로그로 제대로 등록한
+ * 3회독이 화면에 그 기록만 보인다고 "1회독" 으로 내려가면 안 된다.
+ * 번호가 뒤로 갈수록 반드시 커지게 해서 같은 번호가 두 줄에 붙지 않도록 한다.
+ *
+ * 방문자에게는 공개된 회독만 넘어오므로 번호도 '보이는 기록 안에서'의
+ * 순번이다 — 화면이 보여주는 범위 안에서 셈을 맞추는 앱의 규칙과 같다.
+ */
+export const numberReadings = <T extends Readable>(
+  readings: T[]
+): (T & { reading_number: number })[] => {
+  // 완독일이 없는 회독(읽는 중)은 등록 시각이 그 자리를 대신한다
+  const readAt = (reading: T) =>
+    new Date(reading.completed_date ?? reading.created_at).getTime();
+
+  // 정렬은 호출부의 배열을 건드리지 않도록 복사본에서 한다
+  const oldestFirst = [...readings].sort((a, b) => readAt(a) - readAt(b));
+
+  let previous = 0;
+  const numbered = oldestFirst.map((reading) => {
+    previous = Math.max(reading.read_count, previous + 1);
+    return { ...reading, reading_number: previous };
+  });
+
+  // 화면은 최신 회독을 맨 위에 둔다
+  return numbered.reverse();
+};

--- a/apps/page0127/src/widgets/book/ui/BookDetailContent.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookDetailContent.tsx
@@ -22,6 +22,12 @@ type BookDetailContentProps = {
    * (공개 서재 방문자에게는 사적 메모와 공개 여부를 감춘다)
    */
   isOwner?: boolean;
+  /**
+   * 이 기록이 몇 회독인지. 저장된 `book.read_count` 는 등록 시점에 정해져
+   * 재독을 놓친 경우 1 로 남으므로, 회독 목록에서 센 번호를 받아 쓴다
+   * (entities/book/model/numberReadings.ts). 없으면 저장값으로 떨어진다.
+   */
+  readCount?: number;
 };
 
 /**
@@ -34,6 +40,7 @@ type BookDetailContentProps = {
 export const BookDetailContent = ({
   book,
   isOwner = false,
+  readCount = book.read_count,
 }: BookDetailContentProps) => {
   return (
     <>
@@ -73,7 +80,7 @@ export const BookDetailContent = ({
                   {STATUS_TEXT[book.status]}
                 </span>
 
-                <ReadCountBadge readCount={book.read_count} />
+                <ReadCountBadge readCount={readCount} />
 
                 {/* 0("평가 안 함")은 별 배지를 걸지 않고, 인생책은 점수 대신 이름으로 보여준다 */}
                 {isRated(book.rating) && (

--- a/apps/page0127/src/widgets/book/ui/BookReadingList.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookReadingList.tsx
@@ -57,7 +57,7 @@ export const BookReadingList = ({
                     : 'font-medium text-text-strong'
                 }
               >
-                {reading.read_count}회독
+                {reading.reading_number}회독
               </span>
 
               <span className='text-sm text-text-body'>


### PR DESCRIPTION
## 문제

전체 탭 인생책 책장에 같은 책이 두 번 서 있었다.

원인은 **`isbn` 표기가 섞인 것**이었다. 운영 데이터 156권의 `isbn` 은 세 체계가 뒤섞여 있다 — ISBN13 62 · 알라딘 상품코드(`K…`) 68 · ISBN10 24.

| 책 | 행 1 | 행 2 |
| --- | --- | --- |
| 데이터 삽질 끝에 UX가 보였다 | `K622030506` | `9791169214155` |
| 모순 | `8998441012` (ISBN10) | `9788998441012` (ISBN13) |

앱 전체가 isbn **완전 일치**를 "같은 책"의 기준으로 쓰기 때문에(`dedupeReadings` 그룹 키 · 등록 시 중복 감지 `getBookByISBN` · `getBookReadings`), 표기가 갈리면 조용히 두 권이 된다.

**isbn 자체는 데이터 수정으로 맞췄다.** 그런데 배지가 여전히 안 붙었다 — 이 PR 이 고치는 건 그 두 번째 문제다.

## 왜 ISBN 을 맞춰도 배지가 안 붙나

`read_count` 는 **등록 시점에 딱 한 번** 정해진다. "이미 등록된 책입니다 → 2회독 등록" 다이얼로그를 거쳐야 +1 이 되는데, 그때 중복 감지가 ISBN 표기 차이로 빗나갔으니 두 행 모두 `1` 로 저장됐다. 나중에 isbn 을 맞춰 한 권으로 합쳐져도 그 값은 따라오지 않는다. 책장은 회독 수를 "둘 중 큰 값"으로 잡는데 `max(1, 1) = 1` 이라 배지 조건(`> 1`)에 영영 못 닿는다.

## 바꾼 것

**회독 수를 저장값이 아니라 세어서 정한다.** 같은 칸에 같은 책 기록이 n 개 있다는 것 자체가 n 회독이다.

- `dedupeReadings` — `read_count = max(저장 최대값, 합쳐진 기록 수)`
- `numberReadings` (신규) — 상세의 '이 책을 읽은 기록' 이 완독일(없으면 등록 시각) 순으로 번호를 매긴다. 책장이 "2회독" 이라 말한 책을 열었더니 "1회독 / 1회독" 두 줄이 나오던 어긋남을 없앤다
- 상세 헤더 배지도 같은 번호를 받아 쓴다
- `getBookReadings` 의 `read_count` 정렬을 걷어냈다 — 재독인데 값이 둘 다 1 이면 순서를 DB 가 마음대로 정했다

저장값을 버리는 게 아니다. **저장값이 더 크면 그쪽을 존중**한다 — 재독 다이얼로그로 제대로 등록한 3회독이 화면에 그 기록만 보인다고 "1회독" 으로 내려가면 안 된다. 번호는 단조 증가시켜 같은 번호가 두 줄에 붙지 않게 했다.

## 검증

- 단위 테스트 155개 통과. 새로 9개 추가했고, 실제 운영 데이터 값(완독일 `2025-09-12` / `2026-05-08`, 저장값 1·1)을 그대로 케이스에 넣었다
- `turbo run type-check` 5/5 통과, 변경 파일 ESLint 통과
- ⚠️ **화면 렌더는 확인하지 못했다** — 로컬 Supabase 에 데이터가 없어 dev 서버로 눈으로 볼 수 없었다. Preview 배포에서 인생책 책장의 `2` 배지와 상세 페이지를 확인해야 한다

## 남는 것 (이 PR 범위 밖)

isbn 표기가 섞이는 문제 자체는 그대로다. 등록 코드는 `selectedBook.isbn13` 만 저장하므로 ISBN10·K코드는 과거 유입분이지만, **ISBN10 ↔ ISBN13 은 계산으로 변환 가능**하다 — 중복 감지에 정규화를 넣으면 "모순" 류는 애초에 재독으로 잡힌다. 별도 PR 로 다룰 만하다.
