### PR TITLE
🐛 Fix: 가입 직후 첫 화면이 500 나던 것을 고친다

### DIFF
--- a/apps/page0127/src/entities/profile/api/getProfile.ts
+++ b/apps/page0127/src/entities/profile/api/getProfile.ts
@@ -104,7 +104,7 @@ export const generateUniqueUsername = async (source: {
  * "프로필 생성에 실패했습니다" 만 보였다 — Sentry 에도 증상만 쌓였다.
  */
 export type UpsertProfileResult =
-  | { ok: true; savedRows: number }
+  | { ok: true; savedRows: number; profile: Profile | null }
   | { ok: false; reason: string };
 
 export const upsertProfile = async (
@@ -164,10 +164,16 @@ export const upsertProfile = async (
           onConflict: 'id',
         }
       )
-      .select('id');
+      // 저장된 행을 통째로 돌려받는다 — 호출자가 다시 조회하지 않아도 되게
+      .select('*');
 
   const { data, error } = await save(username);
-  if (!error) return { ok: true, savedRows: data?.length ?? 0 };
+  if (!error)
+    return {
+      ok: true,
+      savedRows: data?.length ?? 0,
+      profile: data?.[0] ?? null,
+    };
 
   // username 을 만들지 않은 호출(이미 있는 프로필)이면 재시도해도 결과가 같다
   if (error.code !== UNIQUE_VIOLATION || !username) {
@@ -189,7 +195,11 @@ export const upsertProfile = async (
     };
   }
 
-  return { ok: true, savedRows: retryData?.length ?? 0 };
+  return {
+    ok: true,
+    savedRows: retryData?.length ?? 0,
+    profile: retryData?.[0] ?? null,
+  };
 };
 
 /**
@@ -205,12 +215,25 @@ export const ensureProfile = async (
   email: string | null,
   metadata?: Record<string, unknown> | null
 ): Promise<Profile> => {
-  let profile = await getProfile(userId);
+  const profile = await getProfile(userId);
   if (profile) return profile;
 
   const saved = await upsertProfile(userId, email, metadata);
-  profile = await getProfile(userId);
-  if (profile) return profile;
+
+  /*
+    ⚠️ 여기서 `getProfile` 을 다시 부르면 안 된다.
+
+    Next.js 는 한 번의 렌더 안에서 **같은 GET 요청을 한 번만 실행하고 결과를
+    재사용한다**(Request Memoization). `upsertProfile` 안에서 이미 같은 조회가
+    나갔기 때문에, 저장에 성공했더라도 재조회는 **저장 전의 빈 결과**를 돌려준다.
+
+    그래서 가입 직후 첫 화면이 500 이 났다. 두 번째 요청은 새 렌더라 메모이제이션이
+    초기화돼 정상 동작했고, 그 탓에 "가끔 되는" 문제로 보였다.
+    (행이 실제로 DB에 저장된 것은 service_role 조회로 확인했다)
+
+    저장이 돌려준 행을 그대로 쓴다 — 재조회 자체를 없애는 편이 확실하다.
+  */
+  if (saved.ok && saved.profile) return saved.profile;
 
   /*
     여기까지 왔다는 건 저장과 조회 사이에서 무언가 어긋났다는 뜻이다.


### PR DESCRIPTION
## 증상

갓 가입한 계정이 첫 화면에 들어가면 **500** 이 나고 로그인으로 튕겼습니다. **같은 주소를 한 번 더 열면 정상**이라 "가끔 되는" 문제로 보였습니다. 테스트 계정 여섯 개에서 모두 재현됐습니다.

## 원인 — Next.js 의 Request Memoization

한 번의 렌더 안에서 **같은 GET 요청은 한 번만 실행되고 결과가 재사용**됩니다.

```
getProfile()      → GET profiles?id=X → 빈 결과 (여기서 메모이제이션)
upsertProfile()   → POST → 저장 성공 (1행)
getProfile()      → 같은 GET → 캐시된 빈 결과 → null → throw 500
```

`upsertProfile` 은 내부에서 기존 프로필을 확인하느라 **같은 조회를 이미 한 번** 내보냅니다. 그래서 저장에 성공해도 뒤이은 재조회가 저장 전 결과를 돌려받았습니다.

두 번째 요청은 새 렌더라 메모이제이션이 초기화돼 정상 동작합니다.

## 어떻게 확정했나

추측을 배제하려고 **service_role 로 DB 를 직접 조회**했습니다(RLS 우회).

| 확인 | 결과 |
|---|---|
| 요청 전 `profiles` 행 | 없음 |
| `/dashboard` 응답 | 500 |
| 요청 **직후** `profiles` 행 | **있음** (`username: probe500`) |

**저장은 성공했는데 조회만 못 찾는다**가 확정됐습니다. `profiles` 의 SELECT 정책은 `USING (true)` 라 권한 문제도 아니었습니다. 남는 건 캐시뿐이었습니다.

이 진단은 직전 PR(#98)에서 실패 사유를 드러내게 고친 덕분에 가능했습니다. 그전에는 "프로필 생성에 실패했습니다" 한 줄뿐이었습니다.

## 고친 방법

**재조회 자체를 없앴습니다.** `upsert` 가 `.select('*')` 로 저장된 행을 통째로 돌려주고, `ensureProfile` 이 그걸 그대로 씁니다.

캐시 우회 옵션(`cache: 'no-store'`)을 붙이는 방법도 있지만, 같은 함정이 다른 호출부에서 다시 나올 수 있습니다. **한 번 저장했으면 그 결과를 쓰면 됩니다.**

## 검증

| | 고치기 전 | 고친 후 |
|---|---|---|
| 신규 계정 첫 `/dashboard` | **500** | **200** |

`tsc --noEmit` 통과 · `eslint .` 통과 (경고 0)