### PR TITLE
✨ Feat: 어드민 홈에 매일 볼 숫자를 올린다

### DIFF
--- a/apps/page0127/app/(admin)/admin/page.tsx
+++ b/apps/page0127/app/(admin)/admin/page.tsx
@@ -1,24 +1,73 @@
+import { Suspense } from 'react';
+
 import Link from 'next/link';
+
+import { ErrorBoundary } from '@repo/ui';
+
+import { getOverview } from '@/features/admin-overview/api/getOverview';
+import { OverviewCards } from '@/features/admin-overview/ui/OverviewCards';
+
+// 지표는 매번 새로 읽는다. 어드민은 방금 일어난 일을 보러 오는 화면이라
+// 캐시된 숫자를 보여주면 "왜 안 늘지"로 시간을 쓴다.
+export const dynamic = 'force-dynamic';
 
 const CARDS = [
   { href: '/admin/reports', title: '신고', desc: '접수된 신고 확인·댓글 숨김' },
+  { href: '/admin/quality', title: '품질', desc: 'Lighthouse·번들·실사용자 지표' },
+  { href: '/admin/errors', title: '에러', desc: 'Sentry 이슈 분류' },
   { href: '/admin/costs', title: 'AI 비용', desc: '이번 달 사용액과 예산 대비' },
   { href: '/admin/members', title: '회원 관리', desc: '가입자 조회·정지' },
+  { href: '/admin/banners', title: '메인 배너', desc: '랜딩 히어로 슬라이드' },
 ];
