### PR TITLE
✨ Feat: 댓글 신고 — 접수 · 운영자 숨김

### DIFF
--- a/apps/page0127/app/(admin)/admin/page.tsx
+++ b/apps/page0127/app/(admin)/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 
 const CARDS = [
+  { href: '/admin/reports', title: '신고', desc: '접수된 신고 확인·댓글 숨김' },
   { href: '/admin/costs', title: 'AI 비용', desc: '이번 달 사용액과 예산 대비' },
   { href: '/admin/members', title: '회원 관리', desc: '가입자 조회·정지' },
 ];

--- a/apps/page0127/app/(admin)/admin/reports/page.tsx
+++ b/apps/page0127/app/(admin)/admin/reports/page.tsx
@@ -1,0 +1,20 @@
+import { getReports } from '@/features/admin-reports/api/getReports';
+import { ReportList } from '@/features/admin-reports/ui/ReportList';
+
+export default async function AdminReportsPage() {
+  const reports = await getReports();
+  const pendingCount = reports.filter((r) => r.status === 'pending').length;
+
+  return (
+    <section className='space-y-4'>
+      <div>
+        <h1 className='text-base font-medium'>신고</h1>
+        <p className='mt-1 text-sm text-text-subtle'>
+          미처리 {pendingCount}건 · 전체 {reports.length}건. 숨긴 댓글은 화면에서
+          사라지지만 기록은 남습니다.
+        </p>
+      </div>
+      <ReportList reports={reports} />
+    </section>
+  );
+}

--- a/apps/page0127/app/api/_helpers/schemaContract.ts
+++ b/apps/page0127/app/api/_helpers/schemaContract.ts
@@ -43,6 +43,18 @@ export const SCHEMA_CONTRACT: SchemaProbe[] = [
     columns: ['visit_date', 'first_visit_at'],
     breaks: '재방문 계측 적재 (트랙 D-1)',
   },
+  {
+    table: 'book_comments',
+    // is_hidden 이 없으면 SELECT 정책의 필터가 사라진 것 — 가려 둔 댓글이 다시 보인다.
+    // 조용히 되살아나는 종류의 사고라 여기서 잡는다.
+    columns: ['is_hidden'],
+    breaks: '댓글 숨김 — 없으면 가려 둔 댓글이 다시 노출된다',
+  },
+  {
+    table: 'reports',
+    columns: ['reporter_id', 'comment_id', 'status'],
+    breaks: '신고 접수와 어드민 신고 처리 화면',
+  },
 ];
 
 /** PostgREST 가 "컬럼 없음" 으로 주는 코드. 다른 실패와 구분해야 원인이 드러난다. */

