### PR TITLE
✨ Feat: 첫 로그인에 아이디와 닉네임을 직접 정한다

### DIFF
--- a/apps/page0127/app/(auth)/layout.tsx
+++ b/apps/page0127/app/(auth)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 
 import { createClient } from '@/shared/config/supabase/server';
+import { toPostLoginPath } from '@/shared/lib/auth/onboardingRedirect';
 
 import { ensureProfile } from '@/entities/profile/api/getProfile';
 
@@ -18,14 +19,23 @@ const AuthLayout = async ({ children }: { children: React.ReactNode }) => {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // 이미 로그인한 사용자는 본인 서재로 리디렉션
+  // 이미 로그인한 사용자는 되돌려 보낸다.
+  // 어디로 갈지는 콜백과 **같은 판정**을 쓴다 — 온보딩을 안 마쳤으면
+  // 여기서도 서재가 아니라 온보딩으로 가야 한다. 두 곳이 다르게 판단하면
+  // 로그인 화면을 새로고침하는 것만으로 온보딩을 건너뛸 수 있다.
   if (user) {
     const profile = await ensureProfile(
       user.id,
       user.email ?? null,
       user.user_metadata
     );
-    redirect(`/${profile.username}`);
+    redirect(
+      toPostLoginPath({
+        username: profile.username,
+        onboardedAt: profile.onboarded_at,
+        next: null,
+      })
+    );
   }
 
   return <>{children}</>;

--- a/apps/page0127/app/(onboarding)/layout.tsx
+++ b/apps/page0127/app/(onboarding)/layout.tsx
@@ -1,0 +1,15 @@
+/**
+ * 온보딩 레이아웃
+ *
+ * 보호 라우트와 달리 **AppShell(헤더·네비게이션)을 씌우지 않는다.**
+ * 아직 아이디도 정하지 않은 사람에게 앱을 돌아다닐 메뉴를 주면,
+ * 온보딩을 마쳐야 한다는 사실이 흐려지고 실제로 빠져나갈 수도 있다.
+ *
+ * 로그인 여부와 온보딩 완료 여부는 페이지가 직접 본다 — 화면이 하나뿐이라
+ * 레이아웃에 두면 오히려 흐름이 흩어진다.
+ */
+const OnboardingLayout = ({ children }: { children: React.ReactNode }) => (
+  <div className='min-h-screen bg-background'>{children}</div>
+);
+
+export default OnboardingLayout;

--- a/apps/page0127/app/(onboarding)/onboarding/page.tsx
+++ b/apps/page0127/app/(onboarding)/onboarding/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from 'next/navigation';
+
+import { PageContainer } from '@repo/ui';
+
+import { createClient } from '@/shared/config/supabase/server';
+
+import { getProfile } from '@/entities/profile/api/getProfile';
+
+import { OnboardingForm } from '@/features/onboarding/ui/OnboardingForm';
+
+/**
+ * 첫 로그인 온보딩
+ *
+ * 콜백이 onboarded_at 이 NULL 인 사용자를 여기로 보낸다.
+ * 이미 마친 사람이 주소로 직접 들어오면 서재로 되돌린다 —
+ * 안 그러면 온보딩을 다시 타서 아이디를 또 정할 수 있다.
+ * (서버 액션도 같은 검사를 한다. 여기 검사는 화면을 안 보여 주기 위한 것이다)
+ */
+const OnboardingPage = async () => {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect('/login');
+
+  const profile = await getProfile(user.id);
+  if (!profile) redirect('/login');
+
+  if (profile.onboarded_at) {
+    redirect(`/${profile.username}`);
+  }
+
+  return (
+    <PageContainer width='narrow'>
+      <div className='mx-auto max-w-md py-12'>
+        <h1 className='heading-1 mb-2'>거의 다 왔어요</h1>
+        <p className='mb-8 text-text-subtle'>
+          공개 서재 주소로 쓸 아이디와, 서재에서 보일 이름을 정해 주세요.
+        </p>
+
+        <OnboardingForm
+          // 가입할 때 자동으로 만들어진 값들. 그대로 두고 넘어가도 된다.
+          initialUsername={profile.username ?? ''}
+          initialNickname={profile.nickname ?? ''}
+        />
+      </div>
+    </PageContainer>
+  );
+};
+
+export default OnboardingPage;

--- a/apps/page0127/app/(protected)/layout.tsx
+++ b/apps/page0127/app/(protected)/layout.tsx
@@ -1,3 +1,10 @@
+import { redirect } from 'next/navigation';
+
+import { createClient } from '@/shared/config/supabase/server';
+import { ONBOARDING_PATH } from '@/shared/lib/auth/onboardingRedirect';
+
+import { getProfile } from '@/entities/profile/api/getProfile';
+
 import { AppShell } from '@/widgets/AppShell';
 
 /**
@@ -6,8 +13,33 @@ import { AppShell } from '@/widgets/AppShell';
  * 학습 포인트:
  * - 인증 체크와 네비게이션을 AppShell(Server Component)에 위임
  * - 레이아웃은 셸로 children을 감싸기만 한다
+ *
+ * 온보딩 게이트도 여기 둔다. 콜백과 로그인 레이아웃이 이미 온보딩으로
+ * 보내지만 **주소를 직접 치고 들어오는 경로**는 그 둘을 거치지 않는다.
+ * 보호 라우트 전체가 이 레이아웃을 지나므로 한 곳에서 막을 수 있다.
+ *
+ * 온보딩 화면 자신은 `(onboarding)` 그룹에 있어 여기 걸리지 않는다 —
+ * 같은 그룹에 뒀다면 자기 자신으로 무한히 리디렉션했을 것이다.
  */
-const ProtectedLayout = ({ children }: { children: React.ReactNode }) => {
+const ProtectedLayout = async ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 로그인 여부 판단은 AppShell 이 갖는다(두 곳으로 갈리면 어긋난다).
+  // 여기서는 로그인한 사람이 온보딩을 마쳤는지만 본다.
+  if (user) {
+    const profile = await getProfile(user.id);
+    if (profile && !profile.onboarded_at) {
+      redirect(ONBOARDING_PATH);
+    }
+  }
+
   return <AppShell>{children}</AppShell>;
 };
 

--- a/apps/page0127/app/auth/callback/route.ts
+++ b/apps/page0127/app/auth/callback/route.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/shared/config/supabase/server';
 import { toAuthErrorReason } from '@/shared/lib/auth/authErrorReason';
 import { isBannedRedirect } from '@/shared/lib/auth/isBannedRedirect';
-import { toSafeRedirect } from '@/shared/lib/auth/safeRedirect';
+import { toPostLoginPath } from '@/shared/lib/auth/onboardingRedirect';
 
 import { ensureProfile } from '@/entities/profile/api/getProfile';
 
@@ -38,8 +38,13 @@ export async function GET(request: NextRequest) {
         data.user.email ?? null,
         data.user.user_metadata
       );
-      // next 는 사용자가 조작할 수 있는 값이다 — 외부 URL 이면 버리고 본인 서재로 보낸다
-      const redirectTo = toSafeRedirect(next) ?? `/${profile.username}`;
+      // 어디로 보낼지는 순수 함수가 정한다 — 온보딩 미완료면 next 보다 먼저다.
+      // (next 가 외부 URL 인 경우도 그 안에서 걸러진다)
+      const redirectTo = toPostLoginPath({
+        username: profile.username,
+        onboardedAt: profile.onboarded_at,
+        next,
+      });
       return NextResponse.redirect(`${origin}${redirectTo}`);
     }
   }

