### PR TITLE
✨ Feat: 배너 — 노출 대상 · 예약 게시 · 클릭 집계

### DIFF
--- a/apps/page0127/app/api/_helpers/schemaContract.ts
+++ b/apps/page0127/app/api/_helpers/schemaContract.ts
@@ -55,6 +55,14 @@ export const SCHEMA_CONTRACT: SchemaProbe[] = [
     columns: ['reporter_id', 'comment_id', 'status'],
     breaks: '신고 접수와 어드민 신고 처리 화면',
   },
+  {
+    table: 'hero_slides',
+    // audience 가 없으면 대상 필터가 통째로 사라져 비로그인용 배너("지금
+    // 가입하세요")가 로그인 사용자에게도 뜬다 — 화면은 안 깨지고 문구만
+    // 거짓말이 되는, 조용한 종류의 고장이다.
+    columns: ['audience', 'starts_at', 'ends_at', 'click_count'],
+    breaks: '랜딩 히어로 배너 — 대상·기간 필터와 클릭 집계',
+  },
 ];
 
 /** PostgREST 가 "컬럼 없음" 으로 주는 코드. 다른 실패와 구분해야 원인이 드러난다. */

--- a/apps/page0127/app/api/banners/[id]/click/route.ts
+++ b/apps/page0127/app/api/banners/[id]/click/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+
+import { getSupabaseClient } from '../../../_helpers/auth';
+import { internalErrorResponse, successResponse } from '../../../_helpers/response';
+
+/**
+ * POST /api/banners/[id]/click
+ * 배너 클릭 1회를 센다.
+ *
+ * 로그인을 요구하지 않는다 — 배너는 비로그인에게도 보이고, 그쪽 클릭이 오히려
+ * 더 중요하다(가입 전 사람이 무엇에 반응하는지).
+ *
+ * 집계 실패가 이동을 막으면 안 된다. 클라이언트는 응답을 기다리지 않고
+ * 링크를 따라가고, 여기서는 어떤 경우에도 200 을 돌려준다 — 이 숫자는
+ * 어드민이 눈으로 비교하는 참고값이지 정합성을 지켜야 하는 데이터가 아니다.
+ *
+ * 어떤 슬라이드를 셀지는 DB 가 정한다(increment_slide_click). 노출 조건을
+ * 만족하는 것만 오르므로, 지난 배너 id 로 카운터를 부풀릴 수 없다.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const supabase = await getSupabaseClient();
+
+    const { error } = await supabase.rpc('increment_slide_click', {
+      p_slide_id: id,
+    });
+
+    if (error) {
+      // 집계는 실패해도 사용자 흐름과 무관하다. 원인은 남기되 200 으로 끝낸다.
+      console.warn('[banner] 클릭 집계 실패:', error.message);
+    }
+
+    return successResponse({ ok: true });
+  } catch (error) {
+    return internalErrorResponse(error);
+  }
+}

--- a/apps/page0127/src/entities/banner/api/countBannerClick.ts
+++ b/apps/page0127/src/entities/banner/api/countBannerClick.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/shared/api/client';
+
+/**
+ * 배너 클릭을 센다. **응답을 기다리지 않는다.**
+ *
+ * 이 호출은 사용자가 링크를 따라 떠나는 순간에 일어난다. await 하면 이동이
+ * 그만큼 늦어지고, 집계가 실패하면 이동 자체가 막힐 수도 있다. 이 숫자는
+ * 어드민이 눈으로 비교하는 참고값이라 몇 건 놓쳐도 된다 — 사용자 흐름이 우선이다.
+ *
+ * 페이지를 떠나는 중이라 요청이 잘릴 수 있다. 그래서 실패를 조용히 삼킨다 —
+ * 콘솔에 남기면 정상적인 이탈이 매번 에러로 보인다.
+ */
+export const countBannerClick = (slideId: string): void => {
+  void apiClient.post(`/banners/${slideId}/click`).catch(() => {});
+};

--- a/apps/page0127/src/entities/banner/api/getActiveHeroSlides.ts
+++ b/apps/page0127/src/entities/banner/api/getActiveHeroSlides.ts
@@ -1,23 +1,32 @@
 import { createClient } from '@/shared/config/supabase/server';
 
+import { filterForViewer } from '../lib/audience';
 import { slidesOrFallback } from '../lib/mapSlides';
