### PR TITLE
✨ Feat: 아이디를 한 번 바꿀 수 있게 한다

### DIFF
--- a/apps/page0127/app/api/_helpers/schemaContract.ts
+++ b/apps/page0127/app/api/_helpers/schemaContract.ts
@@ -31,8 +31,10 @@ export const SCHEMA_CONTRACT: SchemaProbe[] = [
   },
   {
     table: 'profiles',
-    columns: ['username', 'nickname'],
-    breaks: '로그인 후 모든 화면 (사용자 식별)',
+    // username_changed_at — 설정 화면이 "아이디 변경 기회가 남았는가"를 이 값으로 판단한다.
+    // NULL 이면 아직 안 바꾼 것. 컬럼이 없으면 설정 화면이 죽는다.
+    columns: ['username', 'nickname', 'username_changed_at'],
+    breaks: '로그인 후 모든 화면 (사용자 식별) · 설정의 아이디 변경',
   },
   {
     table: 'user_daily_visits',

--- a/apps/page0127/src/entities/profile/api/getProfile.ts
+++ b/apps/page0127/src/entities/profile/api/getProfile.ts
@@ -1,8 +1,12 @@
 import { createClient } from '@/shared/config/supabase/server';
 
 import { toIdentityDefaults } from '../model/identityDefaults';
+import { generateUsernameFromEmail, USERNAME_MAX_LENGTH } from '../model/username';
 
 import type { Profile } from '../types';
+
+/** Postgres 유니크 제약 위반. 같은 username 을 동시에 고른 가입자를 구분한다 */
+const UNIQUE_VIOLATION = '23505';
 
 /**
  * 사용자 프로필 조회 (Server Component용)
@@ -35,72 +39,48 @@ export const getProfile = async (userId: string): Promise<Profile | null> => {
   return profile;
 };
 
-/**
- * 이메일에서 username 생성 (abc@gmail.com -> abc)
- *
- * 학습 포인트:
- * - 이메일의 @ 앞부분을 username으로 사용
- * - 특수문자 제거하여 안전한 URL 생성
- *
- * @param email - 사용자 이메일
- * @returns username (예: abc)
- */
-const generateUsernameFromEmail = (email: string): string => {
-  // @ 앞부분만 추출
-  const localPart = email.split('@')[0];
+/** 접미사를 붙여도 20자를 넘지 않도록 앞부분을 자른다 */
+const withSuffix = (base: string, suffix: string): string =>
+  `${base.slice(0, USERNAME_MAX_LENGTH - suffix.length)}${suffix}`;
 
-  // 영문, 숫자, 언더스코어만 허용 (특수문자 제거)
-  const cleaned = localPart.replace(/[^a-zA-Z0-9_]/g, '');
-
-  // 소문자로 변환
-  return cleaned.toLowerCase();
-};
+/** 겹쳤을 때 쓸 무작위 접미사 — 소문자·숫자만이라 형식 규칙을 깨지 않는다 */
+const randomSuffix = (): string => Math.random().toString(36).slice(2, 8);
 
 /**
- * 고유한 username 생성 (중복 시 숫자 추가)
+ * 겹치지 않는 username 을 만든다.
  *
- * 학습 포인트:
- * - username이 중복되면 1, 2, 3... 추가
- * - 예: abc -> abc1 -> abc2
- * - 최대 100번 시도 (무한루프 방지)
+ * 기존 구현은 후보 하나마다 쿼리를 던져 **최대 101회 왕복**했다.
+ * 여기서는 후보를 한 번에 만들고 한 번의 `in` 조회로 걸러 낸다.
+ *
+ * ⚠️ 확인과 저장 사이의 경합은 여기서 막을 수 없다(같은 순간 같은 이름을 고른
+ *    두 가입자). 최종 방어선은 DB 의 유니크 제약이고, 저장에 실패하면
+ *    upsertProfile 이 무작위 이름으로 다시 시도한다.
  *
  * @param email - 사용자 이메일
- * @returns 고유한 username
+ * @returns 형식 규칙을 통과하고, 조회 시점에 비어 있던 username
  */
 export const generateUniqueUsername = async (
   email: string
 ): Promise<string> => {
   const supabase = await createClient();
-  const baseUsername = generateUsernameFromEmail(email);
+  const base = generateUsernameFromEmail(email);
 
-  // 1. 먼저 기본 username 시도
-  const { data: existing } = await supabase
+  // base, base1 … base20 을 후보로 둔다
+  const candidates = [
+    base,
+    ...Array.from({ length: 20 }, (_, i) => withSuffix(base, String(i + 1))),
+  ];
+
+  const { data } = await supabase
     .from('profiles')
     .select('username')
-    .eq('username', baseUsername)
-    .maybeSingle();
+    .in('username', candidates);
 
-  if (!existing) {
-    return baseUsername; // 중복 없으면 바로 반환
-  }
+  const taken = new Set((data ?? []).map((row) => row.username));
+  const free = candidates.find((candidate) => !taken.has(candidate));
 
-  // 2. 중복이 있으면 숫자 추가 (1부터 시작)
-  for (let i = 1; i <= 100; i++) {
-    const candidateUsername = `${baseUsername}${i}`;
-
-    const { data: duplicate } = await supabase
-      .from('profiles')
-      .select('username')
-      .eq('username', candidateUsername)
-      .maybeSingle();
-
-    if (!duplicate) {
-      return candidateUsername; // 사용 가능한 username 발견
-    }
-  }
-
-  // 100번 시도해도 실패하면 랜덤 숫자 추가
-  return `${baseUsername}${Date.now()}`;
+  // 21개가 전부 찼으면 무작위로 간다 (base 가 흔한 이름일 때)
+  return free ?? withSuffix(base, randomSuffix());
 };
 
 /**
@@ -138,19 +118,41 @@ export const upsertProfile = async (
     : toIdentityDefaults(metadata);
 
   // 4. upsert (값이 있는 항목만 추가, 없으면 기존 유지)
-  await supabase.from('profiles').upsert(
-    {
-      id: userId,
-      email,
-      ...(username && { username }), // username이 있을 때만 추가
-      ...(defaults.nickname && { nickname: defaults.nickname }),
-      ...(defaults.photoUrl && { photo_url: defaults.photoUrl }),
-      updated_at: new Date().toISOString(),
-    },
-    {
-      onConflict: 'id',
-    }
+  //
+  // username 은 경합에 질 수 있다 — 같은 순간 같은 이름을 고른 다른 가입자가
+  // 먼저 저장하면 유니크 제약(23505)에 걸린다. 그때는 무작위 이름으로 한 번 더
+  // 시도한다. 예전에는 에러를 통째로 무시해서, 실패하면 프로필 없이 조용히
+  // 넘어갔다가 ensureProfile 이 "프로필 생성에 실패했습니다"로 죽었다.
+  const save = (name: string | undefined) =>
+    supabase.from('profiles').upsert(
+      {
+        id: userId,
+        email,
+        ...(name && { username: name }), // username이 있을 때만 추가
+        ...(defaults.nickname && { nickname: defaults.nickname }),
+        ...(defaults.photoUrl && { photo_url: defaults.photoUrl }),
+        updated_at: new Date().toISOString(),
+      },
+      {
+        onConflict: 'id',
+      }
+    );
+
+  const { error } = await save(username);
+  if (!error) return;
+
+  // username 을 만들지 않은 호출(이미 있는 프로필)이면 재시도해도 결과가 같다
+  if (error.code !== UNIQUE_VIOLATION || !username) {
+    console.error('프로필 저장 실패:', error.message);
+    return;
+  }
+
+  const { error: retryError } = await save(
+    withSuffix(generateUsernameFromEmail(email), randomSuffix())
   );
+  if (retryError) {
+    console.error('프로필 저장 재시도 실패:', retryError.message);
+  }
 };
 
 /**

--- a/apps/page0127/src/entities/profile/model/username.test.ts
+++ b/apps/page0127/src/entities/profile/model/username.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateUsernameFromEmail,
+  normalizeUsername,
+  RESERVED_USERNAMES,
+  USERNAME_MAX_LENGTH,
+  validateUsername,
+} from './username';
+
+describe('normalizeUsername', () => {
+  it('앞뒤 공백을 없애고 소문자로 낮춘다', () => {
+    expect(normalizeUsername('  BookWorm  ')).toBe('bookworm');
+  });
+});
+
+describe('validateUsername', () => {
+  it('규칙에 맞으면 다듬어진 값을 돌려준다', () => {
+    expect(validateUsername('Book_Worm12')).toEqual({
+      ok: true,
+      value: 'book_worm12',
+    });
+  });
+
+  it('빈 값과 공백만 있는 값을 막는다', () => {
+    expect(validateUsername('')).toMatchObject({ ok: false, issue: 'empty' });
+    expect(validateUsername('   ')).toMatchObject({ ok: false, issue: 'empty' });
+  });
+
+  it('3자 미만을 막는다', () => {
+    expect(validateUsername('ab')).toMatchObject({
+      ok: false,
+      issue: 'too_short',
+    });
+  });
+
+  it('20자를 넘으면 막는다', () => {
+    expect(validateUsername('a'.repeat(21))).toMatchObject({
+      ok: false,
+      issue: 'too_long',
+    });
+    // 경계값 — 정확히 20자는 통과해야 한다
+    expect(validateUsername('a'.repeat(20)).ok).toBe(true);
+  });
+
+  it('하이픈·점·한글·공백처럼 URL에서 흔들리는 문자를 막는다', () => {
+    for (const bad of ['my-name', 'my.name', '책벌레', 'book worm', 'a@b']) {
+      expect(validateUsername(bad)).toMatchObject({
+        ok: false,
+        issue: 'invalid_chars',
+      });
+    }
+  });
+
+  it('라우트와 충돌하는 예약어를 막는다', () => {
+    // 'about' 을 쓰면 그 사람의 공개 서재가 소개 페이지에 가려진다
+    for (const reserved of ['about', 'settings', 'admin', 'books', 'login']) {
+      expect(validateUsername(reserved)).toMatchObject({
+        ok: false,
+        issue: 'reserved',
+      });
+    }
+  });
+
+  it('대문자로 친 예약어도 막는다 (소문자로 낮춘 뒤 판정한다)', () => {
+    expect(validateUsername('ADMIN')).toMatchObject({
+      ok: false,
+      issue: 'reserved',
+    });
+  });
+
+  it('길이와 문자가 둘 다 틀리면 길이를 먼저 알려 준다', () => {
+    // 'a!' 는 짧기도 하고 문자도 틀렸다. 고치기 쉬운 쪽을 먼저 말한다.
+    expect(validateUsername('a!')).toMatchObject({
+      ok: false,
+      issue: 'too_short',
+    });
+  });
+});
+
+describe('generateUsernameFromEmail', () => {
+  it('이메일 앞부분을 쓴다', () => {
+    expect(generateUsernameFromEmail('bookworm@gmail.com')).toBe('bookworm');
+  });
+
+  it('허용되지 않는 문자를 걸러 낸다', () => {
+    expect(generateUsernameFromEmail('hong.gil-dong@gmail.com')).toBe(
+      'honggildong'
+    );
+  });
+
+  it('20자를 넘으면 잘라 낸다', () => {
+    const long = `${'a'.repeat(30)}@gmail.com`;
+    expect(generateUsernameFromEmail(long)).toHaveLength(USERNAME_MAX_LENGTH);
+  });
+
+  it('ASCII가 하나도 없는 주소에서 빈 문자열을 만들지 않는다', () => {
+    // 기존 구현은 여기서 '' 를 돌려줘 로그인 후 / 로 튕겼다
+    expect(generateUsernameFromEmail('한글이름@naver.com')).toBe('reader');
+  });
+
+  it('너무 짧은 앞부분은 쓰지 않는다', () => {
+    expect(generateUsernameFromEmail('ab@gmail.com')).toBe('reader');
+  });
+
+  it('예약어와 겹치는 앞부분은 쓰지 않는다', () => {
+    expect(generateUsernameFromEmail('admin@gmail.com')).toBe('reader');
+  });
+
+  it('결과는 항상 형식 규칙을 통과한다', () => {
+    const emails = [
+      'bookworm@gmail.com',
+      '한글@naver.com',
+      'ab@x.com',
+      'admin@x.com',
+      '...@x.com',
+      `${'z'.repeat(40)}@x.com`,
+    ];
+    for (const email of emails) {
+      expect(validateUsername(generateUsernameFromEmail(email)).ok).toBe(true);
+    }
+  });
+});
+
+describe('RESERVED_USERNAMES', () => {
+  it('전부 소문자다 (판정 전에 소문자로 낮추므로 대문자가 섞이면 영영 안 걸린다)', () => {
+    for (const word of RESERVED_USERNAMES) {
+      expect(word).toBe(word.toLowerCase());
+    }
+  });
+});

--- a/apps/page0127/src/entities/profile/model/username.ts
+++ b/apps/page0127/src/entities/profile/model/username.ts
@@ -1,0 +1,158 @@
+/**
+ * 아이디(username) 규칙 — 화면과 서버가 같은 판단을 하도록 한 곳에 모은다.
+ *
+ * ⚠️ 이 파일은 DB 제약의 **거울**이다. 진짜 계약은
+ *    `supabase/migrations/20260805000000_username_change_policy.sql` 에 있고,
+ *    여기 규칙은 "저장하기 전에 친절하게 알려 주기" 위한 것이다.
+ *    한쪽만 고치면 사용자는 통과했다고 생각한 값에서 DB 에러를 본다.
+ *    → 규칙을 바꾸려면 **반드시 마이그레이션과 함께** 바꾼다.
+ */
+
+/** 아이디 최소 길이 (DB CHECK 과 동일) */
+export const USERNAME_MIN_LENGTH = 3;
+/** 아이디 최대 길이 (DB CHECK 과 동일) */
+export const USERNAME_MAX_LENGTH = 20;
+
+/** 허용 문자: 영소문자·숫자·언더스코어. 대문자를 막아 /Hong 과 /hong 혼란을 없앤다 */
+const USERNAME_PATTERN = /^[a-z0-9_]+$/;
+
+/**
+ * 공개 서재 주소로 쓸 수 없는 값.
+ *
+ * Next.js 는 정적 경로를 동적 경로보다 먼저 매칭하므로, username 이 'about' 인
+ * 사용자가 생기면 그 사람의 서재는 영원히 열리지 않는다.
+ * `is_reserved_username()` (마이그레이션)과 같은 목록을 유지한다.
+ */
+export const RESERVED_USERNAMES: ReadonlySet<string> = new Set([
+  // 실제 라우트 (app/ 최상위 세그먼트)
+  'admin',
+  'api',
+  'auth',
+  'login',
+  'logout',
+  'settings',
+  'books',
+  'dashboard',
+  'feed',
+  'notifications',
+  'search',
+  'about',
+  'contact',
+  'privacy',
+  'terms',
+  // Next.js 파일 규칙이 만드는 최상위 경로
+  'sitemap',
+  'sitemap.xml',
+  'robots',
+  'robots.txt',
+  'opengraph-image',
+  'icon',
+  'favicon',
+  'favicon.ico',
+  '_next',
+  'static',
+  'public',
+  'well-known',
+  // 아직 없지만 만들면 충돌하는 것들
+  'help',
+  'support',
+  'blog',
+  'pricing',
+  'signup',
+  'register',
+  'me',
+  'new',
+  'edit',
+  'delete',
+  'account',
+  'profile',
+  'user',
+  'users',
+  'null',
+  'undefined',
+  'page0127',
+]);
+
+/** 검증 실패 사유 — UI 가 문구를 고르고, 테스트가 이 값으로 단언한다 */
+export type UsernameIssue =
+  | 'empty'
+  | 'too_short'
+  | 'too_long'
+  | 'invalid_chars'
+  | 'reserved';
+
+export type UsernameCheck =
+  | { ok: true; value: string }
+  | { ok: false; issue: UsernameIssue; message: string };
+
+const MESSAGES: Record<UsernameIssue, string> = {
+  empty: '아이디를 입력해 주세요.',
+  too_short: `아이디는 ${USERNAME_MIN_LENGTH}자 이상이어야 해요.`,
+  too_long: `아이디는 ${USERNAME_MAX_LENGTH}자 이하여야 해요.`,
+  invalid_chars: '영문 소문자, 숫자, 밑줄(_)만 쓸 수 있어요.',
+  reserved: '이미 서비스가 쓰고 있는 주소예요. 다른 아이디를 골라 주세요.',
+};
+
+/**
+ * 입력을 저장 가능한 형태로 다듬는다 (공백 제거 + 소문자).
+ *
+ * 사용자가 대문자로 쳤다고 거절하기보다 조용히 낮춰 준다 —
+ * 대문자 금지는 우리 사정이지 사용자의 실수가 아니다.
+ */
+export const normalizeUsername = (input: string): string =>
+  input.trim().toLowerCase();
+
+/**
+ * 아이디가 규칙에 맞는지 본다. **중복은 보지 않는다** (DB 를 봐야 알 수 있다).
+ *
+ * @param input 사용자가 친 값 (다듬기 전 원본을 그대로 넘겨도 된다)
+ */
+export const validateUsername = (input: string): UsernameCheck => {
+  const value = normalizeUsername(input);
+
+  if (value.length === 0) {
+    return { ok: false, issue: 'empty', message: MESSAGES.empty };
+  }
+  if (value.length < USERNAME_MIN_LENGTH) {
+    return { ok: false, issue: 'too_short', message: MESSAGES.too_short };
+  }
+  if (value.length > USERNAME_MAX_LENGTH) {
+    return { ok: false, issue: 'too_long', message: MESSAGES.too_long };
+  }
+  // 길이를 먼저 보는 이유: 'ab!' 처럼 둘 다 틀렸을 때 더 고치기 쉬운 쪽을 알려 준다
+  if (!USERNAME_PATTERN.test(value)) {
+    return {
+      ok: false,
+      issue: 'invalid_chars',
+      message: MESSAGES.invalid_chars,
+    };
+  }
+  if (RESERVED_USERNAMES.has(value)) {
+    return { ok: false, issue: 'reserved', message: MESSAGES.reserved };
+  }
+
+  return { ok: true, value };
+};
+
+/**
+ * 가입 시 이메일에서 아이디 후보를 만든다.
+ *
+ * 기존 구현에는 결함이 세 개 있었다.
+ * 1. `한글@naver.com` 처럼 ASCII 가 없는 주소면 **빈 문자열**이 나와
+ *    로그인 후 `/${''}` = `/` 로 튕겼다.
+ * 2. 2자 이하 주소(`ab@`)가 그대로 통과해 길이 규칙을 깼다.
+ * 3. `admin@` 이면 예약어와 충돌했다.
+ * 여기서는 셋 다 막고, 못 쓰는 값이면 `reader` 접두사로 갈아탄다.
+ *
+ * @returns 형식·예약어 규칙을 통과하는 후보 (중복 여부는 호출한 쪽이 확인한다)
+ */
+export const generateUsernameFromEmail = (email: string): string => {
+  const localPart = email.split('@')[0] ?? '';
+  const cleaned = localPart
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '')
+    .slice(0, USERNAME_MAX_LENGTH);
+
+  // 규칙을 통과하지 못하는 후보는 쓰지 않는다 — 무작위 접미사로 대체된다
+  return validateUsername(cleaned).ok ? cleaned : 'reader';
+};

