### PR TITLE
♿ A11y: 브라우저 실측으로 찾은 접근성·반응형 문제 4건

### DIFF
--- a/apps/page0127/app/(auth)/login/page.tsx
+++ b/apps/page0127/app/(auth)/login/page.tsx
@@ -35,6 +35,15 @@ const LoginPage = async ({ searchParams }: LoginPageProps) => {
     <div className='flex min-h-screen items-center justify-center'>
       <Card className='w-full max-w-md shadow-none'>
         <CardHeader className='text-center'>
+          {/*
+            페이지 대표 제목 — 화면에는 안 보인다.
+
+            눈에 보이는 큰 글자는 브랜드명(page0127.)인데, 그건 이 **페이지가 무엇인지**
+            를 말하지 않는다. 로그인 화면은 sitemap 에 올라가 색인되므로(위 metadata 주석
+            참조) 크롤러와 스크린리더에게 "여기는 로그인" 이라고 알려 줄 h1 이 따로 필요하다.
+            CardTitle 은 div 로 렌더돼 제목 계층에 잡히지 않는다.
+          */}
+          <h1 className='sr-only'>로그인</h1>
           <CardTitle className='heading-1'>page0127.</CardTitle>
           <CardDescription>어서 오세요. 책장이 기다리고 있어요.</CardDescription>
         </CardHeader>

--- a/apps/page0127/app/(public)/books/all/loading.tsx
+++ b/apps/page0127/app/(public)/books/all/loading.tsx
@@ -14,13 +14,20 @@ import { BookListItemSkeleton } from '@/widgets/book/ui/BookListItemSkeleton';
 export default function Loading() {
   return (
     <PageContainer width='wide'>
-      {/* Header */}
-      <div className='mb-8 flex items-center justify-between'>
-        <div className='space-y-2'>
-          <Skeleton className='h-9 w-56' />
-          <Skeleton className='h-5 w-80' />
+      {/*
+        Header
+
+        ⚠️ 스켈레톤도 375px 안에 들어와야 한다. 예전에는 부제목이 `w-80`(320px) 고정이라
+        정렬 버튼 자리(128px)와 합쳐 448px이 되어 **로딩 동안만 가로 스크롤이 생겼다.**
+        목록이 뜨면 사라지므로 눈으로는 잡기 어렵다(실측으로 발견).
+        폭을 최대치로만 두고 좁은 화면에서는 줄어들게 한다.
+      */}
+      <div className='mb-8 flex items-center justify-between gap-4'>
+        <div className='min-w-0 flex-1 space-y-2'>
+          <Skeleton className='h-9 w-full max-w-56' />
+          <Skeleton className='h-5 w-full max-w-80' />
         </div>
-        <div className='flex gap-2'>
+        <div className='flex shrink-0 gap-2'>
           <Skeleton className='h-9 w-16' />
           <Skeleton className='h-9 w-16' />
         </div>

--- a/apps/page0127/app/(public)/page.tsx
+++ b/apps/page0127/app/(public)/page.tsx
@@ -75,6 +75,16 @@ const Home = async () => {
           </Suspense>
         </ErrorBoundary>
 
+        {/*
+          페이지 대표 제목 — 화면에는 안 보이고 검색엔진과 스크린리더만 읽는다.
+
+          시각적 제목 역할은 히어로 배너가 하지만 h1 으로 삼을 수 없다. 배너 문구는
+          슬라이드마다 바뀌고 DB(hero_slides)에서 오기도 해서, 크롤러가 올 때마다
+          페이지 제목이 달라진다. 그렇다고 h1 을 비워 두면 검색엔진이 "이 페이지가
+          무엇인가" 를 판단할 첫 단서를 잃는다 — 실측 결과 랜딩의 h1 은 0개였다.
+        */}
+        <h1 className='sr-only'>page0127 — 책장을 보면, 그 사람이 보인다</h1>
+
         {/* 히어로 배너 — 자동 롤링. 실제 책 표지가 들어간다 */}
         <ErrorBoundary fallback={<HeroBannerSkeleton />}>
           <Suspense fallback={<HeroBannerSkeleton />}>

--- a/apps/page0127/src/widgets/book/ui/BookLikeButton.tsx
+++ b/apps/page0127/src/widgets/book/ui/BookLikeButton.tsx
@@ -71,6 +71,16 @@ export const BookLikeButton = ({
       className={`relative z-30 h-8 w-8 rounded-full border border-line bg-card transition-transform hover:scale-110 ${className}`}
       onClick={handleToggle}
       disabled={isPending}
+      /*
+        아이콘만 있는 버튼이라 이름을 직접 준다 — 스크린리더는 하트 그림을 읽지 못하고
+        "버튼" 이라고만 읽는다. 목록 화면에는 이런 버튼이 책 수만큼 있다.
+
+        aria-pressed 로 켜짐/꺼짐을 알린다. 라벨을 "좋아요"/"좋아요 취소" 로 바꾸는
+        방법도 있지만, 그러면 누를 때마다 이름 자체가 바뀌어 "방금 그 버튼" 을 다시
+        찾기 어렵다. 이름은 고정하고 상태만 따로 알리는 쪽이 표준이다.
+      */
+      aria-label='좋아요'
+      aria-pressed={optimisticLiked}
     >
       <Heart
         className={`h-5 w-5 transition-colors ${


### PR DESCRIPTION
## 어떻게 찾았나

오픈 전 점검(`docs/superpowers/specs/2026-08-06-golive-checklist-design.md` P2)의 일부입니다. 헤드리스 브라우저로 **운영 공개 페이지 7개를 375px 폭에서 훑었습니다.**

## ⚠️ 검증 근거 정정 (머지 후 추가)

이 PR 본문에 처음 적은 "로컬 실측으로 재확인"은 **틀린 근거였습니다.**

`localhost:3000` 이 이 작업 폴더가 아니라 **다른 워크트리(`page0127-onboarding`)** 를 서빙하고 있었습니다. 즉 이 PR 의 수정과 무관한 코드를 재고 "통과"라고 적었습니다.

작업 폴더를 별도 포트(3200)로 띄워 다시 쟀습니다. **수정 자체는 정상 동작합니다.**

| 항목 | 고치기 전 | 재검증 |
|---|---|---|
| 랜딩 `h1` | 0개 | 1개 |
| 로그인 `h1` | 0개 | 1개 (`<h1 class="sr-only">로그인</h1>`) |
| `/books/all` 이름 없는 버튼 | 20개 이상 | 1개 |

남은 1개는 하트가 아니라 **헤더 버튼**입니다 — 전 페이지 공통인 별개 문제로, 후속 PR 에서 다룹니다.

로딩 스켈레톤 폭은 **로딩 순간을 포착할 수 없어 실측하지 못했습니다.** 부모가 `flex-1 min-w-0`, 형제가 `shrink-0`(128px)이므로 왼쪽 최대 폭이 231px 로 묶여 `max-w-56`(224px) 안에 들어옵니다 — 계산으로만 확인했습니다.

**교훈:** 워크트리를 쓰는 저장소에서 `localhost` 응답은 어느 폴더에서 왔는지 확인하기 전까지 증거가 아닙니다. `ps` 로 dev 서버의 실행 경로를 먼저 봐야 합니다.

---

## 고친 것

### 1. 좋아요 버튼에 이름이 없었다

아이콘만 있는 버튼이라 스크린리더가 **"버튼"** 이라고만 읽습니다. `/books/all` 에는 이런 버튼이 **책 수만큼(실측 20개 이상)** 있습니다.

이름은 `좋아요` 로 고정하고 켜짐 여부는 `aria-pressed` 로 알립니다. 라벨을 `좋아요`/`좋아요 취소` 로 바꾸면 누를 때마다 **이름 자체가 바뀌어** "방금 그 버튼"을 다시 찾기 어렵습니다.

### 2·3. 랜딩과 로그인에 `h1` 이 아예 없었다

검색엔진이 "이 페이지가 무엇인가"를 판단하는 첫 단서입니다. 둘 다 **시각적 제목을 `h1` 으로 삼을 수 없습니다.**

- 랜딩: 히어로 배너 문구는 슬라이드마다 바뀌고 `hero_slides` 테이블에서 오기도 합니다
- 로그인: 큰 글자가 브랜드명(`page0127.`)이라 **페이지 정체를 말하지 않습니다.** `CardTitle` 은 `div` 로 렌더돼 제목 계층에도 안 잡힙니다

그래서 `sr-only` `h1` 을 따로 뒀습니다. 이 저장소에 이미 쓰이는 방식입니다.

### 4. 전체 도서 로딩 화면이 휴대폰에서 옆으로 밀렸다

375px 화면에서 스켈레톤이 **480px** 로 넘쳤습니다. 부제목 자리가 `w-80`(320px) 고정이라 정렬 버튼 자리(128px)와 합쳐 화면을 넘겼습니다. 목록이 뜨면 사라지므로 눈으로는 잡기 어렵습니다.

## 같은 점검에서 통과한 것

- **가로 스크롤**: 7개 중 6개 정상
- **포커스 표시**: 전 페이지 통과
- **이미지 대체 텍스트**: 전 페이지 통과
- **본문 바로가기 링크**: 로그인 외 전 페이지 존재

## 후속 (별도 PR)

로그인 후 화면에서 4건을 더 찾았습니다 — 신규 가입자 빈 화면 안내 없음, 하단 탭바가 콘텐츠 가림, 헤더 버튼 이름 없음, 공개 서재 `h1 → h3` 건너뜀.