--- a/apps/page0127/src/entities/profile/model/username.test.ts
+++ b/apps/page0127/src/entities/profile/model/username.test.ts
@@ -62,6 +62,19 @@ describe('validateUsername', () => {
     }
   });
 
+  it('예약어를 막는 이유는 밝히지 않는다', () => {
+    // "서비스가 쓰고 있다"고 알려 주면 RESERVED_USERNAMES 가 곧 라우트 지도가 된다 —
+    // 아이디를 하나씩 넣어 보는 것만으로 admin·api 같은 경로의 존재를 확인할 수 있다.
+    const result = validateUsername('admin');
+    const message = result.ok ? '' : result.message;
+
+    for (const leak of ['서비스', '관리자', '경로', '주소']) {
+      expect(message).not.toContain(leak);
+    }
+    // 그래도 무엇을 하면 되는지는 알려 줘야 한다
+    expect(message).toContain('다른 아이디');
+  });
+
   it('대문자로 친 예약어도 막는다 (소문자로 낮춘 뒤 판정한다)', () => {
     expect(validateUsername('ADMIN')).toMatchObject({
       ok: false,

--- a/apps/page0127/src/entities/profile/model/username.ts
+++ b/apps/page0127/src/entities/profile/model/username.ts
@@ -90,7 +90,11 @@ const MESSAGES: Record<UsernameIssue, string> = {
   too_short: `아이디는 ${USERNAME_MIN_LENGTH}자 이상이어야 해요.`,
   too_long: `아이디는 ${USERNAME_MAX_LENGTH}자 이하여야 해요.`,
   invalid_chars: '영문 소문자, 숫자, 밑줄(_)만 쓸 수 있어요.',
-  reserved: '이미 서비스가 쓰고 있는 주소예요. 다른 아이디를 골라 주세요.',
+  // ⚠️ **왜 막혔는지는 말하지 않는다.**
+  //    "서비스가 쓰고 있다"고 알려 주면 RESERVED_USERNAMES 가 곧 라우트 지도가 된다 —
+  //    아이디를 하나씩 넣어 보는 것만으로 admin·api 같은 경로의 존재를 확인할 수 있다.
+  //    사용자가 할 일("다른 걸 고른다")은 그대로 전해지므로 잃는 것도 없다.
+  reserved: '쓸 수 없는 아이디예요. 다른 아이디를 골라 주세요.',
 };
 
 /**

--- a/apps/page0127/src/entities/profile/types/index.ts
+++ b/apps/page0127/src/entities/profile/types/index.ts
@@ -36,6 +36,12 @@ export type Profile = {
    */
   username_changed_at: string | null;
 
+  /**
+   * 첫 로그인 온보딩을 마친 시각. null 이면 미완료 — 로그인 후 온보딩으로 보낸다.
+   * username_changed_at 과 마찬가지로 **서버 소유 컬럼**이다(트리거가 지킨다).
+   */
+  onboarded_at: string | null;
+
   /** 닉네임 */
   nickname: string | null;
 

--- a/apps/page0127/src/features/onboarding/api/completeOnboardingAction.ts
+++ b/apps/page0127/src/features/onboarding/api/completeOnboardingAction.ts
@@ -1,0 +1,133 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { createAdminClient } from '@/shared/config/supabase/admin';
+import { createClient } from '@/shared/config/supabase/server';
+
+import { validateUsername } from '@/entities/profile/model/username';
+
+/**
+ * 첫 로그인 온보딩 완료 — 아이디와 닉네임을 확정한다.
+ *
+ * 왜 service_role 인가:
+ * 가입할 때 아이디는 이메일·닉네임에서 자동으로 만들어진다. 온보딩에서 그걸
+ * 고치는 것은 사용자가 쓰는 "평생 한 번"의 변경 기회가 아니라 **최초 설정**이다.
+ * 일반 경로로 UPDATE 하면 트리거가 username_changed_at 을 찍어 기회를 소진한다.
+ * service_role 은 트리거가 통째로 통과시키므로 그 일이 일어나지 않는다.
+ *
+ * ⚠️ service_role 은 RLS 를 우회한다. 그래서 **누구의 요청인지는 반드시 세션으로**
+ *    확인하고(아래 getUser), 그 사용자 자신의 행만 건드린다.
+ *    formData 로 넘어온 id 같은 건 절대 믿지 않는다.
+ *
+ * ⚠️ 이미 온보딩을 마친 사람은 여기로 못 들어온다. 안 막으면 이 경로로
+ *    아이디를 무한히 바꿀 수 있다(변경 기회를 소진하지 않으므로).
+ */
+
+/**
+ * 성공하면 값을 돌려주지 않는다 — 서버에서 바로 서재로 보내기 때문이다.
+ * 그래서 화면이 볼 상태는 '아직 안 냈다'와 '실패했다' 둘뿐이다.
+ */
+export type OnboardingActionState = {
+  status: 'idle' | 'error';
+  message: string;
+};
+
+/** Postgres 유니크 제약 위반 — 같은 순간 같은 아이디를 고른 사람이 있었다 */
+const UNIQUE_VIOLATION = '23505';
+/** CHECK 제약 위반 — 화면 검사를 우회해 들어온 값 */
+const CHECK_VIOLATION = '23514';
+
+/** 닉네임은 표시용이라 길이만 본다 (프로필 설정과 같은 한도) */
+const NICKNAME_MAX_LENGTH = 20;
+
+export const completeOnboardingAction = async (
+  _prevState: OnboardingActionState,
+  formData: FormData
+): Promise<OnboardingActionState> => {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { status: 'error', message: '로그인이 필요합니다.' };
+  }
+
+  const check = validateUsername((formData.get('username') as string) ?? '');
+  if (!check.ok) {
+    return { status: 'error', message: check.message };
+  }
+  const username = check.value;
+
+  const nickname = ((formData.get('nickname') as string) ?? '').trim();
+  if (nickname.length === 0) {
+    return { status: 'error', message: '닉네임을 입력해 주세요.' };
+  }
+  if (nickname.length > NICKNAME_MAX_LENGTH) {
+    return {
+      status: 'error',
+      message: `닉네임은 ${NICKNAME_MAX_LENGTH}자 이하여야 해요.`,
+    };
+  }
+
+  // 현재 상태는 서버가 직접 읽는다 — 화면이 보낸 값을 믿지 않는다
+  const { data: current, error: readError } = await supabase
+    .from('profiles')
+    .select('username, onboarded_at')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (readError || !current) {
+    console.error('프로필 조회 실패:', readError?.message);
+    return { status: 'error', message: '프로필을 불러올 수 없습니다.' };
+  }
+
+  // 이미 마친 사람은 설정 화면의 '아이디 변경'을 쓰게 한다.
+  // 여기를 열어 두면 변경 횟수 제한이 무의미해진다.
+  if (current.onboarded_at) {
+    return {
+      status: 'error',
+      message: '이미 완료한 단계예요. 아이디는 설정에서 바꿀 수 있어요.',
+    };
+  }
+
+  // 여기부터 service_role — 위에서 확인한 user.id 의 행만 건드린다
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from('profiles')
+    .update({
+      username,
+      nickname,
+      onboarded_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', user.id);
+
+  if (error) {
+    if (error.code === UNIQUE_VIOLATION) {
+      return { status: 'error', message: '이미 쓰고 있는 아이디예요.' };
+    }
+    if (error.code === CHECK_VIOLATION) {
+      return { status: 'error', message: '쓸 수 없는 아이디예요.' };
+    }
+    console.error('온보딩 완료 실패:', error.message);
+    return { status: 'error', message: '저장에 실패했습니다.' };
+  }
+
+  // 자동 생성됐던 주소는 이 순간부터 404 다. 양쪽을 함께 갱신한다.
+  if (current.username && current.username !== username) {
+    revalidatePath(`/${current.username}`);
+  }
+  revalidatePath(`/${username}`);
+  revalidatePath('/settings');
+
+  // 이동은 서버에서 한다. 처음엔 화면에서 router.replace 로 옮겼는데
+  // 실제로 이동하지 않았다(액션 완료와 재렌더가 겹치는 자리다).
+  // 여기서 redirect 하면 그 경합이 없고, 다른 가드들과 방식도 같아진다.
+  //
+  // ⚠️ redirect 는 예외를 던져 흐름을 끊는다 — try/catch 로 감싸면 안 된다.
+  //    그래서 실패 경로(위)를 모두 처리한 뒤 맨 마지막에 부른다.
+  redirect(`/${username}`);
+};

--- a/apps/page0127/src/features/onboarding/ui/OnboardingForm.tsx
+++ b/apps/page0127/src/features/onboarding/ui/OnboardingForm.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useActionState, useEffect, useId, useState } from 'react';
+
+import { Button, Input, Label } from '@repo/ui';
+import { toast } from 'sonner';
+
+import {
+  normalizeUsername,
+  validateUsername,
+} from '@/entities/profile/model/username';
+
+import { checkUsernameAvailability } from '@/features/profile/api/updateUsernameAction';
+
+import {
+  completeOnboardingAction,
+  type OnboardingActionState,
+} from '../api/completeOnboardingAction';
+
+/** 입력이 멈춘 뒤 중복을 물어볼 때까지 (UsernameChangeDialog 와 같은 값) */
+const CHECK_DEBOUNCE_MS = 400;
+
+type FieldState =
+  | { kind: 'invalid'; message: string }
+  | { kind: 'checking' }
+  | { kind: 'available' }
+  | { kind: 'taken'; message: string };
+
+type OnboardingFormProps = {
+  /** 가입할 때 자동으로 만들어진 아이디 — 그대로 둬도 된다 */
+  initialUsername: string;
+  /** 공급자가 준 닉네임. 없으면 빈 값으로 시작한다 */
+  initialNickname: string;
+};
+
+const initialState: OnboardingActionState = { status: 'idle', message: '' };
+
+/**
+ * 첫 로그인 온보딩 — 아이디와 닉네임을 직접 정한다.
+ *
+ * 왜 필요한가: 아이디는 가입할 때 이메일이나 닉네임에서 **자동으로** 만들어진다.
+ * 그 사실을 모르면 자기 이메일 앞부분이 공개 주소가 된 줄도 모르고 지나간다.
+ * 카카오처럼 한국어 닉네임이면 `reader_a1b2c3` 같은 값을 받게 된다.
+ *
+ * 건너뛰기는 두지 않는다 — 아이디는 공개 서재 주소라 반드시 정해져야 한다.
+ * 대신 자동 생성된 값이 미리 채워져 있어 그대로 두고 넘어갈 수 있다.
+ */
+export const OnboardingForm = ({
+  initialUsername,
+  initialNickname,
+}: OnboardingFormProps) => {
+  const formId = useId();
+  const ids = {
+    username: `${formId}-username`,
+    nickname: `${formId}-nickname`,
+  };
+
+  const [username, setUsername] = useState(initialUsername);
+  const [nickname, setNickname] = useState(initialNickname);
+
+  // 어떤 값을 확인한 결과인지 함께 들고 있어야, 입력이 더 진행된 뒤 도착한
+  // 낡은 응답을 화면에 쓰지 않는다.
+  const [checked, setChecked] = useState<{
+    value: string;
+    available: boolean;
+    message: string;
+  } | null>(null);
+
+  // 성공하면 서버 액션이 곧바로 서재로 보낸다(여기로 돌아오지 않는다).
+  // 그래서 여기서 다룰 것은 실패뿐이다.
+  const [, formAction, isPending] = useActionState(
+    async (prev: OnboardingActionState, formData: FormData) => {
+      const next = await completeOnboardingAction(prev, formData);
+      if (next.status === 'error') toast.error(next.message);
+      return next;
+    },
+    initialState
+  );
+
+  // 형식 판정은 동기적이라 상태로 둘 이유가 없다 — 렌더 중에 계산한다
+  const formatCheck = validateUsername(username);
+  const normalized = normalizeUsername(username);
+
+  // formatCheck 는 매 렌더 새 객체라 그대로 의존성에 두면 effect 가 매번 돈다 —
+  // 실제로 달라지는 문자열만 꺼내 둔다.
+  // 처음 값(자동 생성된 아이디)도 확인한다. 그대로 두는 것도 선택지이고,
+  // checkUsernameAvailability 는 "지금 내 아이디"를 사용 가능으로 본다.
+  const candidate = formatCheck.ok ? formatCheck.value : null;
+
+  useEffect(() => {
+    if (candidate === null) return;
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      const result = await checkUsernameAvailability(candidate);
+      if (cancelled) return;
+      setChecked({
+        value: candidate,
+        available: result.available,
+        message: result.available ? '' : result.message,
+      });
+    }, CHECK_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [candidate]);
+
+  // 화면에 보일 상태는 전부 파생값이다
+  const field: FieldState = !formatCheck.ok
+    ? { kind: 'invalid', message: formatCheck.message }
+    : checked?.value !== normalized
+      ? { kind: 'checking' }
+      : checked.available
+        ? { kind: 'available' }
+        : { kind: 'taken', message: checked.message };
+
+  const canSubmit =
+    field.kind === 'available' && nickname.trim().length > 0 && !isPending;
+
+  return (
+    <form action={formAction} className='space-y-6'>
+      <div className='space-y-2'>
+        <Label htmlFor={ids.username}>아이디</Label>
+        <Input
+          id={ids.username}
+          name='username'
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          autoComplete='off'
+          // 모바일에서 첫 글자가 대문자로 바뀌면 규칙에 걸린다
+          autoCapitalize='none'
+          spellCheck={false}
+        />
+        <p className='text-xs text-text-subtle'>
+          공개 서재 주소가 됩니다 — /{normalized || '아이디'}
+        </p>
+        {/* 상태 문구는 한 줄만 — 여러 개를 동시에 띄우면 무엇을 고쳐야 할지 흐려진다 */}
+        <p
+          className={
+            field.kind === 'taken' || field.kind === 'invalid'
+              ? 'text-xs text-destructive'
+              : 'text-xs text-text-subtle'
+          }
+          role={
+            field.kind === 'taken' || field.kind === 'invalid'
+              ? 'alert'
+              : undefined
+          }
+        >
+          {field.kind === 'invalid' && field.message}
+          {field.kind === 'checking' && '확인 중…'}
+          {field.kind === 'available' && '쓸 수 있는 아이디예요.'}
+          {field.kind === 'taken' && field.message}
+        </p>
+      </div>
+
+      <div className='space-y-2'>
+        <Label htmlFor={ids.nickname}>닉네임</Label>
+        <Input
+          id={ids.nickname}
+          name='nickname'
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          maxLength={20}
+          placeholder='서재에서 보일 이름'
+        />
+        <p className='text-xs text-text-subtle'>
+          피드와 댓글에 이 이름으로 보입니다. 나중에 바꿀 수 있어요.
+        </p>
+      </div>
+
+      <Button type='submit' size='lg' className='w-full' disabled={!canSubmit}>
+        {isPending ? '저장 중…' : '시작하기'}
+      </Button>
+    </form>
+  );
+};

--- a/apps/page0127/src/shared/config/schemaVersion.ts
+++ b/apps/page0127/src/shared/config/schemaVersion.ts
@@ -11,7 +11,7 @@
  * 마이그레이션을 추가했다면:
  *   이 값을 새 파일의 앞 14자리 번호로 바꾼다. (예: 20260729000000)
  */
-export const EXPECTED_MIGRATION_VERSION = '20260807000000';
+export const EXPECTED_MIGRATION_VERSION = '20260808000000';
 
 /**
  * 스키마 대조 결과.

--- a/apps/page0127/src/shared/lib/auth/onboardingRedirect.test.ts
+++ b/apps/page0127/src/shared/lib/auth/onboardingRedirect.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { ONBOARDING_PATH, toPostLoginPath } from './onboardingRedirect';
+
+describe('toPostLoginPath', () => {
+  it('온보딩을 마쳤으면 원래 가려던 곳으로 보낸다', () => {
+    expect(
+      toPostLoginPath({
+        username: 'bookworm',
+        onboardedAt: '2026-08-06T00:00:00Z',
+        next: '/feed',
+      })
+    ).toBe('/feed');
+  });
+
+  it('갈 곳이 없으면 본인 서재로 보낸다', () => {
+    expect(
+      toPostLoginPath({
+        username: 'bookworm',
+        onboardedAt: '2026-08-06T00:00:00Z',
+        next: null,
+      })
+    ).toBe('/bookworm');
+  });
+
+  it('온보딩 미완료면 온보딩으로 보낸다', () => {
+    expect(
+      toPostLoginPath({ username: 'reader_a1b2c3', onboardedAt: null, next: null })
+    ).toBe(ONBOARDING_PATH);
+  });
+
+  it('온보딩 미완료면 next 가 있어도 온보딩이 먼저다', () => {
+    // 아이디가 정해지기 전에 서재로 보내면 자동 생성된 주소가 굳어 버린다
+    expect(
+      toPostLoginPath({
+        username: 'reader_a1b2c3',
+        onboardedAt: null,
+        next: '/feed',
+      })
+    ).toBe(ONBOARDING_PATH);
+  });
+
+  it('외부 주소는 버리고 본인 서재로 보낸다', () => {
+    // next 는 사용자가 만들어 열 수 있는 값이다 (오픈 리다이렉트)
+    expect(
+      toPostLoginPath({
+        username: 'bookworm',
+        onboardedAt: '2026-08-06T00:00:00Z',
+        next: 'https://evil.com',
+      })
+    ).toBe('/bookworm');
+    expect(
+      toPostLoginPath({
+        username: 'bookworm',
+        onboardedAt: '2026-08-06T00:00:00Z',
+        next: '//evil.com',
+      })
+    ).toBe('/bookworm');
+  });
+
+  it('아이디가 없으면 온보딩으로 보낸다', () => {
+    // 아이디 없이 서재로 보내면 `/` 로 튕긴다
+    expect(
+      toPostLoginPath({
+        username: null,
+        onboardedAt: '2026-08-06T00:00:00Z',
+        next: null,
+      })
+    ).toBe(ONBOARDING_PATH);
+  });
+});

--- a/apps/page0127/src/shared/lib/auth/onboardingRedirect.ts
+++ b/apps/page0127/src/shared/lib/auth/onboardingRedirect.ts
@@ -1,0 +1,38 @@
+import { toSafeRedirect } from './safeRedirect';
+
+/**
+ * 로그인 직후 어디로 보낼지 정한다.
+ *
+ * 콜백 라우트에 흩어져 있던 판단을 한 곳에 모은다 — 라우트는 I/O 만 하고,
+ * "어디로 갈지"는 순수 함수로 두어 테스트한다.
+ */
+
+export const ONBOARDING_PATH = '/onboarding';
+
+type PostLoginInput = {
+  /** profiles.username. 아직 없을 수 있다 */
+  username: string | null;
+  /** profiles.onboarded_at. NULL 이면 온보딩 미완료 */
+  onboardedAt: string | null;
+  /** 로그인 전에 가려던 내부 경로 (사용자가 조작할 수 있는 값) */
+  next: string | null;
+};
+
+/**
+ * @returns 이동할 내부 경로
+ */
+export function toPostLoginPath({
+  username,
+  onboardedAt,
+  next,
+}: PostLoginInput): string {
+  // 온보딩이 먼저다. next 가 있어도 미룬다 —
+  // 아이디가 정해지기 전에 서재로 보내면 자동 생성된 주소가 그대로 굳는다.
+  //
+  // username 이 없을 때도 여기로 보낸다. 아이디 없이 `/${username}` 을 만들면
+  // `/` 로 튕겨 사용자는 로그인이 실패한 것처럼 느낀다.
+  if (!onboardedAt || !username) return ONBOARDING_PATH;
+
+  // next 는 사용자가 만들어 열 수 있다 — 외부 URL 이면 버린다
+  return toSafeRedirect(next) ?? `/${username}`;
+}

--- a/supabase/migrations/20260808000000_profiles_onboarded_at.sql
+++ b/supabase/migrations/20260808000000_profiles_onboarded_at.sql
@@ -1,0 +1,96 @@
+-- 첫 로그인 온보딩 상태
+--
+-- 지금은 가입할 때 아이디가 이메일·닉네임에서 **자동으로** 만들어지고, 사용자는
+-- 그 사실을 모른 채 공개 서재 주소를 갖게 된다. 카카오 가입자는 한국어 닉네임이면
+-- `reader_xxxxxx` 같은 값을 받는다. 첫 로그인 때 직접 정하게 하려고 상태를 둔다.
+--
+-- NULL = 아직 온보딩을 안 마쳤다.
+
+-- =====================================================
+-- 1. 컬럼 추가
+-- =====================================================
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS onboarded_at timestamptz;
+
+COMMENT ON COLUMN profiles.onboarded_at IS
+  '첫 로그인 온보딩을 마친 시각. NULL 이면 미완료 — 로그인 후 온보딩으로 보낸다. '
+  '서버 소유 컬럼이다(아래 트리거가 클라이언트 값을 버린다).';
+
+-- =====================================================
+-- 2. 기존 사용자 백필
+-- =====================================================
+-- ⚠️ 이걸 빠뜨리면 배포하는 순간 **모든 기존 사용자가 온보딩 화면으로 튕긴다.**
+--    이미 쓰고 있던 사람에게 갑자기 "아이디를 정하세요"가 뜨는 셈이다.
+--    가입 시각을 쓰지 않고 now() 로 채운다 — "언제 온보딩했나"가 아니라
+--    "온보딩 대상이 아니다"를 표시하는 게 목적이다.
+
+UPDATE profiles
+SET onboarded_at = now()
+WHERE onboarded_at IS NULL;
+
+-- =====================================================
+-- 3. onboarded_at 을 서버 소유 컬럼으로 만든다
+-- =====================================================
+-- 왜 필요한가 — 이걸 안 막으면 **아이디 변경 1회 제한이 뚫린다.**
+--
+--   1. 사용자가 프로필 저장으로 onboarded_at 을 NULL 로 되돌린다
+--      (RLS 는 행 단위라 특정 컬럼만 막지 못한다)
+--   2. 다음 로그인에 온보딩 화면이 다시 뜬다
+--   3. 온보딩은 service_role 로 아이디를 정하므로 username_changed_at 을
+--      소진하지 않는다 → 아이디를 무한히 바꿀 수 있다
+--
+-- username_changed_at 과 같은 방식으로 막는다: 클라이언트가 보낸 값은
+-- 어떤 경우에도 채택하지 않고 기존 값을 유지한다.
+--
+-- service_role 은 예외다(함수 첫 줄에서 그대로 통과). 온보딩 서버 액션이
+-- 그 경로로 값을 넣고, 지원 요청이 오면 운영자가 되돌릴 수 있다.
+--
+-- ⚠️ 아래는 20260805000000 의 함수를 **통째로 다시 정의**한 것이다.
+--    그 파일을 고칠 때 이 파일도 같이 봐야 한다 — 나중 정의가 이긴다.
+
+CREATE OR REPLACE FUNCTION enforce_username_change_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  -- 운영자(service_role)는 제한을 받지 않는다.
+  -- 값을 덮지 않고 그대로 통과시키므로, 지원 요청("오타로 바꿨어요")이 오면
+  -- username_changed_at 을 NULL 로 되돌려 기회를 한 번 더 줄 수 있다.
+  -- 온보딩 서버 액션도 이 경로로 아이디·onboarded_at 을 한 번에 쓴다.
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  -- 클라이언트가 보낸 서버 소유 컬럼 값은 버리고 기존 값을 유지한다.
+  -- (아이디를 안 바꾸는 일반 저장에서도 반드시 거쳐야 하는 줄이다)
+  NEW.username_changed_at := OLD.username_changed_at;
+  NEW.onboarded_at := OLD.onboarded_at;
+
+  -- 아이디가 그대로면 여기서 끝(닉네임·사진만 바꾼 일반 저장)
+  IF NEW.username IS NOT DISTINCT FROM OLD.username THEN
+    RETURN NEW;
+  END IF;
+
+  -- 이미 한 번 바꿨으면 거부
+  IF OLD.username_changed_at IS NOT NULL THEN
+    RAISE EXCEPTION 'username_change_limit_exceeded'
+      USING HINT = '아이디는 한 번만 변경할 수 있습니다.';
+  END IF;
+
+  -- 변경 시각은 서버 시각으로 기록한다
+  NEW.username_changed_at := now();
+  RETURN NEW;
+END;
+$$;
+
+-- 트리거 자체는 이미 붙어 있다(20260805000000). 함수만 바꿔 끼운다.
+
+-- =====================================================
+-- 확인용
+-- =====================================================
+-- - onboarded_at 이 NULL 인 사람만 온보딩 대상이다
+-- - 배포 직후에는 0명이어야 한다 (2번 백필)
+--     SELECT count(*) FROM profiles WHERE onboarded_at IS NULL;


### PR DESCRIPTION
가입할 때 아이디는 이메일이나 닉네임에서 **자동으로** 만들어진다. 그 사실을 모르면
자기 이메일 앞부분이 공개 서재 주소가 된 줄도 모르고 지나간다. 카카오처럼 한국어
닉네임이면 `reader_a1b2c3` 같은 값을 받는다. 첫 로그인에 직접 정하게 한다.

소셜 로그인 3단계 중 마지막이다. (1단계 카카오 #84, 2단계 계정 연동 #87)

## 핵심: 온보딩은 "변경 기회"를 쓰지 않는다

아이디는 평생 한 번만 바꿀 수 있다(`username_changed_at` + DB 트리거).
온보딩에서 아이디를 정하는 것은 **변경이 아니라 최초 설정**이므로 그 기회를
소진하면 안 된다. 일반 경로로 UPDATE 하면 트리거가 시각을 찍어 버린다.

`service_role` 로 쓴다 — 트리거가 첫 줄에서 통째로 통과시킨다. 원래 계획했던
"트리거에 온보딩 예외 추가"는 **불필요했다.**

`service_role` 은 RLS 를 우회하므로 **누구의 요청인지는 세션으로 확인**하고
그 사용자 자신의 행만 건드린다. formData 로 넘어온 값은 믿지 않는다.

## 막은 우회

`onboarded_at` 을 사용자가 NULL 로 되돌릴 수 있으면 **아이디 1회 제한이 뚫린다.**

1. 프로필 저장으로 `onboarded_at` 을 NULL 로 되돌리고 (RLS 는 행 단위라 특정
   컬럼만 막지 못한다)
2. 다음 로그인에 온보딩이 다시 뜨고
3. 온보딩은 변경 기회를 소진하지 않으므로 → **아이디를 무한히 바꿀 수 있다**

`username_changed_at` 과 같은 방식으로 **서버 소유 컬럼**으로 만들었다.
로컬에서 실증했다 — 사용자가 `onboarded_at=NULL` 과 닉네임을 함께 보내면
**닉네임만 반영되고 `onboarded_at` 은 무시된다.**

## 게이트 세 곳

하나라도 빠지면 그 경로로 건너뛸 수 있다. 판단은 `toPostLoginPath` 한 곳에 모아
순수 함수로 두고 테스트했다(6건).

| 위치 | 막는 경로 |
| --- | --- |
| 콜백 | 로그인 직후 |
| `(auth)` 레이아웃 | 이미 로그인한 사람이 `/login` 을 열 때 |
| `(protected)` 레이아웃 | **주소를 직접 치고 들어올 때** |

`proxy` 대신 `(protected)` 레이아웃에 둔 이유: 미들웨어에 넣으면 모든 요청마다
DB 를 한 번 더 읽는다. 보호 라우트는 전부 이 레이아웃을 지나므로 한 곳이면 된다.

온보딩 화면은 `(onboarding)` 별도 그룹에 둔다. `(protected)` 안에 두면
AppShell(헤더·네비)이 씌워져 **아이디도 안 정한 사람에게 앱을 돌아다닐 메뉴를
주게 된다.** 게이트가 자기 자신을 리디렉션하는 무한 루프도 함께 피했다.

## 곁들여 고친 것 — 예약어 문구의 정보 노출

`admin` 을 넣으면 "이미 **서비스가 쓰고 있는** 주소예요" 라고 답하고 있었다.
그러면 `RESERVED_USERNAMES` 가 곧 라우트 지도가 된다 — 아이디를 하나씩 넣어
보는 것만으로 `admin`·`api` 같은 경로의 존재를 확인할 수 있다.

`assertAdmin` 은 비관리자에게 403 이 아니라 **404(`notFound`)** 를 내어 admin 의
존재 자체를 숨기고 있었다. 이 문구가 그 방어를 도로 무너뜨리고 있었다.
"쓸 수 없는 아이디예요"로 바꿔 두 곳의 원칙을 맞췄다. 사용자가 할 일은 그대로
전해지므로 잃는 것은 없다. 다시 새지 않도록 테스트로 못 박았다.

## 검증

단위 테스트 377개 통과(신규 7건), 린트·프로덕션 빌드 통과.
로컬에서 실제 소셜 로그인으로 전 경로를 돌렸다.

- 신규 가입 → 서재가 아니라 `/onboarding` 으로
- 예약어(`admin`)·짧은 값(`ab`) → 버튼 잠김 + 사유 표시
- 제출 → 정한 아이디의 서재로 이동
- **직후 설정에 "한 번만 바꿀 수 있습니다" 가 살아 있음** ← 이 PR 의 핵심
- 그 기회를 실제로 써서 아이디를 바꾸니 그제야 소진됨
- 완료자가 `/onboarding`·`/login` 재방문 → 서재로 되돌림
- 미완료자가 `/settings` 직접 진입 → 온보딩으로

DB 로도 확인했다(트리거가 `onboarded_at` 되돌리기를 무시, `service_role` 은 통과,
아이디 1회 제한은 그대로 작동).

## ⚠️ 머지 전에

- [ ] **운영·개발 DB에 마이그레이션 적용** — 백필(`onboarded_at = now()`)이 같이
      돌아야 한다. 안 그러면 배포 순간 **모든 기존 사용자가 온보딩으로 튕긴다.**
- [ ] 운영·개발 Supabase의 **Manual Linking** — 2단계(#87)가 이미 main 에 있는데
      아직 안 켰다면 설정의 "연결하기"가 422 로 실패한다

## 다음 단계

없다. 소셜 로그인 3단계가 이걸로 끝난다.

설계: `docs/superpowers/specs/2026-08-06-social-login-expansion-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