+import { HERO_SLIDE_COLUMNS } from '../types';
 
 import type { HeroSlide, HeroSlideRow } from '../types';
 
 /**
- * 켜진 배너 슬라이드를 sort_order 순으로 읽는다.
+ * 지금 이 사람에게 보여줄 배너 슬라이드를 sort_order 순으로 읽는다.
+ *
+ * 걸러지는 곳이 둘로 나뉜다.
+ * - **활성·기간**은 RLS 가 본다(`anyone can read published slides`). 예약 시작 전
+ *   배너의 문구가 anon 키로 미리 읽히면 안 되므로 DB 에서 막는다.
+ * - **대상**은 여기서 본다. RLS 에 auth.uid() 를 넣으면 비로그인 캐시와 로그인
+ *   캐시가 섞이기 때문에 정책에 담지 않았다.
+ *
  * 결과가 0개면 호출부가 준 폴백(코드 상수)을 반환해 랜딩이 비지 않게 한다.
- * RLS가 is_active=true만 노출하므로 anon 키로 안전하게 읽는다.
+ *
+ * @param isMember 보는 사람이 로그인 상태인가
  */
 export async function getActiveHeroSlides(
-  fallback: HeroSlide[]
+  fallback: HeroSlide[],
+  isMember: boolean
 ): Promise<HeroSlide[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('hero_slides')
-    .select(
-      'id, eyebrow, line1, line2, sub, href, cta, bg, fg, sort_order, is_active'
-    )
+    .select(HERO_SLIDE_COLUMNS)
     .eq('is_active', true)
     .order('sort_order', { ascending: true });
 
@@ -25,5 +34,7 @@ export async function getActiveHeroSlides(
     console.error('[banner] 슬라이드 조회 실패:', error.message);
     return fallback;
   }
-  return slidesOrFallback((data as HeroSlideRow[]) ?? [], fallback);
+
+  const visible = filterForViewer((data as HeroSlideRow[]) ?? [], isMember);
+  return slidesOrFallback(visible, fallback);
 }

--- a/apps/page0127/src/entities/banner/lib/audience.test.ts
+++ b/apps/page0127/src/entities/banner/lib/audience.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterForViewer, isForViewer } from './audience';
+
+describe('isForViewer', () => {
+  it("'all' 은 누구에게나 보인다", () => {
+    expect(isForViewer('all', true)).toBe(true);
+    expect(isForViewer('all', false)).toBe(true);
+  });
+
+  it("'guest' 는 비로그인에게만 보인다", () => {
+    // "지금 가입하세요" 를 이미 가입한 사람에게 보여주면 틀린 말이 된다
+    expect(isForViewer('guest', false)).toBe(true);
+    expect(isForViewer('guest', true)).toBe(false);
+  });
+
+  it("'member' 는 로그인에게만 보인다", () => {
+    expect(isForViewer('member', true)).toBe(true);
+    expect(isForViewer('member', false)).toBe(false);
+  });
+});
+
+describe('filterForViewer', () => {
+  const slides = [
+    { id: 'a', audience: 'all' as const },
+    { id: 'b', audience: 'guest' as const },
+    { id: 'c', audience: 'member' as const },
+    { id: 'd', audience: 'all' as const },
+  ];
+
+  it('비로그인은 all + guest 를 본다', () => {
+    expect(filterForViewer(slides, false).map((s) => s.id)).toEqual([
+      'a',
+      'b',
+      'd',
+    ]);
+  });
+
+  it('로그인은 all + member 를 본다', () => {
+    expect(filterForViewer(slides, true).map((s) => s.id)).toEqual([
+      'a',
+      'c',
+      'd',
+    ]);
+  });
+
+  it('순서를 바꾸지 않는다 — sort_order 로 정렬된 결과를 그대로 유지해야 한다', () => {
+    const result = filterForViewer(slides, false);
+    expect(result.map((s) => s.id)).toEqual(['a', 'b', 'd']);
+  });
+
+  it('맞는 슬라이드가 하나도 없으면 빈 배열이다 (호출부가 폴백을 결정한다)', () => {
+    expect(filterForViewer([{ id: 'x', audience: 'member' as const }], false)).toEqual(
+      []
+    );
+  });
+});

