### PR TITLE
🔧 Chore: 운영 주소를 page0127.com으로 갱신한다

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -30,7 +30,9 @@ jobs:
       - name: /api/health 확인
         env:
           # 공개 엔드포인트라 secret이 아니다(인증 없이 호출된다).
-          TARGET: https://page0127.vercel.app/api/health
+          # 커스텀 도메인이 정식 주소다(2026-08-05). 옛 page0127.vercel.app은
+          # 308로 리다이렉트되는데 아래 curl에는 -L이 없어서 308을 실패로 본다.
+          TARGET: https://page0127.com/api/health
           # 응답에 반드시 들어 있어야 하는 문자열.
           #
           # ⚠️ 상태코드만 보면 안 된다: 이 앱은 존재하지 않는 경로에도

--- a/00_docs/10_시스템_구조.md
+++ b/00_docs/10_시스템_구조.md
@@ -81,7 +81,7 @@ Preview — PR을 열면 생기는 임시 세계
 
 | 무엇 | 주소 |
 | --- | --- |
-| 운영 사이트 | https://page0127.vercel.app |
+| 운영 사이트 | https://page0127.com |
 | Vercel 대시보드 | https://vercel.com/dashboard |
 
 ### 📕 Storybook — 컴포넌트 작업대
@@ -114,7 +114,7 @@ Preview — PR을 열면 생기는 임시 세계
 | 무엇 | 주소 |
 | --- | --- |
 | Sentry 이슈 목록 | https://stronger.sentry.io/projects/page0127/ |
-| 앱 안 에러 탭 | https://page0127.vercel.app/admin/errors |
+| 앱 안 에러 탭 | https://page0127.com/admin/errors |
 
 ### 그 밖에 서버가 호출하는 외부 API
 
@@ -157,7 +157,7 @@ Preview — PR을 열면 생기는 임시 세계
 | 항목             | 내용                                                            |
 | ---------------- | --------------------------------------------------------------- |
 | 어떻게 뜨나      | main에 머지되는 순간 Vercel이 자동 배포                          |
-| 주소             | `page0127.vercel.app`                                            |
+| 주소             | `page0127.com` (옛 `page0127.vercel.app`는 308 리다이렉트)       |
 | 데이터베이스     | **운영 Supabase 프로젝트** — 진짜 사용자의 기록                 |
 | 로그인           | 도메인을 바꾸면 Supabase Site URL·Google Secret도 같이 갱신해야 한다 |
 | 데이터의 무게    | 지우면 끝. 마이그레이션은 되돌리기 어렵다                        |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > 독서 기록을 책장·통계·AI 취향 분석·소셜 피드로 연결한 개인 프로젝트
 
-**Live**: [page0127.vercel.app](https://page0127.vercel.app/)
+**Live**: [page0127.com](https://page0127.com/)
 
 <!--
 TODO: 스크린샷/GIF 추가

--- a/apps/page0127/docs/operations-runbook.md
+++ b/apps/page0127/docs/operations-runbook.md
@@ -63,7 +63,7 @@ page0127 서비스의 상태 확인·백업·장애 대응 절차를 한곳에 �
 
 | 항목 | 값 |
 | --- | --- |
-| Monitor URL | `https://page0127.vercel.app/api/health` |
+| Monitor URL | `https://page0127.com/api/health` |
 | 방식 | HTTP(s) — 상태코드 200 확인 (가능하면 본문에 `"status":"ok"` 포함 검사) |
 | 주기 | 1~5분 |
 | 실패 판정 | 연속 2회 실패 시 알림 (일시적 흔들림으로 인한 오탐 방지) |


### PR DESCRIPTION
## 무엇을

커스텀 도메인 `page0127.com` 연결(2026-08-05)에 따라 옛 `page0127.vercel.app`을 가리키던 곳을 갱신한다.

## 왜

`uptime.yml`이 옛 주소의 `/api/health`를 5분마다 확인하는데, Vercel에서 옛 주소를 308 리다이렉트로 바꾸면 **워크플로가 깨진다.**

- `curl`에 `-L`이 없어 리다이렉트를 따라가지 않는다
- 판정 조건이 `code = 200`이라 308은 실패로 본다
- 사이트는 멀쩡한데 5분마다 오탐 알림이 오게 된다

**이 PR을 머지한 뒤에** Vercel에서 `page0127.vercel.app` → `page0127.com` 308 리다이렉트를 켜야 한다. 순서가 반대면 알림이 울린다.

## 검증

새 주소가 워크플로 판정 조건(`200` + `"database":"ok","schema":"ok"`)을 실제로 통과하는지 같은 방식으로 호출해 확인했다.

```
HTTP 200
{"status":"ok","checks":{"database":"ok","schema":"ok"}}
```

## 남긴 것

`docs/superpowers/specs/2026-07-28-track-e-share-og-design.md`의 옛 주소는 "그 시점에 그 주소로 확인했다"는 과거 기록이라 그대로 뒀다.