### PR TITLE
✨ Feat: 활성화 깔때기 계측 + GA 신호 CSP 수정

### DIFF
--- a/apps/page0127/app/(protected)/books/add/page.tsx
+++ b/apps/page0127/app/(protected)/books/add/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { ErrorBoundary, PageContainer } from '@repo/ui';
 import { toast } from 'sonner';
 
+import { trackEvent } from '@/shared/lib/analytics/trackEvent';
 import {
   upgradeImageResolution,
   validateSpineImageUrl,
@@ -192,6 +193,14 @@ const AddBookPage = () => {
     const result = await createBook(bookData);
 
     if (result) {
+      // 활성화 계측 — 가입 다음 단계가 "첫 책을 꽂았다"이다.
+      // 등록하면서 바로 완독으로 담는 경우가 흔한데, 그 흐름은 편집 화면을 거치지
+      // 않으므로 여기서 세지 않으면 그 완독은 통째로 누락된다.
+      trackEvent('book_add', { status: formData.status, read_count: readCount });
+      if (formData.status === 'completed') {
+        trackEvent('book_complete', { from: 'register' });
+      }
+
       // 상태 초기화
       setExistingBook(null);
 

--- a/apps/page0127/app/api/books/[id]/route.ts
+++ b/apps/page0127/app/api/books/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server';
 
+import { isNewlyCompleted } from '@/entities/book/model/completion';
+
 import { createActivity } from '../../_helpers/activity';
 import { getCurrentUser, getSupabaseClient } from '../../_helpers/auth';
 import {
@@ -88,8 +90,10 @@ export async function PATCH(request: NextRequest, { params }: Params) {
       });
     }
 
-    // status가 completed로 변경된 경우 활동 생성
-    if (oldBook?.status !== 'completed' && body.status === 'completed') {
+    // status가 completed로 변경된 경우 활동 생성.
+    // 판정은 클라이언트 계측(book_complete)과 같은 함수를 쓴다 — 두 곳에 각각
+    // 적으면 한쪽만 고치는 날 활동 기록과 GA 수치가 조용히 어긋난다.
+    if (isNewlyCompleted(oldBook?.status, body.status)) {
       await createActivity({
         supabase,
         userId: user.id,

--- a/apps/page0127/next.config.ts
+++ b/apps/page0127/next.config.ts
@@ -141,7 +141,11 @@ const nextConfig: NextConfig = {
       // API·Sentry 터널(self) + Supabase REST/realtime(wss) + GA 비콘
       // + jsdelivr: Pretendard 폰트 CSS의 소스맵(.map) fetch. DevTools를 열었을
       //   때만 요청되고 일반 방문자엔 영향 없지만, 콘솔 위반을 없애려고 허용한다.
-      `connect-src 'self' ${supabaseOrigin} ${supabaseSocketOrigin} https://cdn.jsdelivr.net https://www.google-analytics.com https://www.googletagmanager.com`,
+      // + www.google.com: GA4 의 Google 신호(Google Signals) 핑이 여기로 간다.
+      //   주 수집 경로(google-analytics.com)와 **호스트가 달라** 빠뜨리기 쉽고,
+      //   빠지면 이벤트는 멀쩡한데 인구통계·관심사·교차기기만 조용히 빈다.
+      //   2026-08-06 운영에서 체류가 쌓인 뒤 4건 차단되는 것을 확인하고 열었다.
+      `connect-src 'self' ${supabaseOrigin} ${supabaseSocketOrigin} https://cdn.jsdelivr.net https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com`,
       // 클릭재킹 방지(X-Frame-Options의 현대적 대응) + 기타 하드닝
       "frame-ancestors 'self'",
       "base-uri 'self'",

--- a/apps/page0127/src/entities/book/model/completion.test.ts
+++ b/apps/page0127/src/entities/book/model/completion.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNewlyCompleted } from './completion';
+
+describe('isNewlyCompleted', () => {
+  it('읽는 중에서 완독으로 바뀌면 전환이다', () => {
+    expect(isNewlyCompleted('reading', 'completed')).toBe(true);
+  });
+
+  it('읽고 싶어요에서 완독으로 바로 가도 전환이다', () => {
+    expect(isNewlyCompleted('want_to_read', 'completed')).toBe(true);
+  });
+
+  it('새로 등록하는 책(이전 상태 없음)을 완독으로 담으면 전환이다', () => {
+    expect(isNewlyCompleted(undefined, 'completed')).toBe(true);
+    expect(isNewlyCompleted(null, 'completed')).toBe(true);
+  });
+
+  it('이미 완독인 책을 다시 저장하는 것은 전환이 아니다', () => {
+    // 메모만 고쳐 저장할 때마다 완독이 늘어나는 것을 막는 규칙이다
+    expect(isNewlyCompleted('completed', 'completed')).toBe(false);
+  });
+
+  it('완독에서 다른 상태로 되돌리는 것은 전환이 아니다', () => {
+    expect(isNewlyCompleted('completed', 'reading')).toBe(false);
+  });
+
+  it('완독과 무관한 상태 변경은 전환이 아니다', () => {
+    expect(isNewlyCompleted('want_to_read', 'reading')).toBe(false);
+  });
+
+  it('다음 상태가 비어 있으면(그 필드를 안 건드린 저장) 전환이 아니다', () => {
+    // PATCH 는 부분 갱신이라 status 가 아예 안 실려 올 수 있다
+    expect(isNewlyCompleted('reading', undefined)).toBe(false);
+    expect(isNewlyCompleted('completed', undefined)).toBe(false);
+  });
+});

--- a/apps/page0127/src/entities/book/model/completion.ts
+++ b/apps/page0127/src/entities/book/model/completion.ts
@@ -1,0 +1,14 @@
+/**
+ * "완독으로 **전환**됐는가" 판정.
+ *
+ * 이 규칙은 원래 서버 라우트(`PATCH /api/books/[id]`)에만 있었는데, 완독 계측을
+ * 붙이면서 클라이언트에도 같은 조건이 필요해졌다. 두 곳에 각각 적으면 한쪽만
+ * 고치는 날 활동 기록과 GA 수치가 어긋난다 — 어긋나도 아무도 모른다는 게 더 나쁘다.
+ *
+ * 핵심은 "지금 완독인가"가 아니라 **"완독이 아니었다가 완독이 됐는가"** 라는 것이다.
+ * 전자로 세면 이미 완독한 책의 메모만 고쳐 저장해도 완독이 한 건씩 늘어난다.
+ */
+export const isNewlyCompleted = (
+  previousStatus: string | null | undefined,
+  nextStatus: string | null | undefined
+): boolean => previousStatus !== 'completed' && nextStatus === 'completed';

--- a/apps/page0127/src/features/share/ui/ShareButton.tsx
+++ b/apps/page0127/src/features/share/ui/ShareButton.tsx
@@ -6,6 +6,8 @@ import { Button } from '@repo/ui';
 import { Link2, Share2 } from 'lucide-react';
 import { toast } from 'sonner';
 
+import { trackEvent } from '@/shared/lib/analytics/trackEvent';
+
 type ShareButtonProps = {
   /** 공유할 경로. 절대 URL 은 이 컴포넌트가 현재 origin 으로 만든다 */
   path: string;
@@ -39,6 +41,8 @@ export const ShareButton = ({ path, title, text, label }: ShareButtonProps) => {
 
       try {
         await navigator.share({ title, text, url });
+        // 성공한 뒤에만 센다 — 시트를 열었다 닫은 것은 공유가 아니다
+        trackEvent('share_click', { method: 'native', path });
         return;
       } catch (error) {
         // 사용자가 공유 시트를 닫은 것은 실패가 아니다 — 아무 말도 하지 않는다
@@ -53,6 +57,7 @@ export const ShareButton = ({ path, title, text, label }: ShareButtonProps) => {
 
     try {
       await navigator.clipboard.writeText(url);
+      trackEvent('share_click', { method: 'copy', path });
       toast.success('주소를 복사했어요.');
     } catch {
       toast.error('주소를 복사하지 못했어요.');

--- a/apps/page0127/src/shared/lib/analytics/trackEvent.ts
+++ b/apps/page0127/src/shared/lib/analytics/trackEvent.ts
@@ -17,8 +17,33 @@ declare global {
   }
 }
 
-// 추적할 이벤트 이름 (오타 방지용 유니온)
-export type AnalyticsEvent = 'cta_click' | 'scroll_depth' | 'signup_start';
+/**
+ * 추적할 이벤트 이름 (오타 방지용 유니온)
+ *
+ * 깔때기 순서로 적는다. 지금까지는 랜딩의 cta_click·signup_start 둘뿐이라
+ * "들어와서 버튼을 눌렀다"까지만 알고 **그 뒤로 무엇을 했는지 몰랐다.**
+ * 이 서비스의 활성화는 첫 책을 꽂고 완독을 찍는 순간인데, 그 두 지점이 계측
+ * 밖에 있었다.
+ *
+ *   랜딩    cta_click · signup_start
+ *   활성화  book_add → book_complete      ← 비어 있던 구간
+ *   차별화  taste_analysis_run
+ *   확산    share_click
+ *
+ * ⚠️ 이름을 바꾸면 GA4 에 쌓인 과거 데이터와 이어지지 않는다. 새 이름은 새 이벤트다.
+ */
+export type AnalyticsEvent =
+  | 'cta_click'
+  | 'scroll_depth'
+  | 'signup_start'
+  /** 책을 서재에 담았다. status 로 어떤 상태로 담았는지 함께 본다 */
+  | 'book_add'
+  /** 완독으로 **전환**됐다. 이미 완독인 책을 다시 저장한 것은 세지 않는다 */
+  | 'book_complete'
+  /** AI 취향 분석을 실행했다 */
+  | 'taste_analysis_run'
+  /** 공유를 눌렀다. method 로 네이티브 공유/링크 복사를 구분한다 */
+  | 'share_click';
 
 export const trackEvent = (
   event: AnalyticsEvent,

--- a/apps/page0127/src/widgets/book/ui/BookEditPageClient.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookEditPageClient.tsx
@@ -9,10 +9,13 @@ import { Card, CardContent, CardHeader, Skeleton } from '@repo/ui';
 import { ErrorBoundary, PageContainer } from '@repo/ui';
 import { toast } from 'sonner';
 
+import { trackEvent } from '@/shared/lib/analytics/trackEvent';
 import {
   upgradeImageResolution,
   validateSpineImageUrl,
 } from '@/shared/lib/imageUtils';
+
+import { isNewlyCompleted } from '@/entities/book/model/completion';
 
 import { useBookCRUD } from '@/features/book/api/useBookCRUD';
 import { useBookSearch } from '@/features/book/api/useBookSearch';
@@ -90,6 +93,10 @@ export const BookEditPageClient = ({
   const handleSubmit = async (formData: BookFormData) => {
     setIsUpdating(true);
 
+    // 저장 **전에** 판정해야 한다 — updateBook 이 성공하면 book 은 이미 새 상태다.
+    // 판정 규칙은 서버가 활동 기록을 만들 때 쓰는 것과 같은 함수를 쓴다.
+    const justCompleted = isNewlyCompleted(book?.status, formData.status);
+
     // 책을 다시 선택했다면 도서 자체 정보(제목/저자/표지 등)도 함께 갱신
     const updates: Partial<BookInput> = { ...formData };
     if (reselectedBook) {
@@ -111,6 +118,8 @@ export const BookEditPageClient = ({
     const result = await updateBook(id, updates);
 
     if (result) {
+      if (justCompleted) trackEvent('book_complete', { from: 'edit' });
+
       toast.success('도서 정보가 수정되었습니다!');
       router.push(`/${username}/${id}`); // 수정한 책 상세로 이동
 

--- a/apps/page0127/src/widgets/public-library/PublicLibraryHeader.tsx
+++ b/apps/page0127/src/widgets/public-library/PublicLibraryHeader.tsx
@@ -17,6 +17,7 @@ import {
   MONTHLY_LIMIT,
   USAGE_LIMIT_EXCEEDED_MESSAGE,
 } from '@/shared/lib/aiUsage';
+import { trackEvent } from '@/shared/lib/analytics/trackEvent';
 
 import { getPersonalityColor } from '@/entities/taste-analysis/model/personalityTypes';
 
@@ -102,6 +103,8 @@ export const PublicLibraryHeader = ({
 
     try {
       await apiClient.post('/taste-analysis/analyze');
+      // 성공한 것만 센다 — 월 한도 초과나 실패는 "실행"이 아니다
+      trackEvent('taste_analysis_run');
       toast.success('취향 분석이 완료되었습니다!');
       // 분석 성공으로 남은 횟수가 줄었으므로, 다른 화면으로 이동하기 전에
       // 이 라우트의 캐시를 무효화해둔다 — 나중에 "내 서재로" 등으로


### PR DESCRIPTION
## 왜

GA 이벤트가 **랜딩의 둘뿐**이었다 — `cta_click`, `signup_start`. "들어와서 버튼을
눌렀다"까지만 알고 그 뒤로 무엇을 했는지 몰랐다. 이 서비스의 활성화는 첫 책을 꽂고
완독을 찍는 순간인데 정작 그 두 지점이 계측 밖이었다.

베타를 열면 그때부터 데이터가 쌓인다. 지금 안 심으면 초기 유입은 영영 복원할 수 없다.

```
랜딩    cta_click · signup_start
활성화  book_add → book_complete      ← 비어 있던 구간
차별화  taste_analysis_run
확산    share_click
```

## 1. GA 신호가 CSP 에 막혀 있었다 (`12de9ad`)

GA4 는 주 수집 경로(`google-analytics.com`) 외에 **`www.google.com/g/collect`** 로도
신호를 보낸다. `connect-src` 에 그 호스트가 없어 차단되고 있었다.

증상이 고약하다 — 이벤트는 정상으로 나가서 GA 화면에 숫자가 뜬다. 대신 Google 신호가
채우는 **인구통계·관심사·교차기기만 조용히 빈다.** 무엇이 빠졌는지 화면만 봐선 모른다.

호스트가 `google-analytics.com` 이 아니라 `google.com` 이라 눈으로 훑을 때
"GA 는 이미 허용돼 있네"로 넘어가기 쉽다.

**재현 조건이 까다롭다** — 페이지 로드 직후엔 안 나가고 체류가 쌓인 뒤
`user_engagement` 와 함께 나간다. 잠깐 열어보는 것만으로는 안 잡힌다. 스크롤·페이지
이동을 섞어 40초쯤 두니 운영에서 4건 차단됐다.

## 2. 완독은 상태가 아니라 **전환**을 센다 (`02908b1`)

"지금 `completed` 인가"로 세면 **이미 완독한 책의 메모만 고쳐 저장해도 완독이 한 건씩
늘어난다.** 서버 라우트는 원래 전환으로 판정하고 있었는데, 클라이언트에 같은 조건을 또
적으면 한쪽만 고치는 날 활동 기록과 GA 수치가 어긋난다 — 어긋나도 아무도 모른다는 게
더 나쁘다.

`isNewlyCompleted` 순수 함수로 묶고 **서버 라우트도 그걸 쓰게** 했다. 계측을 붙이면서
오히려 중복이 하나 줄었다.

편집 화면에서는 **저장 전에** 판정한다. `updateBook` 이 성공하면 `book` 은 이미 새
상태라 그 뒤에 비교하면 항상 `false` 다.

등록하면서 바로 완독으로 담는 흐름은 편집 화면을 거치지 않는다. 거기서 안 세면 그
완독이 통째로 누락되므로 등록 지점에서도 함께 센다(`from: 'register' | 'edit'`).

## 검증

| 확인 | 결과 |
| --- | --- |
| 전환 판정 테스트 7개 | 통과 (읽는 중→완독 / 신규 등록을 완독으로 / 완독→완독 / 완독→읽는 중 / status 없는 부분 갱신) |
| CSP 헤더 | 로컬 응답에 `https://www.google.com` 포함 확인 |
| lint · type-check · test | 통과 (316 → **323**) |

⚠️ **클라이언트 이벤트 발사는 헤드리스에서 확인하지 못했다.** `navigator.clipboard` 가
권한 대기로 멈춰 공유 경로가 끝까지 가지 않는다(토스트조차 안 뜬다). 이벤트 이름은
유니온 타입이라 오타는 타입 검사가 잡지만, **실제 발사는 배포 후 GA 실시간 보고서에서
눈으로 확인해야 한다.**

## 남겨 둔 것

`login_success` 는 넣지 않았다. OAuth 콜백은 서버 라우트라 `gtag` 를 부를 수 없고,
클라이언트로 신호를 넘기려면 리디렉션에 파라미터를 얹거나 `ensureProfile` 이 "방금
만들었는가"를 돌려줘야 한다. 계측 하나 때문에 인증 경로를 건드리는 건 비용이 크다 —
당분간은 `/login` → `/{username}` 페이지 이동 순서로 대신 본다.