--- a/apps/page0127/src/entities/banner/lib/audience.ts
+++ b/apps/page0127/src/entities/banner/lib/audience.ts
@@ -1,0 +1,27 @@
+import type { HeroSlideRow } from '../types';
+
+/**
+ * 노출 대상 판정.
+ *
+ * ⚠️ DB 의 `is_slide_visible()` 과 같은 규칙이다. 활성·기간은 RLS 가 이미
+ * 걸러 주므로 여기서는 **대상만** 본다 — RLS 에 auth.uid() 를 넣지 않은 이유는
+ * 비로그인 캐시와 로그인 캐시가 섞이기 때문이고, 그래서 대상 판정만 앱 몫으로 남는다.
+ *
+ * 왜 필요한가: 배너 문구는 대상에 따라 참·거짓이 갈린다. "지금 가입하세요"를
+ * 이미 가입한 사람에게 보여주면 그 배너는 틀린 말을 하는 것이고, 실제로 눌러도
+ * 로그인 페이지를 거쳐 제자리로 돌아온다.
+ */
+export const isForViewer = (
+  audience: HeroSlideRow['audience'],
+  isMember: boolean
+): boolean => {
+  if (audience === 'all') return true;
+  if (audience === 'member') return isMember;
+  return !isMember; // 'guest'
+};
+
+/** 보는 사람에게 맞는 슬라이드만 남긴다 (순서는 그대로) */
+export const filterForViewer = <T extends { audience: HeroSlideRow['audience'] }>(
+  rows: T[],
+  isMember: boolean
+): T[] => rows.filter((row) => isForViewer(row.audience, isMember));

