### PR TITLE
🎨 UI/UX: 배너 카피 유통기한 제거 + 모바일 테마 색

### DIFF
--- a/apps/page0127/app/layout.tsx
+++ b/apps/page0127/app/layout.tsx
@@ -10,7 +10,7 @@ import { CurrentUserProvider } from '@/entities/user';
 
 import { VisitReporter } from '@/widgets/visit/VisitReporter';
 
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 
 import './globals.css';
 
@@ -41,6 +41,20 @@ const siteDescription =
   - Open Graph/트위터 이미지의 상대 경로를 절대 URL로 변환하는 기준
   - opengraph-image.tsx가 생성한 /opengraph-image 도 이 기준으로 절대화됨
 */
+/*
+  뷰포트·테마 색
+
+  themeColor 는 모바일 브라우저의 주소창·상태바 색을 바꾼다. 안드로이드 크롬에서
+  화면 맨 위 띠가 브랜드 색이 되어, 스크롤하는 동안 브랜드 인상이 화면 밖까지
+  이어진다. 값은 파비콘 바탕과 같은 blue/600 이다 — 다르면 아이콘과 띠가 따로 논다.
+
+  metadata 가 아니라 viewport 로 나가는 이유: Next.js 14부터 themeColor·colorScheme·
+  viewport 는 metadata 에서 분리됐다. metadata 에 두면 빌드 경고가 뜬다.
+*/
+export const viewport: Viewport = {
+  themeColor: '#1e69cb',
+};
+
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: siteTitle,

--- a/apps/page0127/src/widgets/landing/model/heroSlides.test.ts
+++ b/apps/page0127/src/widgets/landing/model/heroSlides.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { heroSlidesFor } from './heroSlides';
+
+/** 슬라이드에 실린 사람이 읽는 글자를 전부 모은다 */
+const allCopy = (now: Date) =>
+  heroSlidesFor(now)
+    .flatMap((slide) => [slide.eyebrow, ...slide.lines, slide.sub, slide.cta])
+    .join(' ');
+
+describe('heroSlidesFor', () => {
+  it('eyebrow 의 연도가 호출 시점을 따라간다', () => {
+    const goal = heroSlidesFor(new Date(2027, 2, 1)).find(
+      (slide) => slide.id === 'goal'
+    );
+
+    expect(goal?.eyebrow).toBe('2027년 독서 목표');
+  });
+
+  it('연도 말고는 시점에 묶이는 표현을 쓰지 않는다', () => {
+    // 이전 카피는 `2026년 하반기 / 올해 절반이 지났어요 / 남은 여섯 달의 목표` 였다.
+    // 7월에만 맞는 말이라 몇 달 지나면 "관리되고 있다"는 신호가 정반대로 뒤집힌다.
+    const copy = allCopy(new Date(2026, 0, 1));
+
+    for (const stale of [
+      '상반기',
+      '하반기',
+      '절반',
+      '분기',
+      '이번 달',
+      '이번 주',
+      '여섯 달',
+    ]) {
+      expect(copy).not.toContain(stale);
+    }
+  });
+
+  it('2인칭 대명사를 쓰지 않는다', () => {
+    // 밀리의서재 UI 문구를 실측해 세운 규칙이다(이 파일 상단 주석).
+    // 규칙이 주석에만 있으면 다음 사람이 모른 채 되돌린다.
+    expect(allCopy(new Date(2026, 7, 6))).not.toContain('당신');
+  });
+
+  it('메인 카피는 두 줄이다', () => {
+    for (const slide of heroSlidesFor(new Date(2026, 7, 6))) {
+      expect(slide.lines).toHaveLength(2);
+    }
+  });
+});

--- a/apps/page0127/src/widgets/landing/model/heroSlides.ts
+++ b/apps/page0127/src/widgets/landing/model/heroSlides.ts
@@ -8,6 +8,9 @@
  * - "당신"을 쓰지 않는다 (밀리도 UI 문구엔 0회)
  *
  * 배너는 편집 산출물이므로 코드가 아니라 이 파일만 고치면 되도록 분리했다.
+ *
+ * ⚠️ 이건 **폴백**이다. `hero_slides` 테이블에 켜진 슬라이드가 있으면 그쪽이 이긴다
+ * (`entities/banner/api/getActiveHeroSlides`). DB 슬라이드의 카피는 어드민에서 고친다.
  */
 import type { HeroSlide } from '@/entities/banner/types';
 
@@ -15,7 +18,18 @@ import type { HeroSlide } from '@/entities/banner/types';
 // 기존 import 경로(@/widgets/landing/model/heroSlides)를 깨지 않도록 재export한다.
 export type { HeroSlide };
 