--- a/apps/page0127/app/api/reports/route.ts
+++ b/apps/page0127/app/api/reports/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest } from 'next/server';
+
+import {
+  isReportReason,
+  REASON_REQUIRING_DETAIL,
+  REPORT_DETAIL_MAX_LENGTH,
+} from '@/entities/report/model/reasons';
+
+import { getCurrentUser, getSupabaseClient } from '../_helpers/auth';
+import {
+  errorResponse,
+  internalErrorResponse,
+  successResponse,
+} from '../_helpers/response';
+
+/** Postgres 유니크 위반 — 같은 사람이 같은 댓글을 다시 신고한 경우 */
+const UNIQUE_VIOLATION = '23505';
+/** RLS 가 막은 경우 — 자기 댓글이거나 볼 수 없는 댓글이다 */
+const RLS_VIOLATION = '42501';
+
+/**
+ * POST /api/reports
+ * 댓글 신고 접수
+ *
+ * 권한 판단을 앱에서 하지 않는다. "볼 수 있는 남의 댓글만 신고할 수 있다"는
+ * 규칙은 RLS(`Users can report visible comments`)가 갖고 있고, 여기서는
+ * 그 거절을 사용자가 읽을 문장으로 옮기기만 한다.
+ *
+ * 앱에서 한 번 더 확인하면 규칙이 두 곳에 생겨 어긋난다 — 실제로 어긋나는
+ * 쪽은 늘 앱이고, DB 는 조용히 통과시킨다.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { user, error: authError } = await getCurrentUser();
+    if (authError) return authError;
+
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return errorResponse('잘못된 요청입니다.', 400);
+    }
+
+    const { commentId, reason, detail } = body as {
+      commentId?: unknown;
+      reason?: unknown;
+      detail?: unknown;
+    };
+
+    if (typeof commentId !== 'string' || !commentId) {
+      return errorResponse('신고할 댓글을 찾을 수 없습니다.', 400);
+    }
+    if (!isReportReason(reason)) {
+      return errorResponse('신고 사유를 골라 주세요.', 400);
+    }
+
+    const trimmedDetail =
+      typeof detail === 'string' ? detail.trim().slice(0, REPORT_DETAIL_MAX_LENGTH) : '';
+
+    // '기타'는 설명이 없으면 운영자가 판단할 근거가 없다
+    if (reason === REASON_REQUIRING_DETAIL && !trimmedDetail) {
+      return errorResponse('어떤 점이 문제인지 적어 주세요.', 400);
+    }
+
+    const supabase = await getSupabaseClient();
+    const { error } = await supabase.from('reports').insert({
+      reporter_id: user.id,
+      comment_id: commentId,
+      reason,
+      detail: trimmedDetail || null,
+    });
+
+    if (error) {
+      // 이미 신고한 건은 실패가 아니다 — 사용자 입장에선 접수된 상태 그대로다
+      if (error.code === UNIQUE_VIOLATION) {
+        return successResponse({ alreadyReported: true }, 200);
+      }
+      if (error.code === RLS_VIOLATION) {
+        return errorResponse('신고할 수 없는 댓글입니다.', 403);
+      }
+      throw error;
+    }
+
+    return successResponse({ alreadyReported: false }, 201);
+  } catch (error) {
+    return internalErrorResponse(error);
+  }
+}

--- a/apps/page0127/src/entities/report/model/reasons.ts
+++ b/apps/page0127/src/entities/report/model/reasons.ts
@@ -1,0 +1,34 @@
+/**
+ * 신고 사유 — 화면과 API 가 같은 목록을 본다.
+ *
+ * ⚠️ 값은 DB CHECK 제약(`reports_reason_check`)의 거울이다.
+ *    늘리려면 `supabase/migrations/…_create_comment_reports.sql` 과 함께 고친다.
+ *
+ * 넷으로 묶은 이유: 항목이 많아질수록 사용자는 읽지 않고 아무거나 고른다.
+ * 운영자가 실제로 다르게 대응하는 갈래만 남겼다.
+ */
+
+export const REPORT_REASONS = [
+  { value: 'spam', label: '스팸·광고' },
+  { value: 'abuse', label: '욕설·비방' },
+  { value: 'sexual', label: '음란물' },
+  { value: 'other', label: '기타' },
+] as const;
+
+export type ReportReason = (typeof REPORT_REASONS)[number]['value'];
+
+const REASON_VALUES = REPORT_REASONS.map((r) => r.value) as readonly string[];
+
+/** 쿼리·본문으로 들어온 값을 믿지 않기 위해 쓴다 */
+export const isReportReason = (value: unknown): value is ReportReason =>
+  typeof value === 'string' && REASON_VALUES.includes(value);
+
+/** 어드민 목록에서 사유를 한국어로 보여줄 때 */
+export const reportReasonLabel = (value: string): string =>
+  REPORT_REASONS.find((r) => r.value === value)?.label ?? value;
+
+/** '기타'로 신고할 때는 설명을 받는다 — 아니면 운영자가 판단할 근거가 없다 */
+export const REASON_REQUIRING_DETAIL: ReportReason = 'other';
+
+/** 설명 최대 길이. DB 는 text 지만 화면과 API 가 함께 제한한다 */
+export const REPORT_DETAIL_MAX_LENGTH = 300;

--- a/apps/page0127/src/features/admin-reports/api/getReports.ts
+++ b/apps/page0127/src/features/admin-reports/api/getReports.ts
@@ -1,0 +1,141 @@
+import { createAdminClient } from '@/shared/config/supabase/admin';
+
+/** 어드민 신고 목록 한 줄 */
+export type ReportRow = {
+  id: string;
+  reason: string;
+  detail: string | null;
+  status: 'pending' | 'resolved' | 'rejected';
+  createdAt: string;
+  handledAt: string | null;
+  /** 신고자 — 탈퇴하면 null 이 된다 */
+  reporterName: string | null;
+  comment: {
+    id: string;
+    content: string;
+    isHidden: boolean;
+    authorName: string | null;
+    authorId: string | null;
+  } | null;
+};
+
+type RawReport = {
+  id: string;
+  reason: string;
+  detail: string | null;
+  status: ReportRow['status'];
+  created_at: string;
+  handled_at: string | null;
+  reporter_id: string | null;
+  comment_id: string | null;
+};
+
+type RawComment = {
+  id: string;
+  content: string;
+  is_hidden: boolean;
+  user_id: string | null;
+};
+
+/**
+ * 신고 목록을 미처리 먼저, 그 안에서 최신순으로.
+ *
+ * service_role 로 읽는다 — RLS 는 "내 신고만"이라 운영자가 남의 신고를 볼 수 없다.
+ * 어드민 기능은 전부 이 경로를 쓴다(admin-members 와 같은 방식).
+ *
+ * 조인을 PostgREST 임베딩으로 하지 않고 따로 조회해 합친다. book_comments 와
+ * profiles 사이에 선언된 FK 가 없어(user_id 는 auth.users 를 가리킨다) 임베딩이
+ * 스키마 캐시에서 실패하기 때문이다.
+ */
+export const getReports = async (): Promise<ReportRow[]> => {
+  const supabase = createAdminClient();
+
+  const { data: reports, error } = await supabase
+    .from('reports')
+    .select('id, reason, detail, status, created_at, handled_at, reporter_id, comment_id')
+    // 미처리를 위로: pending < rejected < resolved 가 아니라 명시적으로 status 정렬
+    .order('status', { ascending: true })
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (error) {
+    console.error('신고 목록 조회 실패:', error.message);
+    return [];
+  }
+
+  const rows = (reports ?? []) as RawReport[];
+  if (rows.length === 0) return [];
+
+  // 댓글 본문 — 가려진 것도 함께 가져온다(service_role 은 RLS 를 우회한다)
+  const commentIds = [
+    ...new Set(rows.map((r) => r.comment_id).filter((id): id is string => !!id)),
+  ];
+  const { data: comments } = await supabase
+    .from('book_comments')
+    .select('id, content, is_hidden, user_id')
+    .in('id', commentIds);
+  const commentById = new Map(
+    ((comments ?? []) as RawComment[]).map((c) => [c.id, c])
+  );
+
+  // 신고자·작성자 이름
+  const userIds = [
+    ...new Set(
+      [
+        ...rows.map((r) => r.reporter_id),
+        ...((comments ?? []) as RawComment[]).map((c) => c.user_id),
+      ].filter((id): id is string => !!id)
+    ),
+  ];
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, nickname, username')
+    .in('id', userIds);
+  const nameById = new Map(
+    (profiles ?? []).map((p: { id: string; nickname: string | null; username: string | null }) => [
+      p.id,
+      p.nickname || p.username,
+    ])
+  );
+
+  return rows.map((r) => {
+    const comment = r.comment_id ? commentById.get(r.comment_id) : undefined;
+    return {
+      id: r.id,
+      reason: r.reason,
+      detail: r.detail,
+      status: r.status,
+      createdAt: r.created_at,
+      handledAt: r.handled_at,
+      reporterName: r.reporter_id ? (nameById.get(r.reporter_id) ?? null) : null,
+      comment: comment
+        ? {
+            id: comment.id,
+            content: comment.content,
+            isHidden: comment.is_hidden,
+            authorId: comment.user_id,
+            authorName: comment.user_id
+              ? (nameById.get(comment.user_id) ?? null)
+              : null,
+          }
+        : // 댓글이 지워지면 CASCADE 로 신고도 사라지므로 보통 여기 오지 않는다.
+          // 조회 사이의 경합으로 비는 경우를 위해 남겨 둔다.
+          null,
+    };
+  });
+};
+
+/** 미처리 건수 — 어드민 네비게이션 뱃지에 쓴다 */
+export const getPendingReportCount = async (): Promise<number> => {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from('reports')
+    .select('id', { count: 'exact', head: true })
+    .eq('status', 'pending');
+
+  if (error) {
+    console.error('미처리 신고 수 조회 실패:', error.message);
+    return 0;
+  }
+  return count ?? 0;
+};

