### PR TITLE
♿ A11y: 신규 가입자 빈 화면 + 알림 버튼 이름

### DIFF
--- a/apps/page0127/src/features/notification/ui/NotificationDropdown.tsx
+++ b/apps/page0127/src/features/notification/ui/NotificationDropdown.tsx
@@ -37,11 +37,30 @@ export const NotificationDropdown = ({ userId }: NotificationDropdownProps) => {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <Button variant='ghost' size='icon-md' className='relative'>
+        {/*
+          아이콘만 있는 버튼이라 이름을 직접 준다 — 스크린리더는 종 그림을 읽지 못한다.
+          이 버튼은 GNB 에 있어 **로그인한 사람이 보는 모든 화면**에 나온다.
+
+          읽지 않은 개수를 이름에 넣는다. 뱃지 숫자는 눈으로만 보이는 정보라,
+          이름이 "알림" 뿐이면 새 알림이 있는지 소리로는 알 수 없다.
+        */}
+        <Button
+          variant='ghost'
+          size='icon-md'
+          className='relative'
+          aria-label={
+            unreadCount && unreadCount.count > 0
+              ? `알림, 읽지 않음 ${unreadCount.count}건`
+              : '알림'
+          }
+        >
           <Bell className='h-5 w-5' />
-          {/* 읽지 않은 알림 뱃지 */}
+          {/* 읽지 않은 알림 뱃지 — 이름에 이미 개수가 들어가므로 중복해 읽지 않게 숨긴다 */}
           {unreadCount && unreadCount.count > 0 && (
-            <span className='absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs font-bold text-white'>
+            <span
+              aria-hidden='true'
+              className='absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs font-bold text-white'
+            >
               {unreadCount.count > 99 ? '99+' : unreadCount.count}
             </span>
           )}

--- a/apps/page0127/src/widgets/library/LibraryView.tsx
+++ b/apps/page0127/src/widgets/library/LibraryView.tsx
@@ -78,6 +78,15 @@ type LibraryViewProps = {
   /** 공개 서재에서 책 링크에 쓸 username (내 서재는 생략) */
   username?: string;
 
+  /**
+   * 지금 이 서재의 주인이 보고 있는지.
+   *
+   * ⚠️ `username` 유무로는 판별할 수 없다 — 내 서재로 들어가도 `/[username]` 으로
+   * 넘어오기 때문에 주인도 방문자도 같은 라우트를 본다. 빈 서재 안내 문구가
+   * "첫 책을 기록해 보세요"(주인) / "아직 공개된 기록이 없어요"(방문자)로 갈린다.
+   */
+  isOwner?: boolean;
+
   /** 목표 설정 — 소유자에게만 전달 (없으면 버튼 자체가 안 보인다) */
   onSetGoal?: () => void;
 
@@ -119,6 +128,7 @@ export const LibraryView = ({
   allShelfTitle = '서재 전체',
   lifeBooksTitle = '인생책',
   username,
+  isOwner = false,
   onSetGoal,
   calendarSlot,
   showWishlist = false,
@@ -211,6 +221,34 @@ export const LibraryView = ({
         ) : isAllView ? (
           /* ── 전체(누적) 뷰 ── */
           <div className='space-y-6'>
+            {/*
+              기록이 하나도 없을 때는 안내를 **통계보다 먼저** 보여준다.
+
+              처음 가입한 사람에게 이 화면은 `0권 · 0쪽 · 0권` 세 숫자로 시작한다.
+              숫자만 놓으면 초대가 아니라 **빈 성적표**로 읽힌다. 같은 이유로 공유
+              카드에서도 0권일 때는 숫자를 세지 않기로 했다
+              (app/(public)/[username]/opengraph-image.tsx).
+
+              통계 카드를 지우지는 않는다 — 한 권을 넣었을 때 어디가 채워지는지
+              미리 보이는 편이 낫다.
+            */}
+            {books.length === 0 && (
+              <Card className='rounded-2xl border-dashed bg-card py-6 shadow-none'>
+                <CardHeader>
+                  <CardTitle>
+                    {isOwner
+                      ? '첫 책을 기록해 보세요'
+                      : '아직 공개된 기록이 없어요'}
+                  </CardTitle>
+                  <p className='text-sm text-muted-foreground'>
+                    {isOwner
+                      ? '상단 “도서 추가”로 한 권을 넣으면 아래 통계가 채워지기 시작합니다. 한 권이면 충분해요.'
+                      : '이 서재의 주인이 책을 공개하면 여기에 쌓입니다.'}
+                  </p>
+                </CardHeader>
+              </Card>
+            )}
+
             <div className='grid grid-cols-1 gap-6 lg:grid-cols-3'>
               <Card className='rounded-2xl bg-card py-6 shadow-none'>
                 <CardHeader>

--- a/apps/page0127/src/widgets/public-library/PublicLibraryContent.tsx
+++ b/apps/page0127/src/widgets/public-library/PublicLibraryContent.tsx
@@ -179,6 +179,7 @@ export const PublicLibraryContent = ({
         onSetGoal={isOwnProfile ? () => setIsGoalDialogOpen(true) : undefined}
         calendarSlot={isOwnProfile ? calendarSlot : undefined}
         showWishlist={isOwnProfile}
+        isOwner={isOwnProfile}
         isWishlistView={isWishlistView}
         wishlistBooks={wishlistBooks}
       />


### PR DESCRIPTION
## 어떻게 찾았나

PR #93 에 이어, 이번엔 **로그인한 뒤의 화면**을 봤습니다. 로컬 Supabase 에 테스트 계정을 만들어 "처음 가입한 사람이 보는 것"을 그대로 재현했습니다. (계정은 로컬에만 있었고 점검 후 삭제했습니다)

## 고친 것

### 1. 빈 서재가 성적표처럼 보였다

처음 가입한 사람에게 서재 화면은 **`0권 · 0쪽 · 0권`** 세 숫자로 시작합니다. 뭘 하라는 안내가 없습니다.

이 저장소는 같은 판단을 이미 한 번 내렸습니다 — 공유 카드에서 `0권` 일 때 숫자를 세지 않기로 했고, 이유가 "0권은 초대가 아니라 빈 성적표로 읽힌다" 였습니다(`app/(public)/[username]/opengraph-image.tsx`). 같은 원칙을 서재 화면에도 적용합니다.

**통계 카드는 지우지 않았습니다.** 한 권을 넣었을 때 어디가 채워지는지 미리 보이는 편이 낫습니다.

#### 주인/방문자 판별을 `username` 으로 할 수 없었다

처음엔 `username` prop 유무로 갈랐는데 틀렸습니다. **내 서재로 들어가도 `/[username]` 으로 넘어와서** 주인도 방문자도 같은 라우트를 봅니다. 실제로 검증에서 주인에게 "아직 공개된 기록이 없어요"가 떴습니다.

호출부(`PublicLibraryContent`)에 이미 `isOwnProfile` 이 있어서 `isOwner` 로 명시해 넘깁니다.

### 2. 알림 종 버튼에 이름이 없었다

GNB 에 있어 **로그인한 사람이 보는 모든 화면**에 나옵니다. 스크린리더는 "버튼" 이라고만 읽었습니다.

읽지 않은 개수를 이름에 넣었습니다 — 뱃지 숫자는 눈으로만 보이는 정보라, 이름이 `알림` 뿐이면 **새 알림이 있는지 소리로는 알 수 없습니다.** 대신 뱃지 자체는 `aria-hidden` 으로 가려 개수를 두 번 읽지 않게 했습니다.

## 검증

로컬(3200 포트, 이 브랜치 코드)에서 신규 계정으로 확인했습니다.

| 항목 | 결과 |
|---|---|
| 빈 서재 주인 안내 노출 | ✅ "첫 책을 기록해 보세요" |
| 알림 버튼 이름 | ✅ `알림` |
| `tsc --noEmit` | 통과 |
| `eslint .` | 통과 |

## 오탐이라 고치지 않은 것

**하단 탭바가 콘텐츠를 가린다** 고 봤는데 **오탐이었습니다.** 가린 검은 원은 **Next.js 개발 인디케이터**로 운영에는 없습니다. `AppShellLayout` 은 이미 `pb-16 md:pb-0` 으로 탭바 높이를 확보하고 있습니다.

## 남은 것 (이 PR 범위 밖)

### ⚠️ 신규 가입자의 첫 `/dashboard` 접근이 500 을 낸다

점검 중 **재현 가능한 패턴**을 발견했습니다. 갓 만든 계정으로 `/dashboard` 에 처음 들어가면 **500** 이 나고 `/login` 으로 튕깁니다. **같은 URL 을 한 번 더 열면 200** 이 되고 정상 동작합니다.

세 계정에서 모두 같았습니다. 프로필 생성이 첫 요청 중에 일어나면서 그 요청 자체는 실패하는 것으로 보입니다. **가입 직후 첫 화면이라 영향이 큽니다** — 별도로 파봐야 합니다.

### 제목 계층 `h1 → h3`

공개 서재에서 단계를 건너뜁니다. 경고 수준이라 두었습니다.