+
+const OverviewSection = async () => {
+  const overview = await getOverview();
+  return <OverviewCards overview={overview} />;
+};
+
+const OverviewSkeleton = () => (
+  <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-4'>
+    {Array.from({ length: 4 }, (_, i) => (
+      <div
+        key={i}
+        className='h-24 animate-pulse rounded-lg border border-line bg-sunken'
+      />
+    ))}
+  </div>
+);
 
 export default function AdminHomePage() {
   return (
-    <section className='grid gap-4 sm:grid-cols-2'>
-      {CARDS.map((c) => (
-        <Link
-          key={c.href}
-          href={c.href}
-          className='rounded border border-line p-4 hover:bg-accent'
-        >
-          <div className='text-sm font-medium'>{c.title}</div>
-          <p className='mt-1 text-sm text-text-subtle'>{c.desc}</p>
-        </Link>
-      ))}
-    </section>
+    <div className='space-y-8'>
+      {/* 지표 조회가 실패해도 아래 이동 링크는 살아 있어야 한다 —
+          숫자를 못 읽는 것과 콘솔을 못 쓰는 것은 다른 사고다 */}
+      <ErrorBoundary
+        fallback={
+          <p className='rounded-lg border border-line p-4 text-sm text-text-subtle'>
+            지표를 불러오지 못했습니다.
+          </p>
+        }
+      >
+        <Suspense fallback={<OverviewSkeleton />}>
+          <OverviewSection />
+        </Suspense>
+      </ErrorBoundary>
+
+      <section>
+        <h2 className='mb-3 text-sm font-medium'>바로가기</h2>
+        <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+          {CARDS.map((c) => (
+            <Link
+              key={c.href}
+              href={c.href}
+              className='rounded-lg border border-line p-4 transition-colors hover:bg-accent'
+            >
+              <div className='text-sm font-medium'>{c.title}</div>
+              <p className='mt-1 text-sm text-text-subtle'>{c.desc}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/page0127/src/features/admin-overview/api/getOverview.ts
+++ b/apps/page0127/src/features/admin-overview/api/getOverview.ts
@@ -1,0 +1,137 @@
+import { createAdminClient } from '@/shared/config/supabase/admin';
+
+import {
+  kstDateToUtcEnd,
+  kstDateToUtcStart,
+  resolveMetricPeriod,
+} from '../lib/period';
+
+/**
+ * 어드민 홈이 매일 아침 보여줄 숫자.
+ *
+ * 지금까지 홈은 링크 카드 세 장뿐이라, "어제 몇 명 왔고 몇 권 등록됐나"를 보려면
+ * 화면을 다섯 개 돌아야 했다. 매일 볼 것은 한 화면에 있어야 실제로 매일 본다.
+ *
+ * service_role 로 읽는다 — RLS 는 본인 것만 보여주므로 전체 집계가 안 된다.
+ * (admin-members·admin-reports 와 같은 경로)
+ */
+
+export type AdminOverview = {
+  /** 집계 기준일 (KST). 화면에 박아 "언제까지의 숫자인지" 밝힌다 */
+  yesterday: string;
+  today: string;
+
+  /** 지금 사람이 처리해야 하는 것 — 0 이 아니면 화면이 이걸 먼저 말한다 */
+  pendingReports: number;
+
+  members: { total: number; yesterday: number };
+  books: { total: number; yesterday: number };
+  completions: { yesterday: number };
+  /** 방문자 — user_daily_visits 는 하루 한 사람 한 줄이라 그대로 세면 DAU 다 */
+  visitors: { yesterday: number; last7Days: number; today: number };
+};
+
+/** count 전용 조회 — head:true 라 행을 안 가져온다 */
+const countRows = async (
+  build: () => PromiseLike<{ count: number | null; error: unknown }>
+): Promise<number> => {
+  const { count, error } = await build();
+  if (error) {
+    // 지표 하나가 실패해도 화면 전체가 죽지 않게 0 으로 떨어뜨린다.
+    // 조용히 0 이 되면 "진짜 0" 과 구분이 안 되므로 로그는 남긴다.
+    console.error('어드민 지표 조회 실패:', error);
+    return 0;
+  }
+  return count ?? 0;
+};
+
+export const getOverview = async (): Promise<AdminOverview> => {
+  const supabase = createAdminClient();
+  const { today, yesterday, weekStart } = resolveMetricPeriod(new Date());
+
+  const yStart = kstDateToUtcStart(yesterday);
+  const yEnd = kstDateToUtcEnd(yesterday);
+
+  const [
+    pendingReports,
+    membersTotal,
+    membersYesterday,
+    booksTotal,
+    booksYesterday,
+    completionsYesterday,
+    visitorsYesterday,
+    visitorsWeek,
+    visitorsToday,
+  ] = await Promise.all([
+    countRows(() =>
+      supabase
+        .from('reports')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'pending')
+    ),
+    countRows(() =>
+      supabase.from('profiles').select('id', { count: 'exact', head: true })
+    ),
+    countRows(() =>
+      supabase
+        .from('profiles')
+        .select('id', { count: 'exact', head: true })
+        .gte('created_at', yStart)
+        .lt('created_at', yEnd)
+    ),
+    countRows(() =>
+      supabase.from('books').select('id', { count: 'exact', head: true })
+    ),
+    countRows(() =>
+      supabase
+        .from('books')
+        .select('id', { count: 'exact', head: true })
+        .gte('created_at', yStart)
+        .lt('created_at', yEnd)
+    ),
+    // 완독은 completed_date(날짜 컬럼)를 본다. status 만 보면 "어제 완독으로
+    // 바꾼 것"이 아니라 "지금 완독 상태인 것"을 세게 된다.
+    countRows(() =>
+      supabase
+        .from('books')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'completed')
+        .eq('completed_date', yesterday)
+    ),
+    countRows(() =>
+      supabase
+        .from('user_daily_visits')
+        .select('user_id', { count: 'exact', head: true })
+        .eq('visit_date', yesterday)
+    ),
+    // 최근 7일은 **연인원**이다(같은 사람이 3일 오면 3). 순 방문자가 아니라는
+    // 것을 화면 문구로도 밝힌다 — 둘을 헷갈리면 재방문율을 잘못 읽는다.
+    countRows(() =>
+      supabase
+        .from('user_daily_visits')
+        .select('user_id', { count: 'exact', head: true })
+        .gte('visit_date', weekStart)
+        .lte('visit_date', yesterday)
+    ),
+    countRows(() =>
+      supabase
+        .from('user_daily_visits')
+        .select('user_id', { count: 'exact', head: true })
+        .eq('visit_date', today)
+    ),
+  ]);
+
+  return {
+    yesterday,
+    today,
+    pendingReports,
+    members: { total: membersTotal, yesterday: membersYesterday },
+    books: { total: booksTotal, yesterday: booksYesterday },
+    completions: { yesterday: completionsYesterday },
+    visitors: {
+      yesterday: visitorsYesterday,
+      last7Days: visitorsWeek,
+      today: visitorsToday,
+    },
+  };
+};

--- a/apps/page0127/src/features/admin-overview/lib/period.test.ts
+++ b/apps/page0127/src/features/admin-overview/lib/period.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  kstDateToUtcEnd,
+  kstDateToUtcStart,
+  resolveMetricPeriod,
+} from './period';
+
+describe('resolveMetricPeriod', () => {
+  it('KST 기준으로 오늘·어제·7일 시작을 잡는다', () => {
+    // 2026-08-06 12:00 KST = 2026-08-06 03:00 UTC
+    const now = new Date('2026-08-06T03:00:00Z');
+    expect(resolveMetricPeriod(now)).toEqual({
+      today: '2026-08-06',
+      yesterday: '2026-08-05',
+      weekStart: '2026-07-30',
+    });
+  });
+
+  it('UTC 로는 전날이지만 KST 로는 오늘인 시각을 오늘로 본다', () => {
+    // 2026-08-06 08:00 KST = 2026-08-05 23:00 UTC
+    // UTC 기준으로 계산하면 today 가 08-05 로 하루 밀린다
+    const now = new Date('2026-08-05T23:00:00Z');
+    expect(resolveMetricPeriod(now).today).toBe('2026-08-06');
+    expect(resolveMetricPeriod(now).yesterday).toBe('2026-08-05');
+  });
+
+  it('월이 바뀌는 경계에서도 어제를 제대로 잡는다', () => {
+    // 2026-09-01 09:00 KST = 2026-09-01 00:00 UTC
+    const now = new Date('2026-09-01T00:00:00Z');
+    const period = resolveMetricPeriod(now);
+    expect(period.today).toBe('2026-09-01');
+    expect(period.yesterday).toBe('2026-08-31');
+  });
+});
+
+describe('kstDateToUtcStart / End', () => {
+  it('KST 자정을 UTC 로 옮긴다 (전날 15:00Z)', () => {
+    expect(kstDateToUtcStart('2026-08-06')).toBe('2026-08-05T15:00:00.000Z');
+  });
+
+  it('끝은 다음 날 KST 자정이다', () => {
+    expect(kstDateToUtcEnd('2026-08-06')).toBe('2026-08-06T15:00:00.000Z');
+  });
+
+  it('시작과 끝의 간격은 정확히 하루다', () => {
+    const start = new Date(kstDateToUtcStart('2026-08-06')).getTime();
+    const end = new Date(kstDateToUtcEnd('2026-08-06')).getTime();
+    expect(end - start).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it('KST 오전 8시에 만들어진 기록은 그날 범위에 들어간다', () => {
+    // 문자열 비교(UTC 기준)로 하면 전날로 새어 나가는 시각이다
+    const createdAt = new Date('2026-08-05T23:00:00Z'); // = 08-06 08:00 KST
+    const start = new Date(kstDateToUtcStart('2026-08-06'));
+    const end = new Date(kstDateToUtcEnd('2026-08-06'));
+    expect(createdAt >= start && createdAt < end).toBe(true);
+  });
+});

--- a/apps/page0127/src/features/admin-overview/lib/period.ts
+++ b/apps/page0127/src/features/admin-overview/lib/period.ts
@@ -1,0 +1,48 @@
+import { toKstDateKey } from '@/shared/lib/date';
+
+/**
+ * 어드민 지표가 보는 기간 계산.
+ *
+ * 왜 "어제"가 기준인가:
+ * 오늘은 아직 안 끝났다. 오전 9시에 "오늘 방문자 1명"을 보면 서비스가 죽은 줄
+ * 안다 — 실제로는 하루가 시작됐을 뿐이다. **끝난 날끼리 비교해야** 늘었는지
+ * 줄었는지 알 수 있다. 오늘 숫자도 함께 보여주되 "진행 중"임을 밝힌다.
+ *
+ * 날짜 경계는 전부 KST 다. user_daily_visits.visit_date 가 toKstDateKey 로
+ * 쌓이므로(=/api/visit), 조회도 같은 기준을 써야 하루가 어긋나지 않는다.
+ */
+
+/** 하루 밀리초 */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type MetricPeriod = {
+  /** KST 오늘 (YYYY-MM-DD) — 아직 진행 중인 날 */
+  today: string;
+  /** KST 어제 — 지표의 기준일 */
+  yesterday: string;
+  /** 최근 7일의 시작일(어제 포함 7일) */
+  weekStart: string;
+};
+
+/**
+ * @param now 기준 시각. 테스트가 고정 시각을 넣을 수 있게 인자로 받는다
+ */
+export const resolveMetricPeriod = (now: Date): MetricPeriod => ({
+  today: toKstDateKey(now),
+  yesterday: toKstDateKey(new Date(now.getTime() - DAY_MS)),
+  // 어제를 마지막 날로 하는 7일 구간 → 어제로부터 6일 전이 시작
+  weekStart: toKstDateKey(new Date(now.getTime() - 7 * DAY_MS)),
+});
+
+/**
+ * KST 날짜 문자열을 그 날 00:00(KST)의 UTC 시각으로 바꾼다.
+ *
+ * created_at 같은 timestamptz 컬럼을 날짜로 거를 때 쓴다. 문자열 비교로 하면
+ * UTC 기준이 되어 **KST 오전 9시 이전에 만들어진 것이 전날로 새어 나간다.**
+ */
+export const kstDateToUtcStart = (dateKey: string): string =>
+  new Date(`${dateKey}T00:00:00+09:00`).toISOString();
+
+/** 그 날의 끝(다음 날 00:00 KST) — 범위 조회의 상한으로 쓴다 */
+export const kstDateToUtcEnd = (dateKey: string): string =>
+  new Date(new Date(`${dateKey}T00:00:00+09:00`).getTime() + DAY_MS).toISOString();

--- a/apps/page0127/src/features/admin-overview/ui/OverviewCards.tsx
+++ b/apps/page0127/src/features/admin-overview/ui/OverviewCards.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link';
+
+import { AlertTriangle } from 'lucide-react';
+
+import type { AdminOverview } from '@/features/admin-overview/api/getOverview';
+
+type OverviewCardsProps = {
+  overview: AdminOverview;
+};
+
+type MetricProps = {
+  label: string;
+  value: number;
+  /** 값 아래 한 줄. 단위나 기준을 밝힌다 */
+  hint?: string;
+};
+
+const Metric = ({ label, value, hint }: MetricProps) => (
+  <div className='rounded-lg border border-line p-4'>
+    <p className='text-xs text-text-subtle'>{label}</p>
+    {/* tabular-nums: 숫자가 바뀌어도 자리가 흔들리지 않는다 */}
+    <p className='mt-1 text-2xl font-bold tabular-nums text-text-strong'>
+      {value.toLocaleString('ko-KR')}
+    </p>
+    {hint && <p className='mt-0.5 text-xs text-text-subtle'>{hint}</p>}
+  </div>
+);
+
+/**
+ * 어드민 홈 지표.
+ *
+ * 순서에 뜻이 있다 — **행동이 필요한 것이 맨 위**다. 미처리 신고는 0 이면
+ * 조용히 사라지고, 1 건이라도 있으면 눈에 띄는 배너로 올라온다. 나머지 숫자는
+ * 읽고 지나가는 것이고 신고만 손이 필요하다.
+ */
+export const OverviewCards = ({ overview }: OverviewCardsProps) => {
+  const { visitors, members, books, completions } = overview;
+
+  return (
+    <div className='space-y-6'>
+      {/* 처리할 게 있을 때만 나온다. 0 건일 때 "신고 0건" 카드를 두면
+          매일 보는 화면에 아무 의미 없는 줄이 하나 늘어난다 */}
+      {overview.pendingReports > 0 && (
+        <Link
+          href='/admin/reports'
+          className='flex items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4 transition-colors hover:bg-destructive/10'
+        >
+          <AlertTriangle aria-hidden className='size-5 text-destructive' />
+          <span className='text-sm font-medium text-destructive'>
+            미처리 신고 {overview.pendingReports}건
+          </span>
+          <span className='ml-auto text-xs text-text-subtle'>확인하기 →</span>
+        </Link>
+      )}
+
+      <section>
+        <h2 className='mb-3 text-sm font-medium'>
+          어제{' '}
+          <span className='font-normal text-text-subtle'>
+            ({overview.yesterday} 기준)
+          </span>
+        </h2>
+        <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-4'>
+          <Metric
+            label='방문자'
+            value={visitors.yesterday}
+            hint={`오늘 ${visitors.today}명 (진행 중)`}
+          />
+          <Metric label='가입' value={members.yesterday} />
+          <Metric label='등록된 책' value={books.yesterday} />
+          <Metric label='완독' value={completions.yesterday} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className='mb-3 text-sm font-medium'>누적</h2>
+        <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-4'>
+          <Metric label='회원' value={members.total} />
+          <Metric label='책' value={books.total} />
+          <Metric
+            label='최근 7일 방문'
+            value={visitors.last7Days}
+            hint='연인원 (같은 사람이 3일 오면 3)'
+          />
+        </div>
+      </section>
+    </div>
+  );
+};


### PR DESCRIPTION
## 왜

어드민 홈이 **링크 카드 세 장뿐**이었다. "어제 몇 명 왔고 몇 권 등록됐나"를 보려면
화면을 다섯 개 돌아야 했다. 곧 베타를 여는데, 매일 볼 것이 한 화면에 없으면 실제로는
매일 안 본다.

방문 데이터(`user_daily_visits`)는 이미 쌓이고 있었다. 보여주는 화면만 없었다.

## 순서에 뜻이 있다

**행동이 필요한 것이 맨 위다.** 미처리 신고는 0이면 조용히 사라지고, 1건이라도 있으면
눈에 띄는 배너로 올라온다. 나머지 숫자는 읽고 지나가는 것이고 손이 필요한 건 신고뿐이다.

0건일 때 "신고 0건" 카드를 두면 매일 보는 화면에 아무 의미 없는 줄이 하나 는다.

## "어제"가 기준인 이유

오늘은 아직 안 끝났다. 오전 9시에 "오늘 방문자 1명"을 보면 서비스가 죽은 줄 안다 —
실제로는 하루가 시작됐을 뿐이다. **끝난 날끼리 비교해야** 늘었는지 줄었는지 알 수 있다.
오늘 숫자도 함께 보여주되 `(진행 중)`을 붙인다.

## 숫자가 무엇인지 밝힌다

- **집계 기준일**(`2026-08-05`)을 제목에 박는다 — 랜딩 랭킹과 같은 규칙
- **최근 7일은 연인원**임을 적는다. 순 방문자로 오해하면 재방문율을 잘못 읽는다
- **완독은 `completed_date`로 센다.** `status`만 보면 "어제 완독한 것"이 아니라
  "지금 완독 상태인 것"을 세게 된다

## KST 를 명시한 이유

`user_daily_visits.visit_date`는 `toKstDateKey`로 쌓인다(`/api/visit`). 조회를 UTC로
하면 **하루가 통째로 어긋난다.**

`created_at` 같은 `timestamptz`를 거를 때도 마찬가지다. 날짜 문자열로 비교하면 UTC
기준이 되어 **KST 오전 9시 이전에 만들어진 것이 전날로 새어 나간다.** 그래서 경계를
UTC 시각으로 바꿔 범위 조회한다.

## 검증

**DB에서 KST 기준으로 직접 센 값과 화면 숫자가 일치한다.**

| | DB 실측 | 화면 |
| --- | --- | --- |
| 어제 방문 | 3 | 3 |
| 오늘 방문 | 2 | 2 (진행 중) |
| 어제 등록 | 2 | 2 |
| 어제 완독 | 15 | 15 |

KST 오전 8시(=UTC 전날 23시)에 만들어진 책을 일부러 심어, 문자열 비교였다면 전날로
샜을 케이스가 제대로 잡히는 것까지 확인했다.

신고를 넣으니 배너가 뜨고 기준일도 `2026-08-05`로 박혔다.

기간 계산 테스트 7개(UTC로는 전날이지만 KST로는 오늘인 시각 / 월 경계 / KST 오전 8시
기록의 소속). lint · type-check · test 통과 (335 → **342**).

## 그 밖에

- 지표 조회가 실패해도 아래 이동 링크는 살아 있게 `ErrorBoundary`로 감쌌다 —
  숫자를 못 읽는 것과 콘솔을 못 쓰는 것은 다른 사고다
- `force-dynamic` — 어드민은 방금 일어난 일을 보러 오는 화면이라 캐시된 숫자를
  보여주면 "왜 안 늘지"로 시간을 쓴다
- 바로가기를 nav와 같은 6개로 맞췄다 (품질·에러·배너가 빠져 있었다)