--- a/apps/page0127/src/entities/banner/lib/mapSlides.test.ts
+++ b/apps/page0127/src/entities/banner/lib/mapSlides.test.ts
@@ -16,6 +16,10 @@ const row: HeroSlideRow = {
   fg: '#fff',
   sort_order: 0,
   is_active: true,
+  audience: 'all',
+  starts_at: null,
+  ends_at: null,
+  click_count: 0,
 };
 
 describe('rowToHeroSlide', () => {

--- a/apps/page0127/src/entities/banner/types.ts
+++ b/apps/page0127/src/entities/banner/types.ts
@@ -18,6 +18,17 @@ export type HeroSlide = {
   fg: string;
 };
 
+/**
+ * 슬라이드 행이 가진 모든 컬럼.
+ *
+ * 랜딩 조회와 어드민 조회가 각각 select 문자열을 들고 있었다. 그래서 컬럼을 넷
+ * 늘렸을 때 한쪽만 고치고 다른 쪽은 그대로였고, 어드민이 click_count 를
+ * undefined 로 읽어 500 이 났다(실제로 발생). 목록을 한 곳에 두어 그 어긋남이
+ * 생길 자리를 없앤다.
+ */
+export const HERO_SLIDE_COLUMNS =
+  'id, eyebrow, line1, line2, sub, href, cta, bg, fg, sort_order, is_active, audience, starts_at, ends_at, click_count';
+
 export type HeroSlideRow = {
   id: string;
   eyebrow: string;
@@ -30,4 +41,11 @@ export type HeroSlideRow = {
   fg: string;
   sort_order: number;
   is_active: boolean;
+  /** 노출 대상 — all/guest/member. DB CHECK 과 같은 값이다 */
+  audience: 'all' | 'guest' | 'member';
+  /** 예약 게시 구간. null 이면 제한 없음 */
+  starts_at: string | null;
+  ends_at: string | null;
+  /** 누적 클릭 수 — 어드민 목록에서 눈으로 비교하는 값 */
+  click_count: number;
 };

--- a/apps/page0127/src/features/admin-banners/api/getAllSlides.ts
+++ b/apps/page0127/src/features/admin-banners/api/getAllSlides.ts
@@ -1,16 +1,14 @@
 import { createAdminClient } from '@/shared/config/supabase/admin';
 import { assertAdmin } from '@/shared/lib/admin/assertAdmin';
 
-import type { HeroSlideRow } from '@/entities/banner/types';
+import { HERO_SLIDE_COLUMNS, type HeroSlideRow } from '@/entities/banner/types';
 
 export async function getAllSlides(): Promise<HeroSlideRow[]> {
   await assertAdmin();
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from('hero_slides')
-    .select(
-      'id, eyebrow, line1, line2, sub, href, cta, bg, fg, sort_order, is_active'
-    )
+    .select(HERO_SLIDE_COLUMNS)
     .order('sort_order', { ascending: true });
 
   if (error) console.error('[admin] 배너 목록 조회 실패:', error.message);

--- a/apps/page0127/src/features/admin-banners/api/slideActions.ts
+++ b/apps/page0127/src/features/admin-banners/api/slideActions.ts
@@ -14,7 +14,21 @@ export type SlideFields = {
   cta: string;
   bg: string;
   fg: string;
+  /** 노출 대상 — all/guest/member */
+  audience: 'all' | 'guest' | 'member';
+  /** 예약 게시. 폼에서는 datetime-local 문자열이고, 비어 있으면 '제한 없음' */
+  starts_at: string;
+  ends_at: string;
 };
+
+/**
+ * 빈 문자열을 NULL 로 되돌린다.
+ *
+ * datetime-local 입력을 비우면 '' 가 오는데, 그대로 넣으면 timestamptz 캐스팅이
+ * 실패한다. 빈 값의 뜻은 "제한 없음"이므로 NULL 이어야 한다 — 여기서 안 바꾸면
+ * 운영자가 예약을 **취소할 방법이 없어진다**(한 번 넣으면 못 지운다).
+ */
+const emptyToNull = (value: string): string | null => value.trim() || null;
 
 function revalidate() {
   revalidatePath('/admin/banners');
@@ -60,9 +74,20 @@ export async function updateSlide(
   const supabase = createAdminClient();
   const { error } = await supabase
     .from('hero_slides')
-    .update({ ...fields, updated_at: new Date().toISOString() })
+    .update({
+      ...fields,
+      starts_at: emptyToNull(fields.starts_at),
+      ends_at: emptyToNull(fields.ends_at),
+      updated_at: new Date().toISOString(),
+    })
     .eq('id', id);
-  if (error) throw new Error(`슬라이드 저장 실패: ${error.message}`);
+  if (error) {
+    // 기간이 거꾸로면 DB CHECK 이 막는다 — 그 뜻을 운영자 말로 옮긴다
+    if (error.message.includes('hero_slides_period_order')) {
+      throw new Error('종료 시각이 시작 시각보다 앞설 수 없습니다.');
+    }
+    throw new Error(`슬라이드 저장 실패: ${error.message}`);
+  }
   revalidate();
 }
 

--- a/apps/page0127/src/features/admin-banners/ui/SlideCard.tsx
+++ b/apps/page0127/src/features/admin-banners/ui/SlideCard.tsx
@@ -24,6 +24,26 @@ const FIELD_LABELS: { key: keyof SlideFields; label: string }[] = [
   { key: 'href', label: '링크' },
 ];
 
+const AUDIENCE_OPTIONS = [
+  { value: 'all', label: '모두' },
+  { value: 'guest', label: '비로그인만' },
+  { value: 'member', label: '로그인만' },
+] as const;
+
+/**
+ * timestamptz → datetime-local 입력값.
+ *
+ * datetime-local 은 **로컬 시각 문자열**을 받는다(타임존 표기가 없다). ISO 를
+ * 그대로 넣으면 브라우저가 값을 버리고 칸이 빈 채로 뜬다 — 운영자는 예약을
+ * 걸어 뒀는데 화면에 안 보이는 상태가 된다.
+ */
+const toLocalInput = (iso: string | null): string => {
+  if (!iso) return '';
+  const at = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${at.getFullYear()}-${pad(at.getMonth() + 1)}-${pad(at.getDate())}T${pad(at.getHours())}:${pad(at.getMinutes())}`;
+};
+
 export const SlideCard = ({ slide }: { slide: HeroSlideRow }) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: slide.id });
@@ -36,11 +56,14 @@ export const SlideCard = ({ slide }: { slide: HeroSlideRow }) => {
     cta: slide.cta,
     bg: slide.bg,
     fg: slide.fg,
+    audience: slide.audience,
+    starts_at: toLocalInput(slide.starts_at),
+    ends_at: toLocalInput(slide.ends_at),
   });
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const set = (k: keyof SlideFields, v: string) =>
+  const set = <K extends keyof SlideFields>(k: K, v: SlideFields[K]) =>
     setFields((f) => ({ ...f, [k]: v }));
 
   const run = (fn: () => Promise<void>) => {
@@ -79,17 +102,24 @@ export const SlideCard = ({ slide }: { slide: HeroSlideRow }) => {
         >
           <GripVertical className='h-4 w-4' aria-hidden />
         </button>
-        <label className='flex items-center gap-1 text-xs'>
-          <input
-            type='checkbox'
-            checked={slide.is_active}
-            onChange={(e) =>
-              run(() => toggleActive(slide.id, e.target.checked))
-            }
-            disabled={isPending}
-          />
-          노출
-        </label>
+        <div className='flex items-center gap-3'>
+          {/* 클릭 수 — 무엇이 먹히는지 여기서 바로 비교한다.
+              0 도 정보다("아무도 안 누른다")이므로 감추지 않는다 */}
+          <span className='text-xs tabular-nums opacity-70'>
+            클릭 {slide.click_count.toLocaleString('ko-KR')}
+          </span>
+          <label className='flex items-center gap-1 text-xs'>
+            <input
+              type='checkbox'
+              checked={slide.is_active}
+              onChange={(e) =>
+                run(() => toggleActive(slide.id, e.target.checked))
+              }
+              disabled={isPending}
+            />
+            노출
+          </label>
+        </div>
       </div>
 
       <div className='grid gap-2 sm:grid-cols-2'>
@@ -104,6 +134,46 @@ export const SlideCard = ({ slide }: { slide: HeroSlideRow }) => {
             />
           </label>
         ))}
+        <label className='text-xs'>
+          노출 대상
+          <select
+            value={fields.audience}
+            onChange={(e) =>
+              set('audience', e.target.value as SlideFields['audience'])
+            }
+            disabled={isPending}
+            className='mt-0.5 w-full rounded border border-line bg-white px-2 py-1 text-sm text-text-strong disabled:opacity-50'
+          >
+            {AUDIENCE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* 비워 두면 "제한 없음". 저장 시 NULL 로 돌아간다 */}
+        <label className='text-xs'>
+          시작 (비우면 제한 없음)
+          <input
+            type='datetime-local'
+            value={fields.starts_at}
+            onChange={(e) => set('starts_at', e.target.value)}
+            disabled={isPending}
+            className='mt-0.5 w-full rounded border border-line bg-white px-2 py-1 text-sm text-text-strong disabled:opacity-50'
+          />
+        </label>
+        <label className='text-xs'>
+          종료 (비우면 제한 없음)
+          <input
+            type='datetime-local'
+            value={fields.ends_at}
+            onChange={(e) => set('ends_at', e.target.value)}
+            disabled={isPending}
+            className='mt-0.5 w-full rounded border border-line bg-white px-2 py-1 text-sm text-text-strong disabled:opacity-50'
+          />
+        </label>
+
         <label className='text-xs'>
           배경색
           <input

--- a/apps/page0127/src/shared/config/schemaVersion.ts
+++ b/apps/page0127/src/shared/config/schemaVersion.ts
@@ -11,7 +11,7 @@
  * 마이그레이션을 추가했다면:
  *   이 값을 새 파일의 앞 14자리 번호로 바꾼다. (예: 20260729000000)
  */
-export const EXPECTED_MIGRATION_VERSION = '20260806000000';
+export const EXPECTED_MIGRATION_VERSION = '20260807000000';
 
 /**
  * 스키마 대조 결과.

--- a/apps/page0127/src/widgets/landing/ui/HeroBanner.tsx
+++ b/apps/page0127/src/widgets/landing/ui/HeroBanner.tsx
@@ -10,6 +10,8 @@ import { ChevronLeft, ChevronRight, Pause, Play } from 'lucide-react';
 import { trackEvent } from '@/shared/lib/analytics/trackEvent';
 import { cn } from '@/shared/lib/utils';
 
+import { countBannerClick } from '@/entities/banner/api/countBannerClick';
+
 import type { HeroSlide } from '@/widgets/landing/model/heroSlides';
 
 const AUTOPLAY_MS = 6000;
@@ -137,12 +139,18 @@ export const HeroBanner = ({ slides, covers = [] }: HeroBannerProps) => {
                   <Link
                     href={slide.href}
                     tabIndex={isActive ? 0 : -1}
-                    onClick={() =>
+                    onClick={() => {
+                      // GA 에 슬라이드 id 도 실어 보낸다 — label(CTA 문구)만으로는
+                      // 같은 문구를 쓰는 배너끼리 구분되지 않는다.
                       trackEvent('cta_click', {
                         location: 'hero_banner',
                         label: slide.cta,
-                      })
-                    }
+                        slide_id: slide.id,
+                      });
+                      // DB 카운터는 따로 센다. 혼자 운영하면 GA 를 자주 안 열게
+                      // 되므로 어드민 목록에도 숫자를 남긴다.
+                      countBannerClick(slide.id);
+                    }}
                     className='mt-6 inline-flex h-10 items-center rounded-md bg-white px-5 text-sm font-medium text-text-strong transition-opacity hover:opacity-90'
                   >
                     {slide.cta}

--- a/apps/page0127/src/widgets/landing/ui/HeroBannerSection.tsx
+++ b/apps/page0127/src/widgets/landing/ui/HeroBannerSection.tsx
@@ -28,10 +28,20 @@ export const HeroBannerSection = async () => {
     .map((row) => row.book_info?.cover_image)
     .filter((url): url is string => Boolean(url));
 
+  // 로그인 여부에 따라 보여줄 배너가 다르다 — "지금 가입하세요"를 이미 가입한
+  // 사람에게 보여주면 그 배너는 틀린 말을 하고, 눌러도 로그인 페이지를 거쳐
+  // 제자리로 돌아온다(운영 배너 4개가 전부 그 상태였다).
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
   // 켜진 슬라이드를 DB에서, 비면 코드 폴백.
   // 폴백을 요청 시점으로 만드는 이유: eyebrow 의 연도가 해가 바뀌어도 따라가야 한다
   // (모듈 상수로 두면 서버가 떠 있는 동안 작년 연도가 박혀 있는다).
-  const slides = await getActiveHeroSlides(heroSlidesFor(new Date()));
+  const slides = await getActiveHeroSlides(
+    heroSlidesFor(new Date()),
+    Boolean(user)
+  );
 
   return <HeroBanner slides={slides} covers={covers} />;
 };

--- a/supabase/migrations/20260807000000_hero_slides_targeting.sql
+++ b/supabase/migrations/20260807000000_hero_slides_targeting.sql
@@ -1,0 +1,155 @@
+-- 히어로 배너 — 노출 대상 · 예약 게시 · 클릭 집계
+-- 작성일: 2026-08-07
+--
+-- 지금 운영 배너 4개가 **전부 href='/login'** 이다. 로그인한 사용자가 누르면
+-- 로그인 페이지로 갔다가 되돌아온다. 즉 가입자에게는 히어로 전체가 죽어 있다.
+-- 그런데 히어로는 랜딩에서 가장 큰 면이고, 가입자가 매번 처음 보는 화면이다.
+--
+-- 함께 넣는 둘:
+--  - 예약 게시: "2026년 하반기" 같은 시의성 배너가 이미 있는데, 지금은 끝나는 날
+--    새벽에 사람이 손으로 꺼야 한다.
+--  - 클릭 집계: 무엇이 먹히는지 모르면 배너를 고칠 근거가 없다.
+
+-- =====================================================
+-- 1. 노출 대상
+-- =====================================================
+--
+-- 슬라이드마다 정한다. "지금 가입하세요"는 비로그인에게만, "취향 분석 보기"는
+-- 로그인에게만 보내야 각 문구가 거짓말이 되지 않는다.
+ALTER TABLE hero_slides
+  ADD COLUMN IF NOT EXISTS audience text NOT NULL DEFAULT 'all'
+    CHECK (audience IN ('all', 'guest', 'member'));
+
+COMMENT ON COLUMN hero_slides.audience IS
+  '노출 대상. all=모두 / guest=비로그인만 / member=로그인만.';
+
+-- =====================================================
+-- 2. 예약 게시
+-- =====================================================
+--
+-- 둘 다 NULL 이면 "언제나" 다. 기존 슬라이드는 전부 그렇게 남는다.
+ALTER TABLE hero_slides
+  ADD COLUMN IF NOT EXISTS starts_at timestamptz;
+ALTER TABLE hero_slides
+  ADD COLUMN IF NOT EXISTS ends_at timestamptz;
+
+COMMENT ON COLUMN hero_slides.starts_at IS
+  '노출 시작. NULL 이면 제한 없음.';
+COMMENT ON COLUMN hero_slides.ends_at IS
+  '노출 종료(이 시각 이후 안 보임). NULL 이면 제한 없음.';
+
+-- 끝이 시작보다 앞서는 기간은 영원히 안 보이는 배너다 — 저장 시점에 막는다.
+ALTER TABLE hero_slides
+  DROP CONSTRAINT IF EXISTS hero_slides_period_order;
+ALTER TABLE hero_slides
+  ADD CONSTRAINT hero_slides_period_order
+  CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at);
+
+-- =====================================================
+-- 3. 클릭 집계
+-- =====================================================
+--
+-- 어드민 목록에서 바로 보이는 단순 카운터. 기간별·유입경로별 분석은 GA 가 맡고
+-- (cta_click 에 슬라이드 id 를 실어 보낸다), 여기서는 "어느 배너가 눌리나"만 센다.
+-- 혼자 운영하면 GA 를 자주 안 열게 되는 게 현실이라 화면에 숫자를 남긴다.
+ALTER TABLE hero_slides
+  ADD COLUMN IF NOT EXISTS click_count integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN hero_slides.click_count IS
+  '배너 클릭 누적. 정밀 분석용이 아니라 어드민 목록에서 눈으로 비교하는 값이다.';
+
+-- =====================================================
+-- 4. 노출 조건을 한 곳에 둔다
+-- =====================================================
+--
+-- 조건이 넷(활성·시작·종료·대상)으로 늘었다. 앱과 DB 에 각각 적으면 한쪽만
+-- 고치는 날 어긋난다. 판정을 함수로 묶어 조회가 그것만 부르게 한다.
+--
+-- SECURITY INVOKER + STABLE: RLS 를 우회하지 않고, 같은 트랜잭션 안에서 now() 가
+-- 고정된다(한 요청 안에서 슬라이드마다 다른 시각을 보면 안 된다).
+CREATE OR REPLACE FUNCTION is_slide_visible(
+  slide hero_slides,
+  viewer_is_member boolean
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT slide.is_active
+     AND (slide.starts_at IS NULL OR slide.starts_at <= now())
+     AND (slide.ends_at   IS NULL OR slide.ends_at   >  now())
+     AND (
+       slide.audience = 'all'
+       OR (slide.audience = 'member' AND viewer_is_member)
+       OR (slide.audience = 'guest'  AND NOT viewer_is_member)
+     );
+$$;
+
+COMMENT ON FUNCTION is_slide_visible(hero_slides, boolean) IS
+  '배너 노출 판정. 활성·기간·대상을 한 번에 본다. 앱 조회가 이것만 부른다.';
+
+-- =====================================================
+-- 5. RLS — 기간이 지난 배너는 읽히지도 않게 한다
+-- =====================================================
+--
+-- 기존 정책은 is_active 만 봤다. 그대로 두면 **예약 시작 전 배너의 문구가 anon
+-- 키로 미리 읽힌다.** 배너는 공개 콘텐츠지만 "아직 안 띄운 것"은 공개가 아니다.
+--
+-- 대상(audience)은 여기서 거르지 않는다. RLS 는 로그인 여부만 알고, guest/member
+-- 판정은 앱이 렌더 시점에 한다 — 정책에 auth.uid() 를 넣으면 비로그인 캐시와
+-- 로그인 캐시가 섞이는 문제가 따라온다.
+DROP POLICY IF EXISTS "anyone can read active slides" ON hero_slides;
+
+CREATE POLICY "anyone can read published slides"
+  ON hero_slides FOR SELECT
+  USING (
+    is_active = true
+    AND (starts_at IS NULL OR starts_at <= now())
+    AND (ends_at   IS NULL OR ends_at   >  now())
+  );
+
+-- =====================================================
+-- 6. 클릭 카운터 증가 함수
+-- =====================================================
+--
+-- 카운터만 올리는 좁은 통로를 연다. UPDATE 권한을 열면 배너 문구까지 고칠 수 있다.
+-- SECURITY DEFINER 로 소유자 권한을 빌리되, 하는 일은 단 한 컬럼 +1 이다.
+CREATE OR REPLACE FUNCTION increment_slide_click(p_slide_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 노출 조건을 만족하는 슬라이드만 센다. 지난 배너의 id 로 카운터를 부풀리는
+  -- 것을 막는다(집계는 공개 API 로 열리므로 아무나 부를 수 있다).
+  UPDATE hero_slides
+  SET click_count = click_count + 1
+  WHERE id = p_slide_id
+    AND is_active = true
+    AND (starts_at IS NULL OR starts_at <= now())
+    AND (ends_at   IS NULL OR ends_at   >  now());
+END;
+$$;
+
+-- 20260725000001 방침: PUBLIC 회수 후 실제로 쓰는 롤에만 부여
+REVOKE ALL ON FUNCTION increment_slide_click(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION increment_slide_click(uuid) TO anon, authenticated, service_role;
+
+REVOKE ALL ON FUNCTION is_slide_visible(hero_slides, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION is_slide_visible(hero_slides, boolean) TO anon, authenticated, service_role;
+
+-- =====================================================
+-- 7. 기존 배너를 대상에 맞게 정리
+-- =====================================================
+--
+-- 넷 다 href='/login' 이라 로그인 사용자에게는 죽은 배너였다. 지금 있는 문구는
+-- 전부 "가입을 권하는" 말이므로 비로그인 대상으로 내린다. 로그인 사용자용 배너는
+-- 운영자가 어드민에서 새로 만든다(문구를 코드가 지어내지 않는다).
+UPDATE hero_slides SET audience = 'guest' WHERE href = '/login';
+
+-- Migration 완료
+-- - audience — 슬라이드마다 노출 대상 (all/guest/member)
+-- - starts_at·ends_at — 예약 게시. 기간이 지나면 RLS 가 읽히지도 않게 한다
+-- - click_count + increment_slide_click() — 카운터만 올리는 좁은 통로
+-- - is_slide_visible() — 노출 판정을 한 곳에


### PR DESCRIPTION
## 왜

운영 배너 4개가 **전부 `href='/login'`** 이다. 로그인한 사용자가 누르면 로그인 페이지로
갔다가 되돌아온다. 히어로는 랜딩에서 가장 큰 면이고 가입자가 매번 처음 보는 화면인데,
**그 전체가 죽어 있었다.**

문구도 넷 다 가입을 권하는 말이라, 이미 가입한 사람에게는 배너가 틀린 말을 하고 있었다.

## 1. 노출 대상 (`audience`)

`all` / `guest` / `member`. "지금 가입하세요"는 비로그인에게만, "취향 분석 보기"는
로그인에게만 보내야 각 문구가 참이 된다.

기존 4개는 `guest` 로 내렸다. **로그인 사용자용 배너는 운영자가 어드민에서 새로 만든다 —
문구를 코드가 지어내지 않는다.**

**판정을 어디서 하나**: 활성·기간은 RLS 가, 대상은 앱이 본다. RLS 에 `auth.uid()` 를
넣으면 비로그인 캐시와 로그인 캐시가 섞이므로 정책에 담지 않았다. 대신 규칙을 DB
함수(`is_slide_visible`)와 순수 함수(`isForViewer`) 양쪽에 같은 형태로 두고 테스트를 붙였다.

## 2. 예약 게시

`starts_at` · `ends_at`. "2026년 하반기" 같은 시의성 배너가 이미 있는데 지금은 끝나는 날
새벽에 사람이 손으로 꺼야 한다.

**RLS 도 함께 고쳤다.** 기존 정책은 `is_active` 만 봐서, 그대로 두면 **예약 시작 전 배너의
문구가 anon 키로 미리 읽힌다.** 배너는 공개 콘텐츠지만 "아직 안 띄운 것"은 공개가 아니다.

## 3. 클릭 집계

GA 이벤트에 `slide_id` 를 실었다 — 지금까지는 `label`(CTA 문구)만 보내서 같은 문구를
쓰는 배너끼리 구분되지 않았다.

DB 카운터는 따로 센다. 혼자 운영하면 GA 를 자주 안 열게 되는 게 현실이라 어드민 목록에도
숫자를 남긴다. 카운터만 올리는 **좁은 통로**(`increment_slide_click`)로 여는데, `UPDATE`
권한을 열면 배너 문구까지 고칠 수 있기 때문이다. 공개 API 라 아무나 부를 수 있으므로
**노출 조건을 만족하는 슬라이드만** 센다 — 지난 배너 id 로 카운터를 부풀릴 수 없다.

## 작업 중 실제로 터진 것

컬럼을 넷 늘렸는데 랜딩 조회와 어드민 조회가 **각각 `select` 문자열을 들고 있어서**
한쪽만 고쳤다. 어드민이 `click_count` 를 `undefined` 로 읽고 **500** 이 났다.
`HERO_SLIDE_COLUMNS` 로 모아 그 어긋남이 생길 자리를 없앴다.

어드민 폼에서도 둘을 잡았다.
- `datetime-local` 은 **로컬 시각 문자열**을 받는다. ISO 를 그대로 넣으면 브라우저가 값을
  버리고 칸이 빈 채로 뜬다 — 운영자는 예약을 걸어 뒀는데 화면에 안 보이는 상태가 된다.
- 빈 문자열을 NULL 로 되돌리지 않으면 **한 번 넣은 예약을 취소할 방법이 없어진다.**

## 검증

**DB 7케이스** — anon 이 읽는 것은 "지금 보이는" 1장뿐(예약 전·만료·꺼짐은 안 보인다).
거꾸로 된 기간과 이상한 `audience` 는 거부. `guest` 배너는 비로그인에게만, `member` 는
로그인에게만 참. 만료 배너는 클릭해도 카운터가 안 오르고, anon 은 배너 문구를 못 고친다.
마이그레이션 전량 재생 통과.

**앱** — 비로그인은 `all+guest`, 로그인은 `all+member` 를 본다. 예약 시작을 내일로 바꾸니
그 배너만 사라졌다. 클릭 API 3회 → 카운터 3, 나머지 0. 어드민 화면에 대상 드롭다운·기간
입력·클릭 수 렌더 확인.

lint · type-check · test 통과 (**370**).

## ⚠️ 머지 전에

마이그레이션이 있다. **PR 을 올린 직후 개발 Supabase 에 `db push`** 해야 CI 의 E2E 가
초록불이 된다(`00_docs/10_시스템_구조.md` ⑥ "함정 셋"). 운영은 머지 직전에.

기존 배너 4개가 `guest` 로 바뀌므로, **머지 후 로그인 사용자용 배너를 하나 만들어야**
가입자 화면의 히어로가 코드 폴백으로 떨어지지 않는다.