--- a/apps/page0127/src/features/admin-reports/api/reportActions.ts
+++ b/apps/page0127/src/features/admin-reports/api/reportActions.ts
@@ -1,0 +1,88 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createAdminClient } from '@/shared/config/supabase/admin';
+import { assertAdmin } from '@/shared/lib/admin/assertAdmin';
+
+/**
+ * 신고 처리 — 숨김/해제와 신고 상태를 함께 쓴다.
+ *
+ * 둘을 따로 두면 "댓글은 가렸는데 신고는 미처리로 남는" 상태가 생기고, 운영자가
+ * 같은 건을 두 번 본다. 한 액션에 묶어 항상 같이 움직이게 한다.
+ */
+
+/** 댓글을 가리고 신고를 처리 완료로 넘긴다 */
+export async function hideComment(
+  reportId: string,
+  commentId: string
+): Promise<void> {
+  const admin = await assertAdmin();
+  const supabase = createAdminClient();
+
+  const { error: hideError } = await supabase
+    .from('book_comments')
+    .update({ is_hidden: true })
+    .eq('id', commentId);
+  if (hideError) throw new Error(`댓글 숨김 실패: ${hideError.message}`);
+
+  // 같은 댓글에 달린 다른 신고도 함께 정리한다 — 이미 조치했는데 목록에 남아
+  // 있으면 운영자가 같은 건을 다시 본다.
+  const { error: statusError } = await supabase
+    .from('reports')
+    .update({
+      status: 'resolved',
+      handled_by: admin.id,
+      handled_at: new Date().toISOString(),
+    })
+    .eq('comment_id', commentId)
+    .eq('status', 'pending');
+  if (statusError) throw new Error(`신고 상태 갱신 실패: ${statusError.message}`);
+
+  revalidatePath('/admin/reports');
+}
+
+/** 숨김을 되돌린다. 신고는 '반려'로 남긴다 — 지우지 않아야 이력이 남는다 */
+export async function unhideComment(
+  reportId: string,
+  commentId: string
+): Promise<void> {
+  const admin = await assertAdmin();
+  const supabase = createAdminClient();
+
+  const { error: unhideError } = await supabase
+    .from('book_comments')
+    .update({ is_hidden: false })
+    .eq('id', commentId);
+  if (unhideError) throw new Error(`숨김 해제 실패: ${unhideError.message}`);
+
+  const { error: statusError } = await supabase
+    .from('reports')
+    .update({
+      status: 'rejected',
+      handled_by: admin.id,
+      handled_at: new Date().toISOString(),
+    })
+    .eq('id', reportId);
+  if (statusError) throw new Error(`신고 상태 갱신 실패: ${statusError.message}`);
+
+  revalidatePath('/admin/reports');
+}
+
+/** 문제없는 신고를 반려한다 (댓글은 그대로 둔다) */
+export async function rejectReport(reportId: string): Promise<void> {
+  const admin = await assertAdmin();
+  const supabase = createAdminClient();
+
+  const { error } = await supabase
+    .from('reports')
+    .update({
+      status: 'rejected',
+      handled_by: admin.id,
+      handled_at: new Date().toISOString(),
+    })
+    .eq('id', reportId);
+  if (error) throw new Error(`신고 반려 실패: ${error.message}`);
+
+  revalidatePath('/admin/reports');
+}