--- a/apps/page0127/src/entities/profile/types/index.ts
+++ b/apps/page0127/src/entities/profile/types/index.ts
@@ -30,6 +30,12 @@ export type Profile = {
   /** 사용자 고유 ID (공개 서재 URL용, 예: abc, abc1, abc2) */
   username: string | null;
 
+  /**
+   * 아이디를 바꾼 시각. null 이면 가입 시 자동 발급된 상태(변경 기회 1회 남음).
+   * 값을 채우는 것은 DB 트리거다 — 클라이언트가 보낸 값은 채택되지 않는다.
+   */
+  username_changed_at: string | null;
+
   /** 닉네임 */
   nickname: string | null;
 

--- a/apps/page0127/src/features/profile/api/updateUsernameAction.ts
+++ b/apps/page0127/src/features/profile/api/updateUsernameAction.ts
@@ -1,0 +1,163 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createClient } from '@/shared/config/supabase/server';
+
+import {
+  normalizeUsername,
+  validateUsername,
+} from '@/entities/profile/model/username';
+
+/**
+ * 아이디(공개 서재 주소) 변경 — 평생 한 번.
+ *
+ * 왜 별도 액션인가:
+ * 프로필 저장(updateProfileAction)과 섞으면 "닉네임만 바꾸려다 아이디까지 소진"하는
+ * 사고가 난다. 되돌릴 수 없는 변경이므로 입구를 따로 둔다.
+ *
+ * ⚠️ 여기 검사는 사용자에게 친절한 메시지를 주기 위한 것이고,
+ *    진짜 방어선은 DB 다(형식 CHECK · 예약어 CHECK · 유니크 · 1회 트리거).
+ *    RLS 가 컬럼을 막지 못해 브라우저에서 직접 UPDATE 를 던질 수 있기 때문에,
+ *    이 액션을 통과하지 않는 경로도 DB 가 똑같이 막아야 한다.
+ */
+
+export type UsernameActionState = {
+  status: 'idle' | 'success' | 'error';
+  message: string;
+  /** 성공 시 새 아이디 — 화면이 공개 서재 링크를 갱신할 때 쓴다 */
+  username?: string;
+};
+
+/** DB 트리거가 올리는 예외 메시지 (마이그레이션과 동일 문자열) */
+const CHANGE_LIMIT_ERROR = 'username_change_limit_exceeded';
+/** Postgres 유니크 제약 위반 */
+const UNIQUE_VIOLATION = '23505';
+/** CHECK 제약 위반 — 화면 검사를 우회해 들어온 값 */
+const CHECK_VIOLATION = '23514';
+
+export const updateUsernameAction = async (
+  _prevState: UsernameActionState,
+  formData: FormData
+): Promise<UsernameActionState> => {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { status: 'error', message: '로그인이 필요합니다.' };
+  }
+
+  // 형식·예약어를 먼저 본다 (중복은 DB 만 안다)
+  const raw = (formData.get('username') as string) ?? '';
+  const check = validateUsername(raw);
+  if (!check.ok) {
+    return { status: 'error', message: check.message };
+  }
+  const nextUsername = check.value;
+
+  // 현재 상태를 서버가 직접 읽는다 — 화면이 보낸 값을 믿지 않는다
+  const { data: current, error: readError } = await supabase
+    .from('profiles')
+    .select('username, username_changed_at')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (readError || !current) {
+    console.error('프로필 조회 실패:', readError?.message);
+    return { status: 'error', message: '프로필을 불러올 수 없습니다.' };
+  }
+
+  if (current.username_changed_at) {
+    return {
+      status: 'error',
+      message: '아이디는 한 번만 변경할 수 있어요.',
+    };
+  }
+
+  // 같은 값이면 기회를 쓰지 않고 조용히 끝낸다 (트리거도 변경으로 보지 않는다)
+  if (current.username === nextUsername) {
+    return {
+      status: 'success',
+      message: '지금 아이디와 같아요.',
+      username: nextUsername,
+    };
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ username: nextUsername, updated_at: new Date().toISOString() })
+    .eq('id', user.id);
+
+  if (error) {
+    if (error.message.includes(CHANGE_LIMIT_ERROR)) {
+      return { status: 'error', message: '아이디는 한 번만 변경할 수 있어요.' };
+    }
+    if (error.code === UNIQUE_VIOLATION) {
+      return { status: 'error', message: '이미 쓰고 있는 아이디예요.' };
+    }
+    if (error.code === CHECK_VIOLATION) {
+      return { status: 'error', message: '쓸 수 없는 아이디예요.' };
+    }
+    console.error('아이디 변경 실패:', error.message);
+    return { status: 'error', message: '아이디 변경에 실패했습니다.' };
+  }
+
+  // 예전 주소는 이 순간부터 404 다. 공개 서재와 설정 화면을 함께 갱신한다.
+  revalidatePath('/settings');
+  if (current.username) revalidatePath(`/${current.username}`);
+  revalidatePath(`/${nextUsername}`);
+
+  return {
+    status: 'success',
+    message: '아이디를 변경했어요.',
+    username: nextUsername,
+  };
+};
+
+/**
+ * 입력 중 중복 확인 — 저장 전에 "쓸 수 있는지"만 본다.
+ *
+ * 여기서 통과해도 저장 시점에 다른 사람이 먼저 가져갈 수 있다(경합).
+ * 그래서 이건 편의 기능이고, 최종 판정은 언제나 저장 결과다.
+ */
+export type UsernameAvailability =
+  | { available: true }
+  | { available: false; message: string };
+
+export const checkUsernameAvailability = async (
+  raw: string
+): Promise<UsernameAvailability> => {
+  const check = validateUsername(raw);
+  if (!check.ok) {
+    return { available: false, message: check.message };
+  }
+
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { available: false, message: '로그인이 필요합니다.' };
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('username', normalizeUsername(raw))
+    .maybeSingle();
+
+  if (error) {
+    console.error('아이디 중복 확인 실패:', error.message);
+    return { available: false, message: '확인에 실패했어요. 잠시 후 다시 시도해 주세요.' };
+  }
+
+  // 지금 내 아이디면 "쓸 수 있다"로 본다 (바꾸지 않는 선택지)
+  if (data && data.id !== user.id) {
+    return { available: false, message: '이미 쓰고 있는 아이디예요.' };
+  }
+
+  return { available: true };
+};

