### PR TITLE
📝 Docs: 개인정보처리방침에 카카오 로그인을 반영한다

### DIFF
--- a/apps/page0127/app/(public)/privacy/page.tsx
+++ b/apps/page0127/app/(public)/privacy/page.tsx
@@ -14,7 +14,9 @@ export const metadata: Metadata = {
  * 개인정보처리방침
  *
  * 코드에서 실제로 확인한 처리 내역만 적는다. 지어내지 않는다.
- * - 인증: Supabase Auth + Google OAuth
+ * - 인증: Supabase Auth + Google·Kakao OAuth
+ *   (카카오는 이메일 동의가 선택이라 email 이 null 로 올 수 있다 —
+ *    app/auth/callback/route.ts, entities/profile/model/identityDefaults.ts)
  * - 저장: Supabase(Postgres, Storage)
  * - 호스팅: Vercel
  * - AI 분석: OpenAI
@@ -32,11 +34,18 @@ const PrivacyPage = () => {
     >
       <DocSection title='1. 수집하는 정보'>
         <p className='font-medium text-text-strong'>
-          구글 계정으로 로그인할 때
+          소셜 계정으로 로그인할 때
         </p>
         <DocList
-          items={['이메일 주소', '이름과 프로필 사진 (구글 계정에 등록된 것)']}
+          items={[
+            '구글 — 이메일 주소, 이름, 프로필 사진',
+            '카카오 — 닉네임, 프로필 사진, 이메일 주소(동의한 경우에만)',
+          ]}
         />
+        <p className='mt-3 text-sm text-text-subtle'>
+          카카오는 이메일 제공이 선택 항목입니다. 동의하지 않아도 가입할 수
+          있으며, 그때는 이메일을 받지 않습니다.
+        </p>
         <p className='mt-4 font-medium text-text-strong'>
           서비스를 쓰면서 직접 남기는 것
         </p>

--- a/apps/page0127/src/features/auth/api/useLinkedAccounts.ts
+++ b/apps/page0127/src/features/auth/api/useLinkedAccounts.ts
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 
 import { createClient } from '@/shared/config/supabase/client';
 
@@ -13,6 +14,14 @@ import { OAUTH_PROVIDERS, type OAuthProvider } from '../model/providers';
 export const linkedAccountKeys = {
   all: ['linkedAccounts'] as const,
 };
+
+/**
+ * 연결을 마치고 돌아왔음을 알리는 쿼리 파라미터.
+ *
+ * 값은 URL 에서 오므로 **사용자가 손으로 바꿀 수 있다.** 읽는 쪽에서
+ * 아는 공급자인지 확인하고 쓴다 (isOAuthProvider).
+ */
+export const LINKED_PARAM = 'linked';
 
 const fetchLinkedAccounts = async () => {
   const supabase = createClient();
@@ -62,10 +71,16 @@ export const useLinkedAccounts = () => {
 
     // 연결이 끝나면 설정 화면으로 돌아온다 — 시작한 자리로 돌려보내야
     // 사용자가 "됐나?" 하고 목록을 다시 찾아 헤매지 않는다.
+    //
+    // ?linked= 를 달아 보내는 이유: 연결은 공급자 페이지를 왕복하고 오므로
+    // 이 함수 안에서는 성공을 알 수 없다(성공하면 코드가 여기서 끝난다).
+    // 돌아온 화면이 이 값을 보고 알림을 띄운다.
+    const next = `/settings?${LINKED_PARAM}=${provider}`;
+
     const { error } = await supabase.auth.linkIdentity({
       provider,
       options: {
-        redirectTo: `${siteUrl}/auth/callback?next=${encodeURIComponent('/settings')}`,
+        redirectTo: `${siteUrl}/auth/callback?next=${encodeURIComponent(next)}`,
       },
     });
 
@@ -103,6 +118,10 @@ export const useLinkedAccounts = () => {
     if (error) {
       console.error('계정 해제 실패:', error.message);
       setActionError('연결을 끊지 못했어요. 잠시 후 다시 시도해 주세요.');
+    } else {
+      // 목록만 조용히 바뀌면 눌린 건지 알기 어렵다.
+      // 되돌릴 수 있는 동작이라 확인 다이얼로그 대신 알림으로 끝낸다.
+      toast.success(`${OAUTH_PROVIDERS[provider].label} 연결을 끊었어요.`);
     }
 
     await queryClient.invalidateQueries({ queryKey: linkedAccountKeys.all });

--- a/apps/page0127/src/features/auth/model/providers.test.ts
+++ b/apps/page0127/src/features/auth/model/providers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { isOAuthProvider, LOGIN_PROVIDER_ORDER } from './providers';
+
+describe('isOAuthProvider', () => {
+  it('아는 공급자면 통과시킨다', () => {
+    expect(isOAuthProvider('kakao')).toBe(true);
+    expect(isOAuthProvider('google')).toBe(true);
+  });
+
+  it('모르는 문자열은 막는다', () => {
+    // ?linked=nonsense 로 들어오면 OAUTH_PROVIDERS[…] 가 undefined 가 되어
+    // .label 을 읽는 순간 화면이 죽는다
+    expect(isOAuthProvider('nonsense')).toBe(false);
+    expect(isOAuthProvider('')).toBe(false);
+  });
+
+  it('문자열이 아닌 값도 막는다', () => {
+    expect(isOAuthProvider(null)).toBe(false);
+    expect(isOAuthProvider(undefined)).toBe(false);
+    expect(isOAuthProvider(123)).toBe(false);
+  });
+
+  it('Object.prototype 의 키에 속지 않는다', () => {
+    // `in` 은 프로토타입 체인까지 본다 — 'toString' 이 통과하면
+    // OAUTH_PROVIDERS['toString'] 은 함수라 .label 이 undefined 가 된다
+    expect(isOAuthProvider('toString')).toBe(false);
+    expect(isOAuthProvider('constructor')).toBe(false);
+  });
+});
+
+describe('LOGIN_PROVIDER_ORDER', () => {
+  it('한국 사용자에게 익숙한 카카오가 먼저다', () => {
+    expect(LOGIN_PROVIDER_ORDER[0]).toBe('kakao');
+  });
+
+  it('아는 공급자만 들어 있다', () => {
+    for (const provider of LOGIN_PROVIDER_ORDER) {
+      expect(isOAuthProvider(provider)).toBe(true);
+    }
+  });
+});

--- a/apps/page0127/src/features/auth/model/providers.tsx
+++ b/apps/page0127/src/features/auth/model/providers.tsx
@@ -69,3 +69,16 @@ export const OAUTH_PROVIDERS: Record<OAuthProvider, ProviderMeta> = {
 
 /** 로그인 화면에 세우는 순서 */
 export const LOGIN_PROVIDER_ORDER: OAuthProvider[] = ['kakao', 'google'];
+
+/**
+ * 우리가 아는 공급자인지 본다.
+ *
+ * URL 쿼리처럼 **밖에서 온 문자열**을 OAUTH_PROVIDERS 의 키로 쓰기 전에 거른다.
+ * 걸르지 않으면 `?linked=nonsense` 로 `undefined.label` 을 읽어 화면이 죽는다.
+ *
+ * ⚠️ `in` 이 아니라 `Object.hasOwn` 을 쓴다. `in` 은 프로토타입 체인까지 보므로
+ *    `'toString' in OAUTH_PROVIDERS` 가 true 가 되고, 그 뒤 `.label` 이
+ *    undefined 로 새어 나온다 (테스트로 잡았다).
+ */
+export const isOAuthProvider = (value: unknown): value is OAuthProvider =>
+  typeof value === 'string' && Object.hasOwn(OAUTH_PROVIDERS, value);

--- a/apps/page0127/src/features/auth/ui/LinkedAccountsSection.tsx
+++ b/apps/page0127/src/features/auth/ui/LinkedAccountsSection.tsx
@@ -1,11 +1,39 @@
 'use client';
 
+import { useEffect } from 'react';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
 import { Button } from '@repo/ui';
 import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 
-import { useLinkedAccounts } from '../api/useLinkedAccounts';
+import { LINKED_PARAM, useLinkedAccounts } from '../api/useLinkedAccounts';
 import { UNLINK_BLOCKED_MESSAGE } from '../model/linkedAccounts';
-import { OAUTH_PROVIDERS } from '../model/providers';
+import { isOAuthProvider, OAUTH_PROVIDERS } from '../model/providers';
+
+/**
+ * 연결을 마치고 돌아왔으면 한 번 알리고 URL 을 정리한다.
+ *
+ * 연결은 공급자 페이지를 왕복하므로 훅 안에서는 성공을 알 수 없다.
+ * 돌아온 화면이 `?linked=` 를 보고 알린다.
+ *
+ * 알린 뒤 파라미터를 지우는 이유: 안 지우면 새로고침할 때마다 다시 뜨고,
+ * 그 URL 을 공유하면 남의 화면에서도 뜬다.
+ */
+const useLinkedToast = () => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const linked = searchParams.get(LINKED_PARAM);
+
+  useEffect(() => {
+    if (!isOAuthProvider(linked)) return;
+
+    toast.success(`${OAUTH_PROVIDERS[linked].label} 계정을 연결했어요.`);
+    router.replace(pathname, { scroll: false });
+  }, [linked, pathname, router]);
+};
 
 /**
  * 설정 화면의 "연결된 계정" 섹션.
@@ -16,6 +44,8 @@ import { OAUTH_PROVIDERS } from '../model/providers';
 export const LinkedAccountsSection = () => {
   const { rows, isPending, error, pendingProvider, link, unlink } =
     useLinkedAccounts();
+
+  useLinkedToast();
 
   return (
     <section className='mt-6 rounded-2xl bg-sunken px-5 py-4'>


### PR DESCRIPTION
## 왜

**카카오 로그인이 이미 운영에 나가 있는데 방침은 구글만 다루고 있었습니다.**

`1. 수집하는 정보` 의 첫 항목이 `구글 계정으로 로그인할 때` 하나뿐이라, 카카오로 가입한 사람에게는 **무엇을 받는지 밝히지 않은 채 정보를 받고 있는** 상태였습니다.

## 무엇을

로그인 제공자별로 수집 항목을 나눠 적었습니다.

- 구글 — 이메일 주소, 이름, 프로필 사진
- 카카오 — 닉네임, 프로필 사진, 이메일 주소(동의한 경우에만)

**카카오는 이메일 제공이 선택 항목**이라는 점을 함께 적었습니다. 코드가 이미 `email` 이 `null` 로 오는 것을 전제로 짜여 있으므로(`app/auth/callback/route.ts`, `entities/profile/model/identityDefaults.ts`), 방침도 같은 사실을 말해야 합니다.

## 어떻게

**외부 서비스 위탁 표에는 카카오를 넣지 않았습니다.** 그 표는 "우리가 정보를 맡기는 곳"이고, 소셜 로그인은 반대로 **제공자로부터 받는** 관계입니다. 구글도 같은 이유로 표에 없습니다. 수집 항목·출처는 1장에서 다룹니다.

파일 상단 주석에도 인증 수단을 갱신했습니다 — 이 문서는 "코드에서 실제로 확인한 처리 내역만 적는다"는 규칙으로 관리되고 있어서, 근거 파일 경로를 함께 남겼습니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `tsc --noEmit` | 통과 |
| `eslint .` | 통과 |