--- a/apps/page0127/src/features/admin-reports/ui/ReportList.tsx
+++ b/apps/page0127/src/features/admin-reports/ui/ReportList.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useTransition } from 'react';
+
+import { EyeOff, Undo2, X } from 'lucide-react';
+
+import { RelativeTime } from '@/shared/ui/RelativeTime';
+
+import { reportReasonLabel } from '@/entities/report/model/reasons';
+
+import {
+  hideComment,
+  rejectReport,
+  unhideComment,
+} from '@/features/admin-reports/api/reportActions';
+
+import type { ReportRow } from '@/features/admin-reports/api/getReports';
+
+type ReportListProps = {
+  reports: ReportRow[];
+};
+
+const STATUS_LABEL: Record<ReportRow['status'], string> = {
+  pending: '미처리',
+  resolved: '숨김 처리',
+  rejected: '반려',
+};
+
+/**
+ * 신고 목록.
+ *
+ * 판단에 필요한 것을 한 줄에 다 둔다 — 무슨 사유로, 누가, 무슨 글을 신고했는지.
+ * 원문을 보러 다른 화면으로 넘어가야 하면 운영자는 처리를 미룬다.
+ */
+export const ReportList = ({ reports }: ReportListProps) => {
+  const [isPending, startTransition] = useTransition();
+
+  if (reports.length === 0) {
+    return (
+      <p className='rounded-lg border border-line p-6 text-center text-sm text-text-subtle'>
+        접수된 신고가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <ul className='flex flex-col gap-3'>
+      {reports.map((report) => (
+        <li
+          key={report.id}
+          className='rounded-lg border border-line p-4 text-sm'
+        >
+          <div className='flex flex-wrap items-center gap-2'>
+            <span className='rounded bg-sunken px-2 py-0.5 text-xs font-medium'>
+              {reportReasonLabel(report.reason)}
+            </span>
+            <span className='text-xs text-text-subtle'>
+              {STATUS_LABEL[report.status]}
+            </span>
+            {report.comment?.isHidden && (
+              <span className='rounded bg-destructive/10 px-2 py-0.5 text-xs text-destructive'>
+                숨김 상태
+              </span>
+            )}
+            <RelativeTime
+              date={report.createdAt}
+              className='ml-auto text-xs text-text-subtle'
+            />
+          </div>
+
+          {/* 신고된 원문 — 판단의 근거다 */}
+          <blockquote className='mt-3 border-l-2 border-line-soft pl-3 text-text-body'>
+            {report.comment?.content ?? '(댓글이 삭제되었습니다)'}
+          </blockquote>
+
+          <p className='mt-2 text-xs text-text-subtle'>
+            작성자 {report.comment?.authorName ?? '알 수 없음'} · 신고자{' '}
+            {report.reporterName ?? '탈퇴한 사용자'}
+          </p>
+
+          {report.detail && (
+            <p className='mt-2 rounded bg-sunken p-2 text-xs text-text-body'>
+              {report.detail}
+            </p>
+          )}
+
+          {report.comment && (
+            <div className='mt-3 flex flex-wrap gap-2'>
+              {report.comment.isHidden ? (
+                <button
+                  type='button'
+                  disabled={isPending}
+                  onClick={() =>
+                    startTransition(() =>
+                      unhideComment(report.id, report.comment!.id)
+                    )
+                  }
+                  className='inline-flex items-center gap-1.5 rounded border border-line px-3 py-1.5 text-xs hover:bg-accent disabled:opacity-50'
+                >
+                  <Undo2 aria-hidden className='size-3.5' />
+                  숨김 해제
+                </button>
+              ) : (
+                <button
+                  type='button'
+                  disabled={isPending}
+                  onClick={() =>
+                    startTransition(() =>
+                      hideComment(report.id, report.comment!.id)
+                    )
+                  }
+                  className='inline-flex items-center gap-1.5 rounded border border-line px-3 py-1.5 text-xs text-destructive hover:bg-accent disabled:opacity-50'
+                >
+                  <EyeOff aria-hidden className='size-3.5' />
+                  댓글 숨기기
+                </button>
+              )}
+
+              {report.status === 'pending' && (
+                <button
+                  type='button'
+                  disabled={isPending}
+                  onClick={() =>
+                    startTransition(() => rejectReport(report.id))
+                  }
+                  className='inline-flex items-center gap-1.5 rounded border border-line px-3 py-1.5 text-xs hover:bg-accent disabled:opacity-50'
+                >
+                  <X aria-hidden className='size-3.5' />
+                  문제없음
+                </button>
+              )}
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/apps/page0127/src/features/comment/ui/CommentItem.tsx
+++ b/apps/page0127/src/features/comment/ui/CommentItem.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Button } from '@repo/ui';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Avatar, AvatarFallback, AvatarImage, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Textarea } from '@repo/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { MoreVertical, Pencil, Reply, Trash2 } from 'lucide-react';
+import { Flag, MoreVertical, Pencil, Reply, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { getApiErrorMessage } from '@/shared/api/getApiErrorMessage';
@@ -14,6 +14,8 @@ import { RelativeTime } from '@/shared/ui/RelativeTime';
 import { Comment, commentApi, commentKeys } from '@/entities/comment';
 import { ProfileLink } from '@/entities/profile/ui/ProfileLink';
 import { useCurrentUserContext } from '@/entities/user';
+
+import { ReportCommentDialog } from '@/features/report/ui/ReportCommentDialog';
 
 import { CommentForm } from './CommentForm';
 
@@ -45,6 +47,7 @@ export const CommentItem = ({
   const [isEditing, setIsEditing] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isReportOpen, setIsReportOpen] = useState(false);
   const [editContent, setEditContent] = useState(comment.content);
 
   const isAuthor = currentUserId === comment.userId;
@@ -141,26 +144,45 @@ export const CommentItem = ({
                 </Button>
               )}
 
-              {/* 수정/삭제 메뉴 (본인 댓글만) */}
-              {isAuthor && (
+              {/* 본인 댓글이면 수정·삭제, 남의 댓글이면 신고.
+                  같은 자리·같은 아이콘이라 사용자는 "이 댓글에 할 수 있는 일"을
+                  한 곳에서 찾는다. 비로그인은 신고할 수 없으므로 메뉴가 없다. */}
+              {(isAuthor || currentUserId) && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant='ghost' size='sm' className='h-8 w-8 p-0'>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-8 w-8 p-0'
+                      aria-label='댓글 메뉴'
+                    >
                       <MoreVertical className='h-4 w-4' />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align='end'>
-                    <DropdownMenuItem onClick={() => setIsEditing(true)}>
-                      <Pencil className='mr-2 h-4 w-4' />
-                      수정
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={handleDelete}
-                      className='text-destructive'
-                    >
-                      <Trash2 className='mr-2 h-4 w-4' />
-                      삭제
-                    </DropdownMenuItem>
+                    {isAuthor ? (
+                      <>
+                        <DropdownMenuItem onClick={() => setIsEditing(true)}>
+                          <Pencil className='mr-2 h-4 w-4' />
+                          수정
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={handleDelete}
+                          className='text-destructive'
+                        >
+                          <Trash2 className='mr-2 h-4 w-4' />
+                          삭제
+                        </DropdownMenuItem>
+                      </>
+                    ) : (
+                      <DropdownMenuItem
+                        onClick={() => setIsReportOpen(true)}
+                        className='text-destructive'
+                      >
+                        <Flag className='mr-2 h-4 w-4' />
+                        신고
+                      </DropdownMenuItem>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}
@@ -242,6 +264,15 @@ export const CommentItem = ({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* 신고는 남의 댓글에만 뜬다 — 본인 댓글이면 메뉴에 항목 자체가 없다 */}
+      {!isAuthor && (
+        <ReportCommentDialog
+          commentId={comment.id}
+          open={isReportOpen}
+          onOpenChange={setIsReportOpen}
+        />
+      )}
     </>
   );
 };

--- a/apps/page0127/src/features/report/ui/ReportCommentDialog.tsx
+++ b/apps/page0127/src/features/report/ui/ReportCommentDialog.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useId, useState } from 'react';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Textarea,
+} from '@repo/ui';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { apiClient } from '@/shared/api/client';
+import { getApiErrorMessage } from '@/shared/api/getApiErrorMessage';
+
+import {
+  REASON_REQUIRING_DETAIL,
+  REPORT_DETAIL_MAX_LENGTH,
+  REPORT_REASONS,
+  type ReportReason,
+} from '@/entities/report/model/reasons';
+
+type ReportCommentDialogProps = {
+  commentId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * 댓글 신고 다이얼로그.
+ *
+ * 신고는 남을 불이익에 놓는 행위라 한 번 더 묻는 화면을 둔다 — 메뉴에서 바로
+ * 접수되면 오조작이 그대로 신고가 된다.
+ *
+ * 접수 뒤 결과를 알려주지 않는다. 처리 결과를 신고자에게 보내면 "누가 신고했는지"가
+ * 역추적되는 통로가 된다. 대신 접수됐다는 사실만 분명히 말한다.
+ */
+export const ReportCommentDialog = ({
+  commentId,
+  open,
+  onOpenChange,
+}: ReportCommentDialogProps) => {
+  const fieldId = useId();
+  const [reason, setReason] = useState<ReportReason | null>(null);
+  const [detail, setDetail] = useState('');
+
+  const needsDetail = reason === REASON_REQUIRING_DETAIL;
+  const canSubmit = reason !== null && (!needsDetail || detail.trim().length > 0);
+
+  const reportMutation = useMutation({
+    mutationFn: async () =>
+      apiClient.post('/reports', { commentId, reason, detail: detail.trim() }),
+    onSuccess: (response) => {
+      // 이미 신고한 건도 성공으로 받는다 — 사용자에겐 접수된 상태 그대로다
+      const alreadyReported = Boolean(
+        (response.data as { alreadyReported?: boolean } | undefined)
+          ?.alreadyReported
+      );
+      toast.success(
+        alreadyReported
+          ? '이미 신고한 댓글이에요.'
+          : '신고를 접수했어요. 확인 후 조치할게요.'
+      );
+      close();
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, '신고에 실패했습니다.'));
+    },
+  });
+
+  const close = () => {
+    onOpenChange(false);
+    // 다음에 열 때 앞선 선택이 남아 있으면 잘못 접수된다
+    setReason(null);
+    setDetail('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>댓글 신고</DialogTitle>
+          <DialogDescription>
+            어떤 점이 문제인지 알려 주세요. 운영자가 확인한 뒤 조치합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <fieldset className='space-y-2'>
+          <legend className='mb-2 text-sm font-medium'>신고 사유</legend>
+          {REPORT_REASONS.map((option) => (
+            <label
+              key={option.value}
+              className='flex cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm hover:bg-accent'
+            >
+              <input
+                type='radio'
+                name='reason'
+                value={option.value}
+                checked={reason === option.value}
+                onChange={() => setReason(option.value)}
+                className='size-4 accent-primary'
+              />
+              {option.label}
+            </label>
+          ))}
+        </fieldset>
+
+        <div className='space-y-2'>
+          <Label htmlFor={fieldId}>
+            설명 {needsDetail ? '(필수)' : '(선택)'}
+          </Label>
+          <Textarea
+            id={fieldId}
+            value={detail}
+            onChange={(e) => setDetail(e.target.value)}
+            maxLength={REPORT_DETAIL_MAX_LENGTH}
+            rows={3}
+            placeholder='자세히 적어 주시면 더 빨리 확인할 수 있어요.'
+            className='resize-none'
+          />
+          <p className='text-xs text-text-subtle'>
+            {detail.length}/{REPORT_DETAIL_MAX_LENGTH}자
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button type='button' variant='outline' onClick={close}>
+            취소
+          </Button>
+          <Button
+            type='button'
+            onClick={() => reportMutation.mutate()}
+            disabled={!canSubmit || reportMutation.isPending}
+          >
+            {reportMutation.isPending ? '접수 중…' : '신고하기'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/page0127/src/shared/config/schemaVersion.ts
+++ b/apps/page0127/src/shared/config/schemaVersion.ts
@@ -11,7 +11,7 @@
  * 마이그레이션을 추가했다면:
  *   이 값을 새 파일의 앞 14자리 번호로 바꾼다. (예: 20260729000000)
  */
-export const EXPECTED_MIGRATION_VERSION = '20260805000000';
+export const EXPECTED_MIGRATION_VERSION = '20260806000000';
 
 /**
  * 스키마 대조 결과.

--- a/apps/page0127/src/widgets/admin/ui/AdminNav.tsx
+++ b/apps/page0127/src/widgets/admin/ui/AdminNav.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 
 import {
   Bug,
+  Flag,
   Gauge,
   ImageIcon,
   LayoutDashboard,
@@ -15,6 +16,7 @@ const NAV = [
   { href: '/admin', label: '대시보드', icon: LayoutDashboard },
   { href: '/admin/quality', label: '품질', icon: Gauge },
   { href: '/admin/errors', label: '에러', icon: Bug },
+  { href: '/admin/reports', label: '신고', icon: Flag },
   { href: '/admin/analytics', label: '유입분석', icon: LineChart },
   { href: '/admin/costs', label: 'AI 비용', icon: Receipt },
   { href: '/admin/members', label: '회원 관리', icon: Users },

--- a/supabase/migrations/20260806000000_create_comment_reports.sql
+++ b/supabase/migrations/20260806000000_create_comment_reports.sql
@@ -1,0 +1,142 @@
+-- 댓글 신고 — 신고 접수 + 운영자 숨김
+-- 작성일: 2026-08-06
+--
+-- 공개 서재·책 정보 페이지·팔로우 피드가 전부 열려 있는데 신고 창구가 없었다.
+-- 유해한 댓글이 하나 올라오면 Supabase 콘솔에서 직접 지우는 것 말고 방법이 없었다.
+--
+-- 범위를 댓글로 좁힌 이유: 남에게 말을 거는 행위라 시비가 실제로 붙는 면이다.
+-- 책 기록(한줄평)은 혼잣말에 가까워 빈도가 훨씬 낮다. 나중에 필요해지면
+-- reports 에 book_id 컬럼 하나를 더하고 아래 CHECK 의 인자만 늘리면 된다.
+--
+-- book_comments 는 책 기록 댓글(book_id)과 책 정보 페이지 댓글(global_book_id)을
+-- 한 테이블로 다루므로, 이 하나로 두 면이 모두 덮인다.
+
+-- =====================================================
+-- 1. 숨김 플래그 — 지우지 않고 가린다
+-- =====================================================
+--
+-- 삭제가 아니라 숨김인 이유: 오판을 되돌릴 수 있고, 신고자와 작성자가 다투면
+-- 무엇이 쓰여 있었는지 확인할 기록이 남는다.
+ALTER TABLE book_comments
+  ADD COLUMN IF NOT EXISTS is_hidden boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN book_comments.is_hidden IS
+  '운영자가 가린 댓글. 화면에서 사라지지만 행은 남는다(오판 복구·분쟁 대비).';
+
+-- 목록 조회는 대부분 "안 가려진 것"만 본다
+CREATE INDEX IF NOT EXISTS book_comments_visible_idx
+  ON book_comments (book_id, created_at)
+  WHERE is_hidden = false;
+
+-- =====================================================
+-- 2. 가려진 댓글은 아무에게도 안 보인다
+-- =====================================================
+--
+-- 작성자에게도 안 보인다. 자기 글만 계속 보이면 "왜 아무도 답을 안 하지"로
+-- 오해하고, 가려졌다는 사실 자체가 전달되지 않는다.
+-- 운영자는 service_role 로 보므로 RLS 를 우회한다(어드민 화면은 그 키를 쓴다).
+DROP POLICY IF EXISTS "Book comments are viewable by allowed viewers" ON book_comments;
+
+CREATE POLICY "Book comments are viewable by allowed viewers"
+  ON book_comments FOR SELECT
+  USING (
+    is_hidden = false
+    AND (
+      global_book_id IS NOT NULL
+      OR EXISTS (
+        SELECT 1 FROM books b
+        WHERE b.id = book_comments.book_id
+          AND (b.is_public = true OR b.user_id = auth.uid())
+      )
+    )
+  );
+
+-- =====================================================
+-- 3. 신고 테이블
+-- =====================================================
+
+CREATE TABLE IF NOT EXISTS reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- 신고자가 탈퇴해도 신고는 남는다(운영 기록). 누가 했는지만 지워진다.
+  reporter_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  -- 대상. 지금은 댓글 하나뿐이지만 컬럼을 늘릴 수 있게 CHECK 형태로 둔다
+  -- (book_comments_one_target 과 같은 방식).
+  comment_id uuid REFERENCES book_comments(id) ON DELETE CASCADE,
+
+  reason text NOT NULL
+    CHECK (reason IN ('spam', 'abuse', 'sexual', 'other')),
+  -- 사용자가 덧붙이는 설명. '기타'가 아니면 비어 있어도 된다.
+  detail text,
+
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'resolved', 'rejected')),
+
+  -- 처리 기록 — 누가 언제. 되돌릴 때 근거가 된다.
+  handled_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  handled_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT reports_one_target CHECK (num_nonnulls(comment_id) = 1)
+);
+
+COMMENT ON TABLE reports IS
+  '사용자 신고. 지금은 댓글만 받는다. 조치는 전부 사람이 한다(자동 숨김 없음).';
+
+-- 같은 사람이 같은 댓글을 여러 번 신고해도 한 건으로 센다.
+-- 탈퇴로 reporter_id 가 NULL 이 되면 유니크에서 빠지는데(NULL 은 서로 다르다),
+-- 이미 접수된 신고라 문제되지 않는다.
+CREATE UNIQUE INDEX IF NOT EXISTS reports_reporter_comment_key
+  ON reports (reporter_id, comment_id)
+  WHERE comment_id IS NOT NULL;
+
+-- 어드민 목록은 "미처리 최신순"이 기본이다
+CREATE INDEX IF NOT EXISTS reports_status_created_idx
+  ON reports (status, created_at DESC);
+
+-- =====================================================
+-- 4. RLS
+-- =====================================================
+
+ALTER TABLE reports ENABLE ROW LEVEL SECURITY;
+
+-- 내가 넣은 신고만 읽는다 — 화면이 "이미 신고함"을 표시하는 데 쓴다.
+-- 남의 신고를 못 봐야 신고자가 노출되지 않는다.
+DROP POLICY IF EXISTS "Users can read own reports" ON reports;
+CREATE POLICY "Users can read own reports"
+  ON reports FOR SELECT
+  USING (auth.uid() = reporter_id);
+
+-- 신고는 로그인 사용자만, 자기 이름으로만 넣는다.
+-- 볼 수 없는 댓글은 신고할 수 없고(EXISTS 가 RLS 를 통과한 행만 본다),
+-- 자기 댓글도 신고할 수 없다.
+DROP POLICY IF EXISTS "Users can report visible comments" ON reports;
+CREATE POLICY "Users can report visible comments"
+  ON reports FOR INSERT
+  WITH CHECK (
+    auth.uid() = reporter_id
+    AND EXISTS (
+      SELECT 1 FROM book_comments c
+      WHERE c.id = reports.comment_id
+        AND c.user_id IS DISTINCT FROM auth.uid()
+    )
+  );
+
+-- 수정·삭제 정책 없음 → 일반 사용자는 접수 후 손댈 수 없다.
+-- 운영자는 service_role 로 처리한다(RLS 우회).
+
+-- =====================================================
+-- 5. 권한
+-- =====================================================
+--
+-- 20260725000001_lock_down_function_privileges.sql 방침: PUBLIC 회수 후 필요한 롤에만.
+REVOKE ALL ON TABLE reports FROM PUBLIC;
+GRANT SELECT, INSERT ON TABLE reports TO authenticated;
+GRANT ALL ON TABLE reports TO service_role;
+
+-- Migration 완료
+-- - book_comments.is_hidden — 가려진 댓글은 RLS 가 아무에게도 안 보여준다
+-- - reports — 댓글 신고 접수. 중복 신고는 유니크로 막고, 자기 댓글은 RLS 가 막는다
+-- - 조치는 전부 수동. 자동 숨김 임계값은 두지 않았다(악의적 신고로 정상 글이 사라진다)


### PR DESCRIPTION
## 왜

공개 서재·책 정보 페이지·팔로우 피드가 전부 열려 있는데 **신고 창구가 0곳**이었다.
어드민은 회원 정지만 가능하고 개별 댓글은 못 건드려서, 유해한 댓글 하나가 올라오면
Supabase 콘솔에서 직접 지우는 것 말고 방법이 없었다.

오픈 차단급으로 꼽았던 항목 중 마지막 남은 하나다.

## 범위를 좁힌 이유

| | v1 | 왜 |
| --- | --- | --- |
| 댓글 | ✅ | 남에게 말을 거는 행위라 시비가 실제로 붙는 면 |
| 책 기록(한줄평) | ❌ | 혼잣말에 가까워 빈도가 훨씬 낮다. 컬럼 하나면 붙는다 |
| 사용자 | ❌ | 어드민 회원 목록의 정지로 충분하다 |
| 금지어 | ❌ | 우회가 쉽고(`시1발`) 오탐이 사람을 쫓아낸다 |

`book_comments` 가 책 기록 댓글(`book_id`)과 책 정보 페이지 댓글(`global_book_id`)을
한 테이블로 다루므로, **댓글 신고 하나로 두 면이 모두 덮인다.**

## 설계에서 의도한 것

**삭제가 아니라 숨김.** 오판을 되돌릴 수 있고, 신고자와 작성자가 다투면 무엇이 쓰여
있었는지 확인할 기록이 남는다. 가려진 댓글은 **작성자에게도** 안 보인다 — 자기 글만
계속 보이면 가려졌다는 사실이 전달되지 않는다.

**자동 조치 없음.** 신고 N건 자동 숨김은 사용자가 적을 때 임계값이 오작동하고, 악의적
신고 몇 건으로 정상 글이 사라진다. 지금 규모면 사람이 보는 게 빠르고 안전하다.

**권한 판단은 DB 가 한다.** "볼 수 있는 남의 댓글만 신고할 수 있다"는 RLS 가 갖고,
API 는 그 거절을 사용자가 읽을 문장으로 옮기기만 한다. 앱에서 한 번 더 확인하면 규칙이
두 곳에 생겨 어긋나는데, 어긋나는 쪽은 늘 앱이고 DB 는 조용히 통과시킨다.

**확장을 열어 뒀다.** 대상 컬럼을 `num_nonnulls(comment_id) = 1` CHECK 로 뒀다
(`book_comments_one_target` 과 같은 방식). 책 기록을 추가할 때 `book_id` 컬럼과 CHECK
인자만 늘리면 된다. `target_type` + `target_id` 로 뭉뚱그리지 않은 건 **외래키를 못
걸기 때문** — 댓글이 지워지면 신고가 고아로 남는다.

**중복 신고는 실패가 아니다.** 유니크 위반을 `200 + alreadyReported` 로 돌려준다.
사용자 입장에선 이미 접수된 상태 그대로다.

**처리 결과를 신고자에게 알리지 않는다.** 알리면 "누가 신고했는지"가 역추적되는 통로가 된다.

## 커밋

| | 내용 |
| --- | --- |
| `2b63846` | 마이그레이션 — `reports` · `book_comments.is_hidden` · RLS |
| `00722c6` | 신고 API + 댓글 메뉴의 신고 버튼 + 다이얼로그 |
| `06af833` | `/admin/reports` — 목록·숨김·해제·반려 |

## 검증

**RLS 9케이스 (SQL)** — 자기 댓글 신고 · 중복 신고 · 남의 이름으로 신고 · 허용 안 된
사유는 전부 거부. 남의 신고는 조회 안 됨. 접수 후 수정·삭제 막힘(`UPDATE 0` / `DELETE 0`).
숨긴 댓글은 작성자 본인에게도 0행. 마이그레이션 49개 전량 재생 통과.

**API 6케이스** — 정상 `201` / 중복 `200+alreadyReported` / 자기 댓글 `403` /
없는 사유 `400` / 기타인데 설명 없음 `400` / 비로그인 `401`.

**앱 통합** — 관리자 세션으로 `/admin/reports` `200`, 사유·원문·조치 버튼 렌더 확인.
숨긴 뒤 공개 댓글 API 에서 해당 댓글이 사라지는 것까지 확인(1회 → 0회).

lint · type-check · test(316) 통과.

## ⚠️ 머지 전에

마이그레이션이 들어 있다. **PR 을 올린 직후 개발 Supabase 에 `db push`** 해야 CI 의
E2E 가 초록불이 된다(`00_docs/10_시스템_구조.md` ⑥ "함정 셋"). 운영은 머지 직전에.