--- a/apps/page0127/src/features/profile/ui/ProfileSettingsForm.tsx
+++ b/apps/page0127/src/features/profile/ui/ProfileSettingsForm.tsx
@@ -18,6 +18,7 @@ import {
   type ProfileActionState,
   updateProfileAction,
 } from '@/features/profile/api/updateProfileAction';
+import { UsernameChangeDialog } from '@/features/profile/ui/UsernameChangeDialog';
 
 import { AvatarUpload } from './AvatarUpload';
 
@@ -40,6 +41,56 @@ type ProfileSettingsFormMyAccountProps = {
   username: string | null;
   onLogout: () => void;
 };
+
+type ProfileSettingsFormUsernameProps = {
+  inputId: string;
+  username: string | null;
+  /** null 이면 아직 안 바꾼 것 — 변경 기회가 한 번 남아 있다 */
+  changedAt: string | null;
+};
+
+/**
+ * 아이디 칸.
+ *
+ * 가입 시 아이디는 이메일 앞부분에서 자동으로 만들어진다. 그 사실을 모르면
+ * 자기 이메일 앞부분이 공개 주소가 된 줄도 모르고 지나가므로, 아직 바꾸지 않은
+ * 사람에게는 그 사정을 먼저 알려 바꿀지 정하게 한다.
+ */
+const ProfileSettingsFormUsername = ({
+  inputId,
+  username,
+  changedAt,
+}: ProfileSettingsFormUsernameProps) => (
+  <div className='space-y-2'>
+    <Label htmlFor={inputId}>아이디</Label>
+    <div className='flex items-center gap-2'>
+      {/* name 이 없으므로 이 값은 프로필 저장 FormData 에 실리지 않는다 */}
+      <Input
+        id={inputId}
+        type='text'
+        value={username || ''}
+        disabled
+        className='bg-muted'
+      />
+      {username && !changedAt && (
+        <UsernameChangeDialog currentUsername={username} />
+      )}
+    </div>
+    <p className='text-xs text-text-subtle'>
+      공개 서재 주소 /{username}
+    </p>
+    {changedAt ? (
+      <p className='text-xs text-text-subtle'>
+        아이디는 한 번만 바꿀 수 있어요. 이미 변경해서 더는 바꿀 수 없습니다.
+      </p>
+    ) : (
+      <p className='text-xs text-text-subtle'>
+        가입할 때 이메일 앞부분으로 자동으로 만들어진 아이디예요.{' '}
+        <strong>한 번만</strong> 바꿀 수 있습니다.
+      </p>
+    )}
+  </div>
+);
 
 const ProfileSettingsFormPhoto = ({
   currentPhotoUrl,
@@ -194,20 +245,13 @@ export const ProfileSettingsForm = ({ profile }: ProfileSettingsFormProps) => {
             />
           </div>
 
-          {/* 아이디 (읽기 전용) — 공개 서재 URL에 쓰인다 */}
-          <div className='space-y-2'>
-            <Label htmlFor={ids.username}>아이디</Label>
-            <Input
-              id={ids.username}
-              type='text'
-              value={profile.username || ''}
-              disabled
-              className='bg-muted'
-            />
-            <p className='text-xs text-text-subtle'>
-              공개 서재 주소 /{profile.username}
-            </p>
-          </div>
+          {/* 아이디 — 공개 서재 URL에 쓰인다. 변경은 평생 한 번뿐이라
+              이 폼(name 없음 → 전송 안 함)이 아니라 별도 다이얼로그가 맡는다. */}
+          <ProfileSettingsForm.Username
+            inputId={ids.username}
+            username={profile.username}
+            changedAt={profile.username_changed_at}
+          />
 
           {/* 닉네임 — 비제어(defaultValue) + name 으로 FormData 자동 수집 */}
           <div className='space-y-2'>
@@ -264,5 +308,6 @@ export const ProfileSettingsForm = ({ profile }: ProfileSettingsFormProps) => {
 };
 
 ProfileSettingsForm.Photo = ProfileSettingsFormPhoto;
+ProfileSettingsForm.Username = ProfileSettingsFormUsername;
 ProfileSettingsForm.MyAccount = ProfileSettingsFormMyAccount;
 ProfileSettingsForm.DangerZone = ProfileSettingsFormDangerZone;

--- a/apps/page0127/src/features/profile/ui/UsernameChangeDialog.tsx
+++ b/apps/page0127/src/features/profile/ui/UsernameChangeDialog.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useActionState, useEffect, useId, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Input,
+  Label,
+} from '@repo/ui';
+import { Check, Loader2, X } from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+  normalizeUsername,
+  USERNAME_MAX_LENGTH,
+  validateUsername,
+} from '@/entities/profile/model/username';
+
+import {
+  checkUsernameAvailability,
+  updateUsernameAction,
+  type UsernameActionState,
+} from '@/features/profile/api/updateUsernameAction';
+
+type UsernameChangeDialogProps = {
+  currentUsername: string;
+};
+
+const initialState: UsernameActionState = { status: 'idle', message: '' };
+
+/** 입력이 멈춘 뒤 중복을 확인하기까지 기다리는 시간 */
+const CHECK_DEBOUNCE_MS = 400;
+
+/**
+ * 미리보기에 쓸 호스트. 도메인을 여기 적어 두면 커스텀 도메인을 사는 순간 틀어지므로
+ * 빌드에 박히는 사이트 주소에서 뽑아 쓴다(프로토콜은 빼고 보여 준다).
+ */
+const SITE_HOST = (process.env.NEXT_PUBLIC_SITE_URL ?? '').replace(
+  /^https?:\/\//,
+  ''
+);
+
+/** 입력 한 글자마다의 판정 결과 — 상태가 아니라 렌더 중 계산되는 파생값이다 */
+type FieldState =
+  | { kind: 'idle' }
+  | { kind: 'invalid'; message: string }
+  | { kind: 'checking' }
+  | { kind: 'available' }
+  | { kind: 'taken'; message: string };
+
+/**
+ * 아이디 변경 다이얼로그 — 평생 한 번뿐인 변경이라 별도 입구로 둔다.
+ *
+ * 왜 다이얼로그인가:
+ * 설정 폼 안에 두면 닉네임을 고치다가 아이디까지 바꿔 버리는 사고가 난다.
+ * (HTML 은 form 중첩을 허용하지 않아서, 어차피 별도 form 이 필요하기도 하다)
+ *
+ * 실시간 확인은 편의일 뿐이다 — 통과했어도 저장 순간에 남이 먼저 가져갈 수 있고,
+ * 최종 판정은 언제나 서버 액션의 결과다.
+ */
+export const UsernameChangeDialog = ({
+  currentUsername,
+}: UsernameChangeDialogProps) => {
+  const router = useRouter();
+  const fieldId = useId();
+
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState(currentUsername);
+
+  // 중복 확인 결과만 상태로 둔다. 어떤 값을 확인한 결과인지 함께 들고 있어야
+  // 입력이 더 진행된 뒤 도착한 낡은 응답을 화면에 쓰지 않는다.
+  const [checked, setChecked] = useState<{
+    value: string;
+    available: boolean;
+    message: string;
+  } | null>(null);
+
+  // 후처리(토스트·닫기·새로고침)를 effect 가 아니라 액션 안에서 한다.
+  // effect 로 하면 state 변화를 뒤늦게 관찰하는 셈이라 setState 가 렌더를 한 번 더 돈다.
+  const [, formAction, isPending] = useActionState(
+    async (prev: UsernameActionState, formData: FormData) => {
+      const next = await updateUsernameAction(prev, formData);
+      if (next.status === 'success') {
+        toast.success(next.message);
+        setOpen(false);
+        router.refresh();
+      } else if (next.status === 'error') {
+        toast.error(next.message);
+      }
+      return next;
+    },
+    initialState
+  );
+
+  const normalized = normalizeUsername(value);
+  const isUnchanged = normalized === currentUsername;
+  // 형식 판정은 동기적이라 상태로 둘 이유가 없다 — 렌더 중에 계산한다
+  const formatCheck = validateUsername(value);
+
+  // 서버에 물어볼 값. null 이면 물어볼 것이 없다(안 바꿨거나 형식이 틀렸다).
+  // formatCheck 는 매 렌더 새 객체라 그대로 의존성에 두면 effect 가 매번 돈다 —
+  // 실제로 달라지는 문자열만 꺼내 둔다.
+  const candidate = !isUnchanged && formatCheck.ok ? formatCheck.value : null;
+
+  // 입력이 멈추면 중복을 확인한다. 형식이 틀리면 서버까지 가지 않는다.
+  useEffect(() => {
+    if (candidate === null) return;
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      const result = await checkUsernameAvailability(candidate);
+      if (cancelled) return;
+      setChecked({
+        value: candidate,
+        available: result.available,
+        message: result.available ? '' : result.message,
+      });
+    }, CHECK_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [candidate]);
+
+  // 화면에 보일 상태는 전부 파생값이다
+  const field: FieldState = isUnchanged
+    ? { kind: 'idle' }
+    : !formatCheck.ok
+      ? { kind: 'invalid', message: formatCheck.message }
+      : checked?.value !== normalized
+        ? { kind: 'checking' } // 아직 이 값에 대한 응답이 없다
+        : checked.available
+          ? { kind: 'available' }
+          : { kind: 'taken', message: checked.message };
+
+  const canSubmit = field.kind === 'available' && !isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type='button' variant='outline' size='sm'>
+          변경
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>아이디 변경</DialogTitle>
+          <DialogDescription>
+            공개 서재 주소가 바뀝니다. <strong>한 번만 바꿀 수 있고</strong>,
+            바꾸면 예전 주소로 들어오던 링크는 열리지 않아요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form action={formAction} className='space-y-4'>
+          <div className='space-y-2'>
+            <Label htmlFor={fieldId}>새 아이디</Label>
+            <Input
+              id={fieldId}
+              name='username'
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              maxLength={USERNAME_MAX_LENGTH}
+              autoComplete='off'
+              // 모바일 키보드가 첫 글자를 대문자로 올리면 매번 교정 문구를 보게 된다
+              autoCapitalize='none'
+              spellCheck={false}
+              aria-describedby={`${fieldId}-help`}
+            />
+
+            {/* 주소를 미리 보여 준다 — 바뀌는 것이 "아이디"가 아니라 "내 링크"임을 알린다 */}
+            <p id={`${fieldId}-help`} className='text-xs text-text-subtle'>
+              {SITE_HOST}/<strong>{normalized || '...'}</strong>
+            </p>
+
+            <FieldMessage state={field} />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setOpen(false)}
+            >
+              취소
+            </Button>
+            <Button type='submit' disabled={!canSubmit}>
+              {isPending ? '변경 중…' : '변경하기'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+/** 입력 상태를 한 줄로 말한다. 색만으로 알리지 않고 아이콘·문구를 함께 둔다 */
+const FieldMessage = ({ state }: { state: FieldState }) => {
+  if (state.kind === 'idle') return null;
+
+  if (state.kind === 'checking') {
+    return (
+      <p className='flex items-center gap-1.5 text-xs text-text-subtle'>
+        <Loader2 aria-hidden className='size-3.5 animate-spin' />
+        확인 중…
+      </p>
+    );
+  }
+
+  if (state.kind === 'available') {
+    return (
+      <p role='status' className='flex items-center gap-1.5 text-xs text-primary'>
+        <Check aria-hidden className='size-3.5' />
+        쓸 수 있는 아이디예요.
+      </p>
+    );
+  }
+
+  return (
+    <p
+      role='alert'
+      className='flex items-center gap-1.5 text-xs text-destructive'
+    >
+      <X aria-hidden className='size-3.5' />
+      {state.message}
+    </p>
+  );
+};

--- a/apps/page0127/src/shared/config/schemaVersion.ts
+++ b/apps/page0127/src/shared/config/schemaVersion.ts
@@ -11,7 +11,7 @@
  * 마이그레이션을 추가했다면:
  *   이 값을 새 파일의 앞 14자리 번호로 바꾼다. (예: 20260729000000)
  */
-export const EXPECTED_MIGRATION_VERSION = '20260729000002';
+export const EXPECTED_MIGRATION_VERSION = '20260805000000';
 
 /**
  * 스키마 대조 결과.

--- a/supabase/migrations/20260805000000_username_change_policy.sql
+++ b/supabase/migrations/20260805000000_username_change_policy.sql
@@ -1,0 +1,188 @@
+-- 아이디(username) 변경 정책 — 형식·중복·예약어·1회 제한을 DB에서 강제한다
+-- 작성일: 2026-08-05
+--
+-- 왜 DB인가:
+-- profiles 의 UPDATE 정책은 행 단위(auth.uid() = id)라 컬럼을 막지 못한다.
+-- 즉 로그인 사용자는 브라우저에서 anon 키로 자기 username 을 무제한 바꿀 수 있다.
+-- 서버 액션에만 "1회 제한"을 두면 우회되므로, 계약을 여기에 박는다.
+
+-- =====================================================
+-- 1. 변경 시각 컬럼 — NULL 이면 "아직 한 번도 안 바꿈"
+-- =====================================================
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS username_changed_at timestamptz;
+
+COMMENT ON COLUMN profiles.username_changed_at IS
+  '아이디를 바꾼 시각. NULL 이면 가입 시 자동 발급된 상태(변경 기회 1회 남음).';
+
+-- =====================================================
+-- 2. 예약어 — /[username] 이 정적 라우트와 충돌하는 것을 막는다
+-- =====================================================
+--
+-- Next.js 는 정적 경로를 동적 경로보다 먼저 매칭한다. 그래서 username 이
+-- 'about' 인 사용자가 생기면 그 사람의 공개 서재는 영원히 열리지 않고
+-- 소개 페이지가 뜬다. 라우트가 늘면 이 목록에도 한 줄 추가해야 한다.
+--
+-- IMMUTABLE 이어야 CHECK 제약에서 쓸 수 있다(입력이 같으면 항상 같은 답).
+CREATE OR REPLACE FUNCTION is_reserved_username(candidate text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT lower(candidate) = ANY (ARRAY[
+    -- 실제 라우트 (app/ 최상위 세그먼트)
+    'admin', 'api', 'auth', 'login', 'logout', 'settings',
+    'books', 'dashboard', 'feed', 'notifications', 'search',
+    'about', 'contact', 'privacy', 'terms',
+    -- Next.js 파일 규칙이 만드는 최상위 경로
+    'sitemap', 'sitemap.xml', 'robots', 'robots.txt',
+    'opengraph-image', 'icon', 'favicon', 'favicon.ico',
+    '_next', 'static', 'public', 'well-known',
+    -- 아직 없지만 만들면 충돌하는 것들 — 미리 잡아둔다
+    'help', 'support', 'blog', 'pricing', 'signup', 'register',
+    'me', 'new', 'edit', 'delete', 'account', 'profile', 'user', 'users',
+    'null', 'undefined', 'page0127'
+  ]);
+$$;
+
+COMMENT ON FUNCTION is_reserved_username(text) IS
+  '공개 서재 주소로 쓸 수 없는 아이디인지 판정. 정적 라우트와의 충돌 방지용.';
+
+-- =====================================================
+-- 3. 기존 데이터 정리 — 제약을 걸기 전에 위반 행을 먼저 고친다
+-- =====================================================
+--
+-- 제약을 그냥 걸면 이미 있는 행 때문에 마이그레이션이 실패한다.
+-- 순서가 중요하다: 형식 → 예약어 → 대소문자 중복.
+
+-- 3-1. 형식 위반(NULL·빈 문자열·너무 짧음·허용 밖 문자)을 안전한 값으로 교체
+--      generateUsernameFromEmail 이 한글 이메일에서 빈 문자열을 만들던 결함의 잔재를 함께 흡수한다.
+UPDATE profiles
+SET username = 'reader' || substr(md5(id::text), 1, 8)
+WHERE username IS NULL
+   OR username !~ '^[a-z0-9_]{3,20}$';
+
+-- 3-2. 예약어를 쓰고 있는 행 교체
+UPDATE profiles
+SET username = 'reader' || substr(md5(id::text), 1, 8)
+WHERE is_reserved_username(username);
+
+-- 3-3. lower() 중복 제거 — 유니크 인덱스를 걸기 위한 안전망.
+--      실제로는 3-1 이 대문자를 이미 전부 걷어냈고 기존 UNIQUE 제약이 완전 동일한
+--      값을 막고 있어 여기서 걸리는 행은 보통 0건이다(로컬 검증에서도 0건).
+--      제약이 없는 DB에 이 마이그레이션이 적용되는 경우를 대비해 남겨 둔다.
+--      걸릴 경우 가장 먼저 만들어진 계정이 아이디를 지키고 나머지가 바뀐다.
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY lower(username)
+           ORDER BY created_at NULLS LAST, id
+         ) AS rn
+  FROM profiles
+  WHERE username IS NOT NULL
+)
+UPDATE profiles p
+SET username = 'reader' || substr(md5(p.id::text), 1, 8)
+FROM ranked r
+WHERE p.id = r.id AND r.rn > 1;
+
+-- =====================================================
+-- 4. 형식·예약어 제약
+-- =====================================================
+--
+-- 3~20자, 영소문자·숫자·언더스코어만. 대문자를 아예 못 넣게 해서
+-- "/Hong 과 /hong 이 다른 주소"인 혼란을 원천 차단한다.
+ALTER TABLE profiles
+  DROP CONSTRAINT IF EXISTS profiles_username_format;
+
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_username_format
+  CHECK (username IS NULL OR username ~ '^[a-z0-9_]{3,20}$');
+
+ALTER TABLE profiles
+  DROP CONSTRAINT IF EXISTS profiles_username_not_reserved;
+
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_username_not_reserved
+  CHECK (username IS NULL OR NOT is_reserved_username(username));
+
+-- =====================================================
+-- 5. 대소문자 구분 없는 유일성
+-- =====================================================
+--
+-- 기존 TEXT UNIQUE 는 'Hong' 과 'hong' 을 서로 다른 값으로 본다.
+-- 4번 제약이 대문자를 막으므로 실질적으로는 중복될 수 없지만,
+-- 인덱스로도 못 박아 두어 나중에 제약을 완화해도 안전하게 만든다.
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_username_lower_key
+  ON profiles (lower(username))
+  WHERE username IS NOT NULL;
+
+-- =====================================================
+-- 6. 변경 1회 제한 트리거
+-- =====================================================
+--
+-- 서버 액션이 아니라 여기서 막는다(파일 상단 주석 참조).
+--
+-- ⚠️ username 이 바뀔 때만 검사하면 뚫린다. RLS 가 컬럼을 막지 못하므로
+--    사용자는 username 은 그대로 둔 채 username_changed_at 만 NULL 로 되돌려
+--    변경 기회를 무한히 리셋할 수 있다(로컬에서 재현 확인함).
+--    그래서 username_changed_at 은 **서버 소유 컬럼**으로 취급한다 —
+--    일반 사용자가 보낸 값은 어떤 경우에도 채택하지 않는다.
+CREATE OR REPLACE FUNCTION enforce_username_change_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  -- 운영자(service_role)는 제한을 받지 않는다.
+  -- 값을 덮지 않고 그대로 통과시키므로, 지원 요청("오타로 바꿨어요")이 오면
+  -- username_changed_at 을 NULL 로 되돌려 기회를 한 번 더 줄 수 있다.
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  -- 클라이언트가 보낸 username_changed_at 은 버리고 기존 값을 유지한다.
+  -- (아이디를 안 바꾸는 일반 저장에서도 반드시 거쳐야 하는 줄이다)
+  NEW.username_changed_at := OLD.username_changed_at;
+
+  -- 아이디가 그대로면 여기서 끝(닉네임·사진만 바꾼 일반 저장)
+  IF NEW.username IS NOT DISTINCT FROM OLD.username THEN
+    RETURN NEW;
+  END IF;
+
+  -- 이미 한 번 바꿨으면 거부
+  IF OLD.username_changed_at IS NOT NULL THEN
+    RAISE EXCEPTION 'username_change_limit_exceeded'
+      USING HINT = '아이디는 한 번만 변경할 수 있습니다.';
+  END IF;
+
+  -- 변경 시각은 서버 시각으로 기록한다
+  NEW.username_changed_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS profiles_username_change_limit ON profiles;
+
+CREATE TRIGGER profiles_username_change_limit
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_username_change_limit();
+
+-- =====================================================
+-- 7. 권한 — 함수는 필요한 롤에만 연다
+-- =====================================================
+--
+-- 20260725000001_lock_down_function_privileges.sql 의 방침을 따른다:
+-- PUBLIC 에서 회수하고 실제로 쓰는 롤에만 부여한다.
+REVOKE ALL ON FUNCTION is_reserved_username(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION is_reserved_username(text) TO anon, authenticated, service_role;
+
+REVOKE ALL ON FUNCTION enforce_username_change_limit() FROM PUBLIC;
+
+-- Migration 완료
+-- - username 형식(3~20자 소문자/숫자/_)·예약어·대소문자 무시 유일성을 DB가 강제
+-- - 변경은 1회. 트리거가 막으므로 클라이언트에서 우회 불가
+-- - username_changed_at 이 NULL 이면 아직 기회가 남은 상태


### PR DESCRIPTION
## 왜

가입하면 **이메일 앞부분이 그대로 공개 서재 주소**가 된다.
`hong.gildong@gmail.com` → `/honggildong`. 그런데 설정에서 바꿀 수 없어 영구적이다.

본명이나 회사명이 이메일에 들어간 사람은 그걸 계속 공개하게 된다.

## 무엇을

아이디를 **평생 한 번** 바꿀 수 있게 한다. 발급 기준(이메일 앞부분)은 그대로 두되,
설정 화면에서 "이건 이메일에서 자동으로 만들어진 아이디"라고 알려 바꿀 기회를 인지시킨다.

커밋 3개로 나눴다. 층이 다르고 각각 따로 읽힌다.

| 커밋 | 층 |
| --- | --- |
| `b23a8cc` | DB — 형식·예약어·유일성·1회 제한 |
| `1dbad15` | 검증 순수함수 + 서버 액션 + 발급 로직 수정 |
| `5c93763` | 설정 화면 다이얼로그 |

## 제한을 DB에 둔 이유

`profiles` 의 UPDATE 정책은 행 단위(`auth.uid() = id`)라 **컬럼을 막지 못한다.**
로그인 사용자는 브라우저에서 anon 키로 자기 `username` 을 무제한 바꿀 수 있었다.
서버 액션에만 제한을 두면 그대로 우회된다.

작업 중 트리거에서 구멍을 하나 더 찾았다. `username` 이 바뀔 때만 검사하면,
**이름은 그대로 둔 채 `username_changed_at` 만 NULL 로 되돌려** 기회를 무한히
리셋할 수 있다. 로컬에서 재현했고, `username_changed_at` 을 서버 소유 컬럼으로
취급하도록 고쳤다.

## 함께 고친 것

가입 시 발급 함수에 결함이 셋 있었다.

- `한글@naver.com` 처럼 ASCII 가 없는 주소 → **빈 문자열** → 로그인 후 `/` 로 튕김
- `ab@` 같은 2자 주소가 그대로 통과
- `admin@` 이면 라우트와 충돌

중복 확인이 후보마다 쿼리를 던져 **최대 101회 왕복**하던 것도 1회로 줄였다.

## 검증

| 확인 | 결과 |
| --- | --- |
| DB 공격 12케이스 (예약어·대문자·길이·하이픈·중복·2회차·시각 위조) | 전부 차단 |
| 트리거 리셋 구멍 | 발견 → 수정 → 재검증 |
| 마이그레이션 48개 전량 재생 | 통과 |
| 화면 5개 상태 (형식오류·짧음·예약어·중복·사용가능) | 문구·버튼 정확 |
| 실제 변경 `tester` → `myreader_99` | 새 주소 200 / 옛 주소 404 / 재변경 잠김 |
| lint · type-check · test(316) | 통과 |

## ⚠️ 머지 전에

이 마이그레이션은 **규칙을 위반하는 기존 아이디를 말없이 바꾼다.**
운영에 올리기 전에 누가 바뀌는지 먼저 확인할 것 — 바뀌는 사람이 있으면 미리 알려야 한다.
점검용 읽기 전용 쿼리는 리뷰에서 요청하면 붙이겠다.

## 남은 것

기본값은 여전히 이메일 앞부분이다. 바꾸지 않는 사용자는 그대로다.
설정 화면 안내 문구가 최소한의 완화책이다.
