### PR TITLE
🐛 Fix: 모바일 랜딩 3건 — 가로 스크롤 · 히어로 표지 · 랭킹 수치

### DIFF
--- a/apps/page0127/app/(public)/page.tsx
+++ b/apps/page0127/app/(public)/page.tsx
@@ -93,7 +93,11 @@ const Home = async () => {
         {/* 발견 카드(틴트 투톤) + 랭킹 리스트 — 편집 면과 데이터 면을 나란히.
             각 섹션은 독립적으로 스트리밍되고 독립적으로 실패한다.
             ErrorBoundary(바깥) > Suspense(안): 로딩은 Suspense, 에러는 ErrorBoundary */}
-        <div className='grid items-start gap-8 lg:grid-cols-[2fr_3fr]'>
+        {/* minmax(0,...) 를 쓰는 이유: 그리드 아이템의 min-width 기본값은 auto 라
+            안의 내용이 트랙보다 넓으면 트랙 자체가 밀려난다. 실제로 모바일에서
+            페이지가 17px 가로 스크롤됐다(375 화면에 392). 0 을 하한으로 박아
+            트랙이 컨테이너를 넘지 못하게 한다. */}
+        <div className='grid grid-cols-[minmax(0,1fr)] items-start gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]'>
           <ErrorBoundary fallback={null}>
             <Suspense
               fallback={

--- a/apps/page0127/src/widgets/book/ui/BookRankingList.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookRankingList.tsx
@@ -20,6 +20,18 @@ import type { BookRanking } from '@/entities/book';
  *   "매일 집계가 돌고 있다"는 증거 (RankDeltaBadge 참조)
  * - 좋아요 버튼은 여기 두지 않는다 — 비교·행동은 책 정보 페이지의 일이다.
  */
+/**
+ * 근거 수치를 화면에 적는 최소 인원.
+ *
+ * 왜 감추나: 1~2명일 때 "1명이 완독"을 그대로 박으면, 처음 온 사람은 랭킹이 아니라
+ * **아무도 안 쓰는 서비스**를 본다. 순위 자체는 여전히 맞다 — 적은 표본을 크게 말하지
+ * 않을 뿐이다. 숫자를 지어내는 것(“오늘 0권 완독” 같은 문구)과는 반대 방향의 처방이다.
+ *
+ * 이 값 아래에서는 줄을 통째로 지운다. 표지·순위·제목·저자 네 필드가 남아
+ * 발견 면의 밀도는 그대로다(00_docs/07 §6-9).
+ */
+const MIN_COUNT_TO_SHOW = 3;
+
 type BookRankingListProps = {
   title: string;
   /** 집계 기준일 등 — 제목 우측에 붙는 메타 정보 */
@@ -102,19 +114,24 @@ export const BookRankingList = ({
                       {book.author}
                     </p>
                   )}
-                  {/* 랭킹 근거 수치 — 발견 면의 마지막 필드 */}
-                  <p className='mt-1 flex items-center gap-1 text-xs text-text-subtle'>
-                    {type === 'best' && (
-                      <Heart
-                        aria-hidden='true'
-                        className='size-3 fill-rank-up text-rank-up'
-                      />
-                    )}
-                    <span>
-                      <b className='font-medium text-text-body'>{item.count}</b>
-                      {type === 'best' ? '명의 인생책' : '명이 완독'}
-                    </span>
-                  </p>
+                  {/* 랭킹 근거 수치 — 발견 면의 마지막 필드.
+                      표본이 얇으면 적지 않는다(MIN_COUNT_TO_SHOW 참조) */}
+                  {item.count >= MIN_COUNT_TO_SHOW && (
+                    <p className='mt-1 flex items-center gap-1 text-xs text-text-subtle'>
+                      {type === 'best' && (
+                        <Heart
+                          aria-hidden='true'
+                          className='size-3 fill-rank-up text-rank-up'
+                        />
+                      )}
+                      <span>
+                        <b className='font-medium text-text-body'>
+                          {item.count}
+                        </b>
+                        {type === 'best' ? '명의 인생책' : '명이 완독'}
+                      </span>
+                    </p>
+                  )}
                 </div>
 
                 {/* 내가 완독한 책 — 완독 표시는 브랜드 블루의 직무다 */}

--- a/apps/page0127/src/widgets/landing/ui/HeroBanner.tsx
+++ b/apps/page0127/src/widgets/landing/ui/HeroBanner.tsx
@@ -118,13 +118,15 @@ export const HeroBanner = ({ slides, covers = [] }: HeroBannerProps) => {
                 isActive ? 'opacity-100' : 'pointer-events-none opacity-0'
               )}
             >
-              <div className='mx-auto flex w-full max-w-6xl items-center justify-between gap-8 px-8 md:px-12'>
-                {/* 카피 */}
-                <div className='max-w-md' style={{ color: slide.fg }}>
+              <div className='mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-5 md:gap-8 md:px-12'>
+                {/* 카피 — min-w-0 이 없으면 긴 제목이 표지를 화면 밖으로 밀어낸다 */}
+                <div className='min-w-0 max-w-md' style={{ color: slide.fg }}>
                   <p className='mb-4 text-sm font-medium opacity-70'>
                     {slide.eyebrow}
                   </p>
-                  <h2 className='text-[28px] font-bold leading-[1.35] md:text-4xl md:leading-[1.3]'>
+                  {/* 모바일 24px — 28px 로 두면 카피가 238px 를 먹어 표지가 49px 로
+                      눌린다(375 화면 기준). 4px 를 내주고 책을 제 크기로 세운다. */}
+                  <h2 className='text-2xl font-bold leading-[1.35] md:text-4xl md:leading-[1.3]'>
                     {slide.lines[0]}
                     <br />
                     {slide.lines[1]}
@@ -149,13 +151,29 @@ export const HeroBanner = ({ slides, covers = [] }: HeroBannerProps) => {
 
                 {/* 실제 책 표지 — 선반에 세워둔다.
                     판형을 크롭하지 않는다: 높이만 고정하고 너비는 원본 비율대로 둔다.
-                    문고본과 양장본은 실제로 판형이 다르고, 그 불균일이 "진짜 책"의 증거다. */}
+                    문고본과 양장본은 실제로 판형이 다르고, 그 불균일이 "진짜 책"의 증거다.
+
+                    모바일에도 반드시 나와야 한다. 예전엔 md 미만에서 통째로 숨겼는데,
+                    그러면 "폴드 안에 책이 보여야 한다"는 이 배너의 존재 이유가
+                    **트래픽이 가장 많은 화면에서만** 사라진다. 대신 375px 에 들어가도록
+                    모바일에서는 한 권만 세운다.
+
+                    shrink-0 이 없으면 카피와 표지가 함께 눌려, 표지가 제 폭을 못 갖고
+                    컨테이너 밖으로 흘러나간다. 표지는 고정하고 카피(min-w-0)가 남는 폭을 쓴다. */}
                 {slideCovers.length > 0 && (
-                  <div className='hidden items-end gap-3 md:flex'>
+                  <div className='flex shrink-0 items-end gap-1.5 md:gap-3'>
                     {slideCovers.map((cover, ci) => (
                       <div
                         key={`${slide.id}-${ci}`}
-                        className='relative shrink-0'
+                        className={cn(
+                          'relative shrink-0',
+                          // 모바일에는 한 권만 세운다.
+                          // 두 권을 넣어 봤더니 375px 화면에서 둘째가 398px 까지
+                          // 나가 잘렸다. 표지는 판형을 그대로 두는 정책이라 폭이
+                          // 책마다 다르고(0.65~1.0), 크기를 줄여 맞춰도 넓은 판형
+                          // 하나가 들어오면 다시 삐져나온다. 한 권은 항상 안전하다.
+                          ci > 0 && 'hidden md:block'
+                        )}
                         style={{
                           // 가운데 책을 살짝 올려 진열대처럼 보이게 한다
                           transform: ci === 1 ? 'translateY(-14px)' : undefined,
@@ -166,13 +184,13 @@ export const HeroBanner = ({ slides, covers = [] }: HeroBannerProps) => {
                           alt=''
                           width={300}
                           height={430}
-                          sizes='(min-width: 1024px) 220px, 180px'
+                          sizes='(min-width: 1024px) 220px, (min-width: 768px) 180px, 100px'
                           // 첫 슬라이드의 표지는 폴드 위 LCP 요소다 — 지연 로딩하면 안 된다
                           priority={i === 0}
                           // 나머지 슬라이드도 미리 로드한다 — lazy로 두면
                           // 슬라이드가 넘어간 순간 표지 없이 책등 줄만 보인다
                           loading={i === 0 ? undefined : 'eager'}
-                          className='h-45 w-auto rounded-r-md lg:h-55'
+                          className='h-28 w-auto rounded-r-md md:h-45 lg:h-55'
                         />
                         {/* 좌측 책등 — 종이 두께 */}
                         <span


### PR DESCRIPTION
## 왜

운영 사이트를 375px 로 실측했더니 셋이 나왔다. 셋 다 **모바일에서만** 생기는 문제다.

| # | 증상 | 실측 |
| --- | --- | --- |
| 1 | 페이지가 좌우로 흔들린다 | `scrollWidth 392` / 뷰포트 375 |
| 2 | 히어로에 책이 하나도 없다 | 표지가 `hidden md:flex` 로 숨겨짐 |
| 3 | 랭킹 1~5위가 전부 "1명이 완독" | 첫 방문자에게 빈 서비스로 읽힘 |

커밋 3개로 나눴다. 서로 독립이라 따로 읽힌다.

## 1. 가로 스크롤 (`ba636b8`)

그리드 아이템의 `min-width` 기본값이 `auto` 라, 안의 내용이 트랙보다 넓으면
**트랙 자체가 밀려난다.** 컨테이너가 343px 인데 두 아이템 모두 376px 로 잡혀 있었다.

`minmax(0, ...)` 로 하한을 박았다. `lg` 뿐 아니라 **기본(한 칸) 상태에도** 걸어야 한다 —
문제가 난 곳이 모바일이다.

## 2. 히어로 표지 (`fddd5f1`)

이 배너의 존재 이유가 *"폴드 안에 책이 보여야 한다"* 인데, 표지가 md 미만에서 통째로
숨겨져 있었다. 설계 의도가 **트래픽이 가장 많은 화면에서만** 무효였던 셈이다.

375px 에 넣으면서 실측으로 정한 것들:

- **표지는 모바일에서 한 권만.** 두 권을 넣으니 둘째가 398px 까지 나가 잘렸다.
  판형을 크롭하지 않는 정책이라 폭이 책마다 다르고(0.65~1.0), 크기를 줄여 맞춰도
  넓은 판형 하나가 들어오면 다시 삐져나온다.
- **표지 줄에 `shrink-0`.** 없으면 카피와 표지가 함께 눌려 표지가 49px 로 찌그러진 채
  컨테이너 밖으로 흘렀다.
- **제목 28px → 24px (모바일만).** 28px 면 카피가 238px 를 먹어 표지 자리가 없다.
  4px 를 내주고 두 줄 구조는 지켰다.
- `sizes` 에 모바일 구간 추가 — 지금까지 180px 짜리 이미지를 받고 있었다.

**md 이상은 종전과 동일**하다(표지 3권 · 제목 4xl). 데스크탑 1280 회귀 확인함.

## 3. 랭킹 수치 (`59900e5`)

3명 미만이면 수치 줄을 지운다. 순위는 여전히 맞고, **적은 표본을 크게 말하지 않을 뿐**이다.
숫자를 지어내지 않는다는 원칙(`00_docs/00` "억지로 채우지 말 것")과 같은 방향 —
없는 걸 만드는 대신 약한 걸 안 내민다.

줄이 빠져도 표지·순위·제목·저자 4필드가 남아 밀도는 그대로다(`00_docs/07` §6-9).
데이터가 쌓이면 임계값을 넘는 책부터 자동으로 다시 붙는다.

## 검증

로컬 DB 에 완독자 수를 **5·3·2·1 로 흩어** 심어, 임계값 위/아래가 한 화면에 같이 보이게 두고 확인했다.

| 확인 | 결과 |
| --- | --- |
| 모바일 가로 스크롤 | 392 → **375** ✅ |
| 모바일 히어로 표지 | 260~339 (79×112), 안전선 339 안쪽 ✅ |
| 모바일 제목 | 2줄 구조 유지 (208×65) ✅ |
| 랭킹 임계값 | 5명·3명 표시 / 2명·1명 감춤 ✅ |
| 데스크탑 1280 회귀 | 표지 3장 · 가로 스크롤 없음 ✅ |
| lint · type-check · test(316) | 통과 ✅ |

두 컴포넌트 모두 Storybook 스토리가 없어 Chromatic 변경은 없을 것으로 본다.
