### PR TITLE
🎨 UI/UX: 다크 모드에서 사라지던 랜딩 텍스트를 살린다

### DIFF
--- a/apps/page0127/app/(public)/page.tsx
+++ b/apps/page0127/app/(public)/page.tsx
@@ -139,14 +139,10 @@ const Home = async () => {
           </Suspense>
         </ErrorBoundary>
 
-        {/* 실제 책 표지와 결과지를 함께 보여주는 에디토리얼 취향 분석 섹션 */}
-        <section
-          className='overflow-hidden rounded-2xl border border-line-soft p-7 md:p-10'
-          style={{
-            background:
-              'linear-gradient(135deg, #f8f7f3 0%, #f1f4f7 58%, #edf2f8 100%)',
-          }}
-        >
+        {/* 실제 책 표지와 결과지를 함께 보여주는 에디토리얼 취향 분석 섹션.
+            그라디언트 값은 디자인 시스템이 갖는다(tint-editorial) — 여기 hex 로
+            박혀 있던 동안 다크에서 이 면만 밝게 남아 대비가 1.07:1 이었다. */}
+        <section className='tint-editorial overflow-hidden rounded-2xl border border-line-soft p-7 md:p-10'>
           <div className='grid items-center gap-10 lg:grid-cols-[5fr_7fr] lg:gap-14'>
             <div className='max-w-md'>
               <p className='flex items-center gap-2 text-xs font-medium text-primary'>
@@ -164,7 +160,7 @@ const Home = async () => {
               </p>
 
               <div className='mt-8 flex flex-wrap items-center gap-2 text-xs font-medium text-text-subtle'>
-                <span className='flex items-center gap-1.5 rounded-full bg-white/80 px-3 py-2'>
+                <span className='tint-chip flex items-center gap-1.5 rounded-full px-3 py-2'>
                   <BookOpen aria-hidden='true' className='size-3.5' />
                   완독 기록
                 </span>
@@ -172,7 +168,7 @@ const Home = async () => {
                   aria-hidden='true'
                   className='size-3.5 text-text-subtle'
                 />
-                <span className='flex items-center gap-1.5 rounded-full bg-white/80 px-3 py-2'>
+                <span className='tint-chip flex items-center gap-1.5 rounded-full px-3 py-2'>
                   <ScanSearch aria-hidden='true' className='size-3.5' />
                   패턴 분석
                 </span>
@@ -180,7 +176,7 @@ const Home = async () => {
                   aria-hidden='true'
                   className='size-3.5 text-text-subtle'
                 />
-                <span className='flex items-center gap-1.5 rounded-full bg-white/80 px-3 py-2'>
+                <span className='tint-chip flex items-center gap-1.5 rounded-full px-3 py-2'>
                   <Sparkles aria-hidden='true' className='size-3.5' />
                   취향 노트
                 </span>
@@ -189,7 +185,7 @@ const Home = async () => {
 
             <Suspense
               fallback={
-                <div className='min-h-96 animate-pulse rounded-2xl border border-line-soft bg-white/70' />
+                <div className='tint-chip min-h-96 animate-pulse rounded-2xl border border-line-soft' />
               }
             >
               <TasteExampleCard />
@@ -197,12 +193,11 @@ const Home = async () => {
           </div>
         </section>
 
-        {/* 시작하기 — 흰 카드 대신 네이비 밴드. 페이지 끝을 무겁게 닫는다 */}
+        {/* 시작하기 — 흰 카드 대신 네이비 밴드. 페이지 끝을 무겁게 닫는다.
+            색은 시스템이 갖는다(band-strong) — 여기 박혀 있던 #14294e 는
+            **다크 모드의 background 와 같은 색**이라 밴드가 배경에 녹았다. */}
         {!user && (
-          <section
-            className='flex flex-col items-center gap-4 rounded-2xl px-6 py-12 text-center'
-            style={{ backgroundColor: '#14294e' }}
-          >
+          <section className='band-strong flex flex-col items-center gap-4 rounded-2xl px-6 py-12 text-center'>
             <h2 className='heading-2 text-white'>
               책장은 한 권부터 시작합니다
             </h2>

--- a/apps/page0127/src/features/stats/ui/ReadingProgressOverview.tsx
+++ b/apps/page0127/src/features/stats/ui/ReadingProgressOverview.tsx
@@ -170,7 +170,7 @@ export const ReadingProgressOverview = ({
           </div>
         </div>
 
-        <div className='relative min-h-64 overflow-hidden bg-[#eef1f5] lg:min-h-full'>
+        <div className='relative min-h-64 overflow-hidden bg-sunken lg:min-h-full'>
           <div className='absolute inset-x-0 top-6 text-center'>
             <p className='text-xs font-medium tracking-[0.18em] text-text-subtle'>
               BOOKS OF {year}

--- a/apps/page0127/src/widgets/landing/ui/DiscoveryCard.tsx
+++ b/apps/page0127/src/widgets/landing/ui/DiscoveryCard.tsx
@@ -27,18 +27,22 @@ type GlobalBookRow = {
 };
 
 // 종이톤 틴트 로테이션 — 책 표지를 방해하지 않도록 채도를 낮춘다.
-const TINTS: Array<[string, string]> = [
-  ['#edf4ef', '#f8faf8'], // 세이지
-  ['#eef3f8', '#fafbfd'], // 쿨 그레이
-  ['#f7f0eb', '#fcfaf8'], // 웜 페이퍼
-  ['#f2eff6', '#faf9fc'], // 소프트 라벤더
-];
+//
+// 값은 디자인 시스템(@repo/ui styles)이 갖는다. 예전에는 여기 hex 로 박혀 있었는데,
+// 그러면 **다크 모드에서 면만 밝게 남아** 흰 글자가 흰 배경에 얹혔다(대비 1.12:1).
+// 이제 클래스만 고르고, 다크에서 무엇으로 바뀔지는 시스템이 정한다.
+const TINT_CLASSES = [
+  'tint-sage',
+  'tint-cool',
+  'tint-warm',
+  'tint-lavender',
+] as const;
 
 // 문자열 해시 → 틴트 인덱스 (같은 책은 항상 같은 색)
-const tintOf = (id: string): [string, string] => {
+const tintOf = (id: string): string => {
   let hash = 0;
   for (const ch of id) hash = (hash * 31 + ch.charCodeAt(0)) | 0;
-  return TINTS[Math.abs(hash) % TINTS.length];
+  return TINT_CLASSES[Math.abs(hash) % TINT_CLASSES.length];
 };
 
 // 소개글의 HTML 흔적을 걷어낸 뒤 첫 문장만 사용한다.
@@ -72,7 +76,7 @@ export const DiscoveryCard = async () => {
   const book = (data as GlobalBookRow[] | null)?.[0];
   if (!book) return null;
 
-  const [tintFrom, tintTo] = tintOf(book.id);
+  const tintClass = tintOf(book.id);
 
   return (
     <Link
@@ -81,10 +85,7 @@ export const DiscoveryCard = async () => {
     >
       {/* 상단 — 틴트 면: 제목·저자(좌) + 표지(우, 경계에 걸침) */}
       <div
-        className='flex min-h-56 items-start justify-between gap-4 px-7 pt-7'
-        style={{
-          background: `linear-gradient(170deg, ${tintFrom}, ${tintTo})`,
-        }}
+        className={`flex min-h-56 items-start justify-between gap-4 px-7 pt-7 ${tintClass}`}
       >
         <div className='pt-1'>
           <p className='text-lg font-bold leading-snug text-text-strong'>

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -258,6 +258,111 @@ body {
   }
 }
 
+/* ============================================
+   편집 면 틴트 — 랜딩의 발견 카드·취향 섹션이 쓰는 종이톤 배경
+
+   왜 여기로 올렸나: 이 색들이 컴포넌트 안에 hex 로 박혀 있었다. 그러면
+   **다크 모드에서 그대로 밝게 남는다.** 글자색만 토큰을 따라 밝아지므로 흰 글자가
+   흰 면 위에 얹혀 대비가 1.07~1.14:1 이 됐다(1.00 = 완전히 같은 색).
+   라이트에서 15.4:1 이던 것이 다크에서 사실상 0 이 되는데, 레이아웃은 멀쩡해서
+   더 늦게 발견되는 종류의 사고다.
+
+   왜 다크에서는 넷을 하나로 합치나: 명도 8% 대에서 "세이지"와 "웜 페이퍼"는
+   사람 눈에 같은 색이다. 구분되지 않는 차이를 지키려고 토큰을 넷 늘리는 대신
+   표준 면(sunken)으로 모은다 — 어두운 UI 의 일반적인 처리다.
+   ============================================ */
+:root {
+  /* 각 틴트는 그라디언트 두 정점을 한 벌로 갖는다 */
+  --tint-sage-from: #edf4ef;
+  --tint-sage-to: #f8faf8;
+  --tint-cool-from: #eef3f8;
+  --tint-cool-to: #fafbfd;
+  --tint-warm-from: #f7f0eb;
+  --tint-warm-to: #fcfaf8;
+  --tint-lavender-from: #f2eff6;
+  --tint-lavender-to: #faf9fc;
+
+  /* 틴트 면 위에 얹는 반투명 칩·플레이스홀더.
+     라이트에서는 흰 막이 자연스럽지만 다크에서는 면보다 밝으면 안 된다 */
+  --tint-chip: rgb(255 255 255 / 0.8);
+
+  /* 페이지를 닫는 어두운 밴드(랜딩 하단 CTA). 흰 글자를 얹는 면이다.
+     ⚠️ 라이트 값 navy/900 은 **다크 모드의 background 와 같은 색**이다.
+     그대로 두면 다크에서 밴드가 배경에 녹아 섹션 경계가 사라진다 —
+     글자는 읽히므로 "안 깨진 것처럼" 보이지만 의도한 마무리가 없어진다. */
+  --band-strong: var(--navy-900);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --tint-sage-from: var(--sunken);
+    --tint-sage-to: var(--card);
+    --tint-cool-from: var(--sunken);
+    --tint-cool-to: var(--card);
+    --tint-warm-from: var(--sunken);
+    --tint-warm-to: var(--card);
+    --tint-lavender-from: var(--sunken);
+    --tint-lavender-to: var(--card);
+    /* 어두운 면 위에서는 흰 막이 아니라 옅은 밝힘으로 단차를 만든다 */
+    --tint-chip: rgb(255 255 255 / 0.08);
+    /* 배경과 같아지지 않게 한 단 올린다. 흰 글자 대비는 8.6:1 로 여전히 넉넉하다 */
+    --band-strong: var(--navy-800);
+  }
+}
+
+/* @layer components 안에 둔다 — 레이어 밖이면 호출부가 bg-* 유틸로 덮으려 해도
+   조용히 무시된다(.heading-* 와 .book-cover 가 겪은 것과 같은 함정). */
+@layer components {
+  .tint-sage {
+    background: linear-gradient(
+      170deg,
+      var(--tint-sage-from),
+      var(--tint-sage-to)
+    );
+  }
+  .tint-cool {
+    background: linear-gradient(
+      170deg,
+      var(--tint-cool-from),
+      var(--tint-cool-to)
+    );
+  }
+  .tint-warm {
+    background: linear-gradient(
+      170deg,
+      var(--tint-warm-from),
+      var(--tint-warm-to)
+    );
+  }
+  .tint-lavender {
+    background: linear-gradient(
+      170deg,
+      var(--tint-lavender-from),
+      var(--tint-lavender-to)
+    );
+  }
+
+  /* 취향 분석 섹션의 넓은 편집 면. 발견 카드보다 각도가 얕고 정점이 셋이다 */
+  .tint-editorial {
+    background: linear-gradient(
+      135deg,
+      var(--tint-warm-from) 0%,
+      var(--tint-cool-from) 58%,
+      var(--tint-cool-to) 100%
+    );
+  }
+
+  /* 틴트 면 위의 칩·플레이스홀더 */
+  .tint-chip {
+    background-color: var(--tint-chip);
+  }
+
+  /* 페이지를 닫는 어두운 밴드 */
+  .band-strong {
+    background-color: var(--band-strong);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## 왜

랜딩의 종이톤 면들이 컴포넌트 안에 hex 로 박혀 있었다. 그러면 **면만 라이트 값에
고정되고 글자색은 토큰을 따라 밝아진다.**

다크 모드에서 흰 글자가 흰 면에 얹혀 이렇게 된다.

| 면 | 다크 대비 | 라이트 대비 |
| --- | --- | --- |
| DiscoveryCard 틴트 4종 | **1.12 : 1** | 15.41 : 1 |
| 취향 섹션 그라디언트 | **1.07 : 1** | 정상 |
| `bg-white/80` 칩 | **1.00 : 1** | 정상 |

`1.00`은 글자와 배경이 **완전히 같은 색**이다. 랜딩의 핵심 섹션 두 개가 통째로 안 보인다.

**레이아웃은 멀쩡하고 글자도 DOM 에 있으므로** 스크린샷·E2E·axe 어디에도 안 걸린다.
OS 를 다크로 둔 사람만 빈 화면을 본다. 다크 모드는 PR #28 에서 병합됐지만 각 화면을
다크로 눈으로 본 기록이 없었다.

## 고친 뒤

| | 전 | 후 |
| --- | --- | --- |
| text-strong | 1.12 | **11.51** |
| text-body | 1.15 | **8.93** |
| text-subtle | 2.24 | **4.60** |

## 왜 다크에서는 틴트 넷을 하나로 합치나

명도 8% 대에서 "세이지"와 "웜 페이퍼"는 사람 눈에 같은 색이다. 구분되지 않는 차이를
지키려고 토큰을 넷 늘리는 대신 표준 면(`sunken`)으로 모은다 — 어두운 UI 의 일반적인
처리다. **라이트의 네 가지 로테이션은 그대로 살아 있다.**

## 밴드도 문제였다

하단 CTA 밴드의 `#14294e` 는 **다크 모드 `--background` 와 같은 색**이다. 밴드가
배경에 녹아 섹션 경계가 사라진다 — 글자는 읽히므로 "안 깨진 것처럼" 보이지만 페이지를
닫는 의도가 없어진다. 다크에서는 `navy/800` 으로 한 단 올렸다(흰 글자 11.51:1,
배경 대비 단차 1.25 — 시스템이 `sunken` 에 적어 둔 기준과 같다).

## 왜 인라인 style 을 걷어냈나

**인라인 `style` 은 미디어쿼리로 못 덮는다.** 틴트가 `style={{background: ...}}` 인
동안에는 어떤 다크 규칙도 이길 수 없었다. 클래스로 바꿔야 시스템이 개입할 수 있다.

값은 `@layer components` 안에 둔다. 밖에 두면 호출부가 `bg-*` 유틸로 덮으려 해도 조용히
무시된다 — `.heading-*` 와 `.book-cover` 가 이미 겪은 함정이라 주석으로 남겨 뒀다.

## 검증

- **대비는 계산으로 확인했다** (WCAG 상대휘도). CDP 다크 에뮬레이션이 allowlist 에
  막혀 있어 눈으로 못 보는 대신, 토큰이 실제로 무엇으로 치환되는지 컴파일된 CSS 에서
  확인하고 그 값으로 대비를 계산했다.
- **컴파일된 CSS** — `@media (prefers-color-scheme: dark)` 블록에 `--tint-*: var(--sunken)`,
  `--band-strong: var(--navy-800)` 이 들어간 것 확인.
- **라이트 회귀 없음** — 편집 면 gradient, 칩 `rgba(255,255,255,0.8)`, 밴드
  `rgb(20,41,78)` 전부 종전과 동일(computed style + 스크린샷).
- lint · type-check · test 통과 (**357**).

## 남겨 둔 것 + 별건 하나

`PromoCards` 의 비비드 그라디언트는 그대로 뒀다. 채도 높은 브랜드 면이라 모드에 따라
바뀔 필요가 없고 다크에서도 흰 글자가 읽힌다.

다만 그 과정에서 **별건**을 봤다 — 파랑 그라디언트 **시작점의 흰 글자가 4.36:1** 로
AA(4.5)에 0.14 못 미친다. `text-lg bold`(18px)는 WCAG Large 기준 18.66px 에 못 닿아
일반 본문 기준을 받는다. **라이트·다크 공통이라 이번 변경과 무관**해 손대지 않았다 —
브랜드 색을 바꾸는 판단이라 따로 봐야 한다.