-export const HERO_SLIDES: HeroSlide[] = [
+/**
+ * 슬라이드를 **호출 시점 기준으로** 만든다.
+ *
+ * 상수 배열이 아니라 함수인 이유: eyebrow 에 날짜를 박는 규칙 때문에 카피가 낡는다.
+ * 실제로 `2026년 하반기 / 올해 절반이 지났어요 / 남은 여섯 달의 목표` 가 박혀 있었는데,
+ * 이건 7월에만 맞는 말이다. 몇 달만 지나도 "누군가 관리하고 있다"는 신호가
+ * **정반대 신호**로 뒤집힌다 — 갱신을 잊은 사이트로 읽힌다.
+ *
+ * 그래서 시점에 묶이는 표현은 **연도 하나만** 남기고 전부 걷어냈다. 연도는 계산으로
+ * 따라가므로 손대지 않아도 맞고, "올해 목표"라는 맥락은 그대로 산다.
+ */
+export const heroSlidesFor = (now: Date): HeroSlide[] => [
   {
     id: 'shelf',
     eyebrow: 'page0127',
@@ -49,8 +63,8 @@ export const HERO_SLIDES: HeroSlide[] = [
   },
   {
     id: 'goal',
-    eyebrow: '2026년 하반기',
-    lines: ['올해 절반이 지났어요', '남은 여섯 달의 목표'],
+    eyebrow: `${now.getFullYear()}년 독서 목표`,
+    lines: ['한 해의 목표를', '숫자로 세워 보세요'],
     sub: '연간 목표를 세우고, 달력에 완독의 흔적을 남겨 보세요.',
     href: '/login',
     cta: '목표 세우기',

--- a/apps/page0127/src/widgets/landing/ui/HeroBannerSection.tsx
+++ b/apps/page0127/src/widgets/landing/ui/HeroBannerSection.tsx
@@ -2,7 +2,7 @@ import { createClient } from '@/shared/config/supabase/server';
 
 import { getActiveHeroSlides } from '@/entities/banner/api/getActiveHeroSlides';
 
-import { HERO_SLIDES } from '@/widgets/landing/model/heroSlides';
+import { heroSlidesFor } from '@/widgets/landing/model/heroSlides';
 import { HeroBanner } from '@/widgets/landing/ui/HeroBanner';
 
 type RankingRow = { book_info: { cover_image: string | null } | null };
@@ -28,8 +28,10 @@ export const HeroBannerSection = async () => {
     .map((row) => row.book_info?.cover_image)
     .filter((url): url is string => Boolean(url));
 
-  // 켜진 슬라이드를 DB에서, 비면 코드 상수 폴백
-  const slides = await getActiveHeroSlides(HERO_SLIDES);
+  // 켜진 슬라이드를 DB에서, 비면 코드 폴백.
+  // 폴백을 요청 시점으로 만드는 이유: eyebrow 의 연도가 해가 바뀌어도 따라가야 한다
+  // (모듈 상수로 두면 서버가 떠 있는 동안 작년 연도가 박혀 있는다).
+  const slides = await getActiveHeroSlides(heroSlidesFor(new Date()));
 
   return <HeroBanner slides={slides} covers={covers} />;
 };


### PR DESCRIPTION
## 무엇을

공개 오픈 점검 스펙(`docs/superpowers/specs/2026-08-06-golive-checklist-design.md`, PR #87)의 P0-4·P1-2 두 항목입니다.

- 히어로 배너 네 번째 슬라이드에서 **시점에 묶이는 카피 제거**
- 모바일 브라우저 주소창 **테마 색** 지정

## 왜

### 배너 카피에 유통기한이 있었다

`2026년 하반기 / 올해 절반이 지났어요 / 남은 여섯 달의 목표` — **7월에만 맞는 말**입니다.

이 프로젝트는 eyebrow 에 날짜·기간을 박는 편집 규칙을 씁니다. "누군가 갱신 책임을 지고 있다"는 신호를 주려는 것인데, 갱신하지 않으면 **정반대 신호**가 됩니다. 몇 달 뒤 방문한 사람은 관리를 놓은 사이트로 읽습니다.

규칙 자체는 살리되, **계산으로 따라갈 수 있는 연도만** 남겼습니다.

### 주소창이 기본 회색이었다

안드로이드 크롬에서 화면 맨 위 띠가 회색이라, 스크롤하는 동안 브랜드가 화면에서 끊깁니다. 파비콘 바탕과 같은 `blue/600` 을 씁니다.

## 어떻게

**상수 배열을 `heroSlidesFor(now)` 함수로 바꿨습니다.** 연도를 계산하려면 호출 시점이 필요합니다. 모듈 상수로 두면 서버가 떠 있는 동안 작년 연도가 박혀 있습니다.

**테스트로 규칙을 고정했습니다.** 지금까지 "시점 표현 금지"와 "2인칭 대명사 금지"는 주석에만 있었습니다. 주석은 다음 사람이 안 읽습니다.

```
✓ eyebrow 의 연도가 호출 시점을 따라간다
✓ 연도 말고는 시점에 묶이는 표현을 쓰지 않는다
✓ 2인칭 대명사를 쓰지 않는다
✓ 메인 카피는 두 줄이다
```

**`themeColor` 는 `metadata` 가 아니라 `viewport` 로 내보냅니다.** Next.js 14부터 분리됐고, `metadata` 에 두면 빌드 경고가 뜹니다.

## ⚠️ 배포 후 확인이 필요합니다

배너는 `hero_slides` 테이블이 우선이고 이 코드는 **폴백**입니다. 지금 운영 화면과 코드 폴백의 문구가 정확히 같아서 **DB 가 비어 폴백이 쓰이는 것으로 보이지만 확신할 수 없습니다.**

배포 후에도 옛 문구가 보이면 DB 에 슬라이드가 들어 있다는 뜻이니, 어드민 배너 관리에서 고쳐야 합니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `tsc --noEmit` | 통과 |
| `eslint .` | 통과 |
| 배너 카피 테스트 | 4개 통과 |

## 스펙 정정 사항 (별건)

스펙의 **P0-5 "미사용 이미지 7.5MB 가 배포에 실림" 은 사실이 아니었습니다.** 삭제 직전에 확인하니 `.gitignore` 18행의 `*.png` 에 걸려 **저장소에 아예 없고, 따라서 배포에도 실리지 않습니다.** 지우면 로컬 원본만 영구 소멸하므로 삭제하지 않았습니다. 스펙 문서 정정은 PR #87 머지 후 하겠습니다.