### PR TITLE
🎨 UI/UX: 다크 모드에서 푸른기를 빼고 선반을 어둡게 한다

### DIFF
--- a/apps/page0127/src/widgets/book/ui/BookListItem.module.css
+++ b/apps/page0127/src/widgets/book/ui/BookListItem.module.css
@@ -90,7 +90,9 @@
   height: 100%;
   box-shadow: none;
   border-radius: 2px 6px 6px 2px;
-  background-color: #fff;
+  /* 표지 없는 책의 대체 표현 — 흰 종이. 다크에서는 어두운 종이여야 한다
+     (아래 다크 블록에서 뒤집는다) */
+  background-color: var(--paper-face, #fff);
   /* 좌측 책등 — 종이 두께 */
   background-image: linear-gradient(
     to right,
@@ -233,4 +235,14 @@
   border-left: var(--size) solid var(--primary);
   border-top: var(--size) solid var(--background);
   box-shadow: -1px 1px 2px 0 rgba(0, 0, 0, 0.16);
+}
+
+/*
+  다크 모드 — 표지 없는 책도 어두운 종이로.
+  흰 사각형을 그대로 두면 검은 배경 위에서 표지 있는 책보다 먼저 눈에 띈다.
+*/
+@media (prefers-color-scheme: dark) {
+  .bookImg > .fallback {
+    --paper-face: #2a2d33;
+  }
 }

--- a/apps/page0127/src/widgets/book/ui/PublicBookShelf.module.css
+++ b/apps/page0127/src/widgets/book/ui/PublicBookShelf.module.css
@@ -1,14 +1,29 @@
 .shelf {
+  /*
+    선반 널의 다섯 단계. 예전에는 여기 색이 직접 박혀 있어 **다크 모드에서도
+    흰 띠가 그대로 그어졌다** — 어두운 배경 위에서 선반이 책보다 밝아 먼저 눈에 띄었다.
+    변수로 빼서 아래 다크 블록이 통째로 갈아끼운다.
+
+    시맨틱 토큰을 쓰지 않는 이유: 선반은 면(surface)이 아니라 **나무 널의 입체 표현**이라
+    카드·배경 토큰과 역할이 다르다. globals.css 의 .book-cover 와 같은 예외다.
+  */
+  --shelf-top: #f3f4f6;
+  --shelf-face: #ffffff;
+  --shelf-edge: #e5e7eb;
+  --shelf-under: #d1d5db;
+  --shelf-shadow: rgba(0, 0, 0, 0.2);
+  --shelf-shadow-soft: rgba(0, 0, 0, 0.14);
+
   margin-top: 2rem;
   background-color: transparent;
   background-image: linear-gradient(
     to bottom,
     transparent 240px,
-    #f3f4f6 250px,
-    #ffffff 250px,
-    #e5e7eb 260px,
-    #d1d5db 262px,
-    rgba(0, 0, 0, 0.2) 262px,
+    var(--shelf-top) 250px,
+    var(--shelf-face) 250px,
+    var(--shelf-edge) 260px,
+    var(--shelf-under) 262px,
+    var(--shelf-shadow) 262px,
     transparent 263px
   );
 
@@ -133,11 +148,11 @@
   background-image: linear-gradient(
     to bottom,
     transparent 210px,
-    #f3f4f6 218px,
-    #ffffff 218px,
-    #e5e7eb 226px,
-    #d1d5db 228px,
-    rgba(0, 0, 0, 0.14) 228px,
+    var(--shelf-top) 218px,
+    var(--shelf-face) 218px,
+    var(--shelf-edge) 226px,
+    var(--shelf-under) 228px,
+    var(--shelf-shadow-soft) 228px,
     transparent 229px
   );
   background-size: 100% 246px;
@@ -168,4 +183,22 @@
 
 .compact .noImage.cover {
   width: 149px;
+}
+
+/*
+  다크 모드 선반 — 어두운 방의 나무 널.
+
+  배경(ink/950 #0f1012)보다는 밝고 카드(ink/900 #1a1c1f)보다 살짝 밝게 둔다.
+  선반이 배경에 묻히면 책이 허공에 뜨고, 너무 밝으면 책보다 먼저 눈에 들어온다.
+  그림자는 라이트보다 진하게 — 어두운 면 위에서는 옅은 그림자가 보이지 않는다.
+*/
+@media (prefers-color-scheme: dark) {
+  .shelf {
+    --shelf-top: #2a2d33;
+    --shelf-face: #33373e;
+    --shelf-edge: #212429;
+    --shelf-under: #17191d;
+    --shelf-shadow: rgba(0, 0, 0, 0.5);
+    --shelf-shadow-soft: rgba(0, 0, 0, 0.38);
+  }
 }

--- a/apps/page0127/src/widgets/book/ui/PublicBookShelf.module.css
+++ b/apps/page0127/src/widgets/book/ui/PublicBookShelf.module.css
@@ -13,6 +13,9 @@
   --shelf-under: #d1d5db;
   --shelf-shadow: rgba(0, 0, 0, 0.2);
   --shelf-shadow-soft: rgba(0, 0, 0, 0.14);
+  /* 책 낱권의 윤곽. 밝은 표지가 흰 배경에 묻히지 않게 두는 선이라 다크에서는 반대로 어두워야 한다 */
+  --book-border: #eee;
+  --book-border-empty: #ddd;
 
   margin-top: 2rem;
   background-color: transparent;
@@ -91,7 +94,7 @@
 .books li a img {
   width: auto;
   height: 240px;
-  border: 1px solid #eee;
+  border: 1px solid var(--book-border);
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   margin: 0 1px;
 }
@@ -113,7 +116,7 @@
 .noImage {
   width: auto;
   height: 240px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--book-border-empty);
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   margin: 0 1px;
   background-color: #f5f5f5;
@@ -194,11 +197,13 @@
 */
 @media (prefers-color-scheme: dark) {
   .shelf {
-    --shelf-top: #2a2d33;
-    --shelf-face: #33373e;
-    --shelf-edge: #212429;
-    --shelf-under: #17191d;
-    --shelf-shadow: rgba(0, 0, 0, 0.5);
-    --shelf-shadow-soft: rgba(0, 0, 0, 0.38);
+    --shelf-top: #1e2126;
+    --shelf-face: #262a30;
+    --shelf-edge: #16181c;
+    --shelf-under: #101215;
+    --shelf-shadow: rgba(0, 0, 0, 0.6);
+    --shelf-shadow-soft: rgba(0, 0, 0, 0.45);
+    --book-border: #2e3136;
+    --book-border-empty: #24262a;
   }
 }

--- a/apps/page0127/src/widgets/landing/ui/HeroBanner.tsx
+++ b/apps/page0127/src/widgets/landing/ui/HeroBanner.tsx
@@ -151,7 +151,10 @@ export const HeroBanner = ({ slides, covers = [] }: HeroBannerProps) => {
                       // 되므로 어드민 목록에도 숫자를 남긴다.
                       countBannerClick(slide.id);
                     }}
-                    className='mt-6 inline-flex h-10 items-center rounded-md bg-white px-5 text-sm font-medium text-text-strong transition-opacity hover:opacity-90'
+                    /* 배너 면은 슬라이드가 지정한 색(항상 어둡다)이라 버튼도 모드를
+                       타면 안 된다. text-text-strong 은 다크에서 흰색이 되어
+                       흰 버튼 위 흰 글자가 된다 — 원색을 직접 참조한다. */
+                    className='mt-6 inline-flex h-10 items-center rounded-md bg-white px-5 text-sm font-medium text-[color:var(--navy-900)] transition-opacity hover:opacity-90'
                   >
                     {slide.cta}
                   </Link>

--- a/apps/page0127/src/widgets/landing/ui/StartCtaButton.tsx
+++ b/apps/page0127/src/widgets/landing/ui/StartCtaButton.tsx
@@ -30,8 +30,16 @@ export const StartCtaButton = ({
       <Button
         size='lg'
         className={
+          /*
+            inverse 는 **항상 어두운** 밴드(band-strong) 위에 놓인다. 그래서 버튼은
+            모드와 무관하게 흰 바탕 + 어두운 글자여야 한다.
+
+            `text-text-strong` 을 쓰면 안 된다 — 그 토큰은 다크에서 흰색이 되므로
+            흰 버튼 위에 흰 글자가 되어 **글자가 통째로 사라진다**(실제로 그랬다).
+            면과 글자가 둘 다 모드를 안 타야 하는 자리라 원색을 직접 참조한다.
+          */
           variant === 'inverse'
-            ? 'bg-white px-8 text-text-strong hover:bg-white/90'
+            ? 'bg-white px-8 text-[color:var(--navy-900)] hover:bg-white/90'
             : 'px-8'
         }
       >

--- a/packages/design-tokens/dist/tokens-dark.css
+++ b/packages/design-tokens/dist/tokens-dark.css
@@ -11,24 +11,24 @@
   :root {
     --text-strong: var(--gray-0); /** 제목·책 제목. navy/900 배경 위 14.41:1 — 라이트 모드와 같은 대비다 */
     --text-body: var(--gray-300); /** 본문. 11.18:1 */
-    --text-subtle: var(--navy-300); /** 저자·출판사·메타·캡션. 5.76:1 — 2026-07-29 부터 옛 faint 자리도 맡는다 */
-    --background: var(--navy-900);
-    --card: var(--navy-900);
-    --popover: var(--navy-900);
-    --sidebar: var(--navy-900);
-    --sunken: var(--navy-800); /** 중립 모듈 면. 배경 대비 1.25 — 면 단차는 대비 기준이 아니라 보이기만 하면 된다 */
-    --secondary: var(--navy-800);
-    --muted: var(--navy-800);
-    --line: var(--navy-700); /** 카드·섹션 경계선. 다크에서도 입체는 그림자가 아니라 이 1px 선으로 만든다 */
-    --line-soft: var(--navy-800);
+    --text-subtle: var(--ink-400); /** 저자·출판사·메타·캡션. 5.76:1 — 2026-07-29 부터 옛 faint 자리도 맡는다 */
+    --background: var(--ink-950);
+    --card: var(--ink-900);
+    --popover: var(--ink-900);
+    --sidebar: var(--ink-900);
+    --sunken: var(--ink-975); /** 중립 모듈 면. 배경 대비 1.25 — 면 단차는 대비 기준이 아니라 보이기만 하면 된다 */
+    --secondary: var(--ink-800);
+    --muted: var(--ink-800);
+    --line: var(--ink-700); /** 카드·섹션 경계선. 다크에서도 입체는 그림자가 아니라 이 1px 선으로 만든다 */
+    --line-soft: var(--ink-800);
     --primary: var(--blue-300); /** 다크에서는 밝은 파랑이 브랜드색이 된다. blue/600 은 navy/900 위에서 2.70 밖에 안 나온다 */
-    --primary-foreground: var(--navy-900); /** 밝은 파랑 버튼 위의 어두운 글자. 6.45:1 */
-    --accent: var(--navy-700); /** 활성 메뉴·호버 배경. 라이트의 스카이 틴트 자리를 어두운 네이비가 대신한다 */
+    --primary-foreground: var(--ink-950); /** 밝은 파랑 버튼 위의 어두운 글자. 6.45:1 */
+    --accent: var(--ink-600); /** 활성 메뉴·호버 배경. 라이트의 스카이 틴트 자리를 어두운 네이비가 대신한다 */
     --accent-foreground: var(--gray-0); /** navy/700 위 8.37:1. blue/300 은 3.74 라 14px 본문에 못 쓴다 */
     --ring: var(--blue-300);
     --sidebar-primary: var(--blue-300);
-    --sidebar-primary-foreground: var(--navy-900);
-    --sidebar-accent: var(--navy-700);
+    --sidebar-primary-foreground: var(--ink-950);
+    --sidebar-accent: var(--ink-600);
     --sidebar-accent-foreground: var(--gray-0);
     --sidebar-ring: var(--blue-300);
     --destructive: var(--red-400); /** 삭제·탈퇴. red/600 은 navy/900 위에서 2.65 라 못 쓴다 → 4.52 */

--- a/packages/design-tokens/dist/tokens.css
+++ b/packages/design-tokens/dist/tokens.css
@@ -19,6 +19,13 @@
   --gray-50: #f6f7f8;
   --gray-200: #eceff2;
   --gray-300: #dfe3e8;
+  --ink-400: #9aa0a8; /** 다크 text-subtle. ink/950 위 7.3:1 */
+  --ink-600: #3f434a; /** 활성 메뉴·호버 배경(accent). 흰 글자 9.5:1 */
+  --ink-700: #2e3136; /** 카드·섹션 경계선 */
+  --ink-800: #24262a; /** 보조 면(muted·secondary). 카드보다 한 단 어둡다 */
+  --ink-900: #1a1c1f; /** 카드·팝오버 면. background 보다 한 단 밝아야 카드가 떠 보인다 */
+  --ink-950: #0f1012; /** 기본 배경 */
+  --ink-975: #0a0b0c; /** 가라앉은 면(sunken). 배경보다 어둡다 — 이전에는 navy/800 이라 배경보다 밝아서 이름과 반대로 튀어나와 보였다 */
   --orange-400: #f0642d; /** 다크 모드 rank-up. orange/600 은 navy/900 위에서 3.35 라 본문에 못 쓴다 (색상·채도 유지, 명도만 45%→56%) */
   --orange-600: #bf3f0d; /** 라이트 rank-up·chart-2. 옛 값 #d9480f 는 흰 배경 4.30 이라 12px bold 인 RankDeltaBadge 에서 AA 미달이었다(WCAG Large 는 18.66px bold 부터다). 색상·채도는 그대로 두고 명도만 12% 낮춰 흰 배경 5.34 / sunken 4.98 — primary(5.33)·destructive(5.44)와 같은 수준으로 맞췄다. 다크는 orange/400 을 따로 쓰므로 영향 없다 */
   --red-400: #dd7065; /** 다크 모드 destructive. red/600 은 navy/900 위에서 2.65 라 못 쓴다 (색상·채도 유지, 명도만 46%→63%) */

--- a/packages/design-tokens/tests/tokens.test.ts
+++ b/packages/design-tokens/tests/tokens.test.ts
@@ -26,6 +26,8 @@ const PRIMITIVE_PREFIXES = [
   '--blue-',
   '--navy-',
   '--gray-',
+  // 다크 모드 표면 전용 계열. 라이트의 navy 를 뒤집어 쓰던 것을 대체한다
+  '--ink-',
   '--orange-',
   '--red-',
   '--amber-',

--- a/packages/design-tokens/tokens/dark.json
+++ b/packages/design-tokens/tokens/dark.json
@@ -13,28 +13,28 @@
       "$description": "본문. 11.18:1"
     },
     "text-subtle": {
-      "$value": "{navy.300}",
+      "$value": "{ink.400}",
       "$type": "color",
       "$description": "저자·출판사·메타·캡션. 5.76:1 — 2026-07-29 부터 옛 faint 자리도 맡는다"
     },
 
-    "background": { "$value": "{navy.900}", "$type": "color" },
-    "card": { "$value": "{navy.900}", "$type": "color" },
-    "popover": { "$value": "{navy.900}", "$type": "color" },
-    "sidebar": { "$value": "{navy.900}", "$type": "color" },
+    "background": { "$value": "{ink.950}", "$type": "color" },
+    "card": { "$value": "{ink.900}", "$type": "color" },
+    "popover": { "$value": "{ink.900}", "$type": "color" },
+    "sidebar": { "$value": "{ink.900}", "$type": "color" },
     "sunken": {
-      "$value": "{navy.800}",
+      "$value": "{ink.975}",
       "$type": "color",
       "$description": "중립 모듈 면. 배경 대비 1.25 — 면 단차는 대비 기준이 아니라 보이기만 하면 된다"
     },
-    "secondary": { "$value": "{navy.800}", "$type": "color" },
-    "muted": { "$value": "{navy.800}", "$type": "color" },
+    "secondary": { "$value": "{ink.800}", "$type": "color" },
+    "muted": { "$value": "{ink.800}", "$type": "color" },
     "line": {
-      "$value": "{navy.700}",
+      "$value": "{ink.700}",
       "$type": "color",
       "$description": "카드·섹션 경계선. 다크에서도 입체는 그림자가 아니라 이 1px 선으로 만든다"
     },
-    "line-soft": { "$value": "{navy.800}", "$type": "color" },
+    "line-soft": { "$value": "{ink.800}", "$type": "color" },
 
     "primary": {
       "$value": "{blue.300}",
@@ -42,12 +42,12 @@
       "$description": "다크에서는 밝은 파랑이 브랜드색이 된다. blue/600 은 navy/900 위에서 2.70 밖에 안 나온다"
     },
     "primary-foreground": {
-      "$value": "{navy.900}",
+      "$value": "{ink.950}",
       "$type": "color",
       "$description": "밝은 파랑 버튼 위의 어두운 글자. 6.45:1"
     },
     "accent": {
-      "$value": "{navy.700}",
+      "$value": "{ink.600}",
       "$type": "color",
       "$description": "활성 메뉴·호버 배경. 라이트의 스카이 틴트 자리를 어두운 네이비가 대신한다"
     },
@@ -59,8 +59,8 @@
     "ring": { "$value": "{blue.300}", "$type": "color" },
 
     "sidebar-primary": { "$value": "{blue.300}", "$type": "color" },
-    "sidebar-primary-foreground": { "$value": "{navy.900}", "$type": "color" },
-    "sidebar-accent": { "$value": "{navy.700}", "$type": "color" },
+    "sidebar-primary-foreground": { "$value": "{ink.950}", "$type": "color" },
+    "sidebar-accent": { "$value": "{ink.600}", "$type": "color" },
     "sidebar-accent-foreground": { "$value": "{gray.0}", "$type": "color" },
     "sidebar-ring": { "$value": "{blue.300}", "$type": "color" },
 

--- a/packages/design-tokens/tokens/primitives.json
+++ b/packages/design-tokens/tokens/primitives.json
@@ -21,6 +21,16 @@
     "200": { "$value": "#eceff2", "$type": "color" },
     "300": { "$value": "#dfe3e8", "$type": "color" }
   },
+  "ink": {
+    "$description": "다크 모드 표면 전용 계열. 숫자가 클수록 어둡다. 라이트의 navy 를 뒤집어 쓰던 것을 대체한다 — navy/900 은 라이트의 본문 글자색이라 넓은 면에 깔면 푸른기가 강하게 남았다. 채도를 거의 뺐고(HSL 채도 8~10%), 브랜드 블루와 어울리도록 아주 미세한 쿨 기운만 남겼다",
+    "400": { "$value": "#9aa0a8", "$type": "color", "$description": "다크 text-subtle. ink/950 위 7.3:1" },
+    "600": { "$value": "#3f434a", "$type": "color", "$description": "활성 메뉴·호버 배경(accent). 흰 글자 9.5:1" },
+    "700": { "$value": "#2e3136", "$type": "color", "$description": "카드·섹션 경계선" },
+    "800": { "$value": "#24262a", "$type": "color", "$description": "보조 면(muted·secondary). 카드보다 한 단 어둡다" },
+    "900": { "$value": "#1a1c1f", "$type": "color", "$description": "카드·팝오버 면. background 보다 한 단 밝아야 카드가 떠 보인다" },
+    "950": { "$value": "#0f1012", "$type": "color", "$description": "기본 배경" },
+    "975": { "$value": "#0a0b0c", "$type": "color", "$description": "가라앉은 면(sunken). 배경보다 어둡다 — 이전에는 navy/800 이라 배경보다 밝아서 이름과 반대로 튀어나와 보였다" }
+  },
   "orange": {
     "400": { "$value": "#f0642d", "$type": "color", "$description": "다크 모드 rank-up. orange/600 은 navy/900 위에서 3.35 라 본문에 못 쓴다 (색상·채도 유지, 명도만 45%→56%)" },
     "600": { "$value": "#bf3f0d", "$type": "color", "$description": "라이트 rank-up·chart-2. 옛 값 #d9480f 는 흰 배경 4.30 이라 12px bold 인 RankDeltaBadge 에서 AA 미달이었다(WCAG Large 는 18.66px bold 부터다). 색상·채도는 그대로 두고 명도만 12% 낮춰 흰 배경 5.34 / sunken 4.98 — primary(5.33)·destructive(5.44)와 같은 수준으로 맞췄다. 다크는 orange/400 을 따로 쓰므로 영향 없다" }


### PR DESCRIPTION
## 왜

다크 모드 배경이 `navy/900 #14294e` 였습니다. 이건 **라이트 모드의 본문 글자색**입니다. 글자색을 그대로 배경에 깔다 보니 넓은 면에서 푸른기가 강하게 남았습니다.

`08_UI_UX_체크리스트.md` 에 이미 적혀 있던 규칙입니다 — *"라이트 값을 반전하지 않는다, 채도를 낮춘 톤 변형을 따로 만든다."*

## 함께 나온 구조 문제 둘

| 문제 | 상태 |
|---|---|
| `background` 와 `card` 가 **같은 색** | 다크에서 카드가 배경 위에 떠 보이지 않았습니다 |
| `sunken` 이 배경보다 **밝음** | "가라앉은 면" 인데 튀어나와 보였습니다 |

이제 `sunken < background < card` 순으로 어둡습니다.

## 새 팔레트 — `ink` 계열

채도를 거의 뺐습니다(HSL 채도 8~10%). 완전 무채색보다 아주 미세한 쿨 기운을 남겨 브랜드 블루와 맞췄습니다.

| 토큰 | 이전 | 지금 |
|---|---|---|
| `background` | `navy/900` `#14294e` | `ink/950` **`#0f1012`** |
| `card`·`popover`·`sidebar` | `navy/900` (배경과 동일) | `ink/900` **`#1a1c1f`** |
| `sunken` | `navy/800` (배경보다 밝음) | `ink/975` **`#0a0b0c`** |
| `muted`·`secondary`·`line-soft` | `navy/800` | `ink/800` `#24262a` |
| `line` | `navy/700` | `ink/700` `#2e3136` |
| `accent` | `navy/700` | `ink/600` `#3f434a` |
| `text-subtle` | `navy/300` | `ink/400` `#9aa0a8` |

## 선반의 흰 띠

`PublicBookShelf.module.css` 의 그라데이션에 색이 **직접 박혀 있었습니다**(`#ffffff`, `#f3f4f6` …). 그래서 다크에서도 흰 띠가 줄줄이 그어져 **선반이 책보다 먼저 눈에 띄었습니다.**

변수로 빼고 다크 값을 따로 줍니다. 배경보다는 밝고 카드보다 살짝 밝게 — 선반이 배경에 묻히면 책이 허공에 뜨고, 너무 밝으면 책보다 먼저 보입니다. 그림자는 진하게 했습니다(어두운 면 위에서 옅은 그림자는 안 보입니다).

**시맨틱 토큰을 쓰지 않은 이유:** 선반은 면(surface)이 아니라 **나무 널의 입체 표현**이라 카드·배경 토큰과 역할이 다릅니다. `globals.css` 의 `.book-cover` 와 같은 예외입니다.

## 대비는 전부 개선됐습니다

배경이 어두워진 만큼 위에 올라가는 색들의 대비가 올라갑니다.

| 항목 | 이전 | 지금 |
|---|---|---|
| `text-subtle` | 5.76 | **7.3** |
| `destructive` | 4.52 | **5.6** |
| `rank-up` | 4.51 | **5.7** |
| `chart-5` | 3.03 | **3.8** |

`primitives.json` 주석에 계산해 둔 수치들이 있어서, 값을 낮추는 방향이면 재검증이 필요했을 텐데 **전부 올라가는 방향**이라 기존 판정이 그대로 유효합니다.

## 검증

토큰 빌드 통과 · `eslint .` 통과

⚠️ **실물 확인이 필요합니다.** 헤드리스 브라우저가 다크 모드를 따라가지 않아(`prefers-color-scheme` → `false`) 제가 눈으로 못 봤습니다. OS 다크에서 확인 부탁드립니다.