### PR TITLE
🐛 Fix: 계정 연결 실패를 로그인 오류로 안내하던 것을 고친다

### DIFF
--- a/apps/page0127/app/auth/callback/route.ts
+++ b/apps/page0127/app/auth/callback/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/shared/config/supabase/server';
 import { toAuthErrorReason } from '@/shared/lib/auth/authErrorReason';
 import { isBannedRedirect } from '@/shared/lib/auth/isBannedRedirect';
+import { toLinkFailurePath } from '@/shared/lib/auth/linkFlow';
 import { toPostLoginPath } from '@/shared/lib/auth/onboardingRedirect';
 
 import { ensureProfile } from '@/entities/profile/api/getProfile';
@@ -47,6 +48,15 @@ export async function GET(request: NextRequest) {
       });
       return NextResponse.redirect(`${origin}${redirectTo}`);
     }
+  }
+
+  // 계정 '연결'이 실패한 것이면 로그인 오류 페이지로 보내면 안 된다.
+  // 사용자는 로그인이 아니라 연결을 하던 참이라 '로그인하지 못했어요' 는
+  // 두 번 틀린 안내가 된다 — 하려던 일도, 원인도.
+  // 시작한 자리인 설정 화면으로 돌려보내고 거기서 사정을 알린다.
+  const linkFailurePath = toLinkFailurePath(next);
+  if (linkFailurePath) {
+    return NextResponse.redirect(`${origin}${linkFailurePath}`);
   }
 
   // 그 밖의 실패는 사유를 실어 안내 페이지로 보낸다.

--- a/apps/page0127/src/features/auth/api/useLinkedAccounts.ts
+++ b/apps/page0127/src/features/auth/api/useLinkedAccounts.ts
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { createClient } from '@/shared/config/supabase/client';
+import { LINKED_PARAM } from '@/shared/lib/auth/linkFlow';
 
 import { toLinkedAccountRows } from '../model/linkedAccounts';
 import { OAUTH_PROVIDERS, type OAuthProvider } from '../model/providers';
@@ -15,13 +16,9 @@ export const linkedAccountKeys = {
   all: ['linkedAccounts'] as const,
 };
 
-/**
- * 연결을 마치고 돌아왔음을 알리는 쿼리 파라미터.
- *
- * 값은 URL 에서 오므로 **사용자가 손으로 바꿀 수 있다.** 읽는 쪽에서
- * 아는 공급자인지 확인하고 쓴다 (isOAuthProvider).
- */
-export const LINKED_PARAM = 'linked';
+// LINKED_PARAM 은 shared/lib/auth/linkFlow 로 옮겼다 —
+// 콜백 라우트(서버)도 같은 값을 봐야 하는데, 이 파일은 'use client' 라
+// 서버에서 가져올 수 없다.
 
 const fetchLinkedAccounts = async () => {
   const supabase = createClient();

--- a/apps/page0127/src/features/auth/model/linkResult.test.ts
+++ b/apps/page0127/src/features/auth/model/linkResult.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { toLinkResultMessage } from './linkResult';
+
+describe('toLinkResultMessage', () => {
+  it('성공이면 연결됐다고 알린다', () => {
+    expect(toLinkResultMessage({ linked: 'kakao', failed: null })).toEqual({
+      kind: 'success',
+      text: '카카오 로그인 계정을 연결했어요.',
+    });
+  });
+
+  it('실패면 빠져나갈 길을 함께 알려 준다', () => {
+    const result = toLinkResultMessage({ linked: null, failed: 'kakao' });
+
+    expect(result?.kind).toBe('error');
+    // 원인을 단정하지 않는다 — 서버가 사유를 주지 않는다
+    expect(result?.text).toContain('이미 다른 계정에서 쓰고 있는 계정이라면');
+    // 무엇을 하면 되는지가 있어야 안내다
+    expect(result?.text).toContain('연결을 끊은 뒤');
+  });
+
+  it('공급자 이름을 문구에 넣는다', () => {
+    expect(toLinkResultMessage({ linked: null, failed: 'google' })?.text).toContain(
+      '구글로 계속하기'
+    );
+  });
+
+  it('둘 다 없으면 알릴 것이 없다', () => {
+    expect(toLinkResultMessage({ linked: null, failed: null })).toBeNull();
+  });
+
+  it('모르는 공급자면 알리지 않는다 — 사용자가 만든 값일 수 있다', () => {
+    expect(toLinkResultMessage({ linked: 'nonsense', failed: null })).toBeNull();
+    expect(toLinkResultMessage({ linked: null, failed: 'nonsense' })).toBeNull();
+  });
+
+  it('프로토타입 키에 속지 않는다', () => {
+    expect(toLinkResultMessage({ linked: 'toString', failed: null })).toBeNull();
+  });
+
+  it('둘 다 실려 오면 성공을 택한다', () => {
+    // 실제로는 생기지 않지만, 주소를 손으로 만들면 가능하다.
+    // 성공을 택해야 "연결됐는데 실패했다고 뜨는" 최악을 피한다.
+    expect(
+      toLinkResultMessage({ linked: 'kakao', failed: 'google' })?.kind
+    ).toBe('success');
+  });
+});

--- a/apps/page0127/src/features/auth/model/linkResult.ts
+++ b/apps/page0127/src/features/auth/model/linkResult.ts
@@ -1,0 +1,48 @@
+/**
+ * 연결 결과를 화면에 뭐라고 알릴지 정한다.
+ *
+ * 연결은 공급자 페이지를 왕복하므로, 시작한 훅 안에서는 결과를 알 수 없다.
+ * 돌아온 주소의 `?linked=`(성공)·`?linkFailed=`(실패)를 보고 판단한다.
+ *
+ * 판단만 여기 두고 toast 호출은 화면이 한다 — 그래야 테스트할 수 있다.
+ */
+
+import { isOAuthProvider, OAUTH_PROVIDERS } from './providers';
+
+export type LinkResultMessage = {
+  kind: 'success' | 'error';
+  text: string;
+};
+
+type LinkResultInput = {
+  /** ?linked= 값 (성공). **사용자가 손으로 바꿀 수 있다** */
+  linked: string | null;
+  /** ?linkFailed= 값 (실패). 마찬가지로 신뢰하지 않는다 */
+  failed: string | null;
+};
+
+/**
+ * @returns 알릴 내용, 알릴 것이 없으면 null
+ */
+export function toLinkResultMessage({
+  linked,
+  failed,
+}: LinkResultInput): LinkResultMessage | null {
+  // 둘 다 실려 오면 성공을 택한다 — 연결됐는데 실패했다고 뜨는 쪽이 더 나쁘다
+  const provider = linked ?? failed;
+  if (!isOAuthProvider(provider)) return null;
+
+  const { label } = OAUTH_PROVIDERS[provider];
+
+  if (linked) {
+    return { kind: 'success', text: `${label} 계정을 연결했어요.` };
+  }
+
+  // 원인을 단정하지 않는다 — 서버가 사유를 돌려주지 않는다(로그에도 안 남았다).
+  // 다만 SDK 문서상으로도 실측으로도 압도적으로 흔한 원인은 "그 계정이 이미
+  // 다른 계정에 붙어 있음"이라, 거기서 빠져나갈 길을 함께 준다.
+  return {
+    kind: 'error',
+    text: `${label} 계정을 연결하지 못했어요. 이미 다른 계정에서 쓰고 있는 계정이라면, 그 계정으로 로그인해 연결을 끊은 뒤 다시 시도해 주세요.`,
+  };
+}

--- a/apps/page0127/src/features/auth/ui/LinkedAccountsSection.tsx
+++ b/apps/page0127/src/features/auth/ui/LinkedAccountsSection.tsx
@@ -8,31 +8,42 @@ import { Button } from '@repo/ui';
 import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { LINKED_PARAM, useLinkedAccounts } from '../api/useLinkedAccounts';
+import { LINK_FAILED_PARAM, LINKED_PARAM } from '@/shared/lib/auth/linkFlow';
+
+import { useLinkedAccounts } from '../api/useLinkedAccounts';
 import { UNLINK_BLOCKED_MESSAGE } from '../model/linkedAccounts';
-import { isOAuthProvider, OAUTH_PROVIDERS } from '../model/providers';
+import { toLinkResultMessage } from '../model/linkResult';
+import { OAUTH_PROVIDERS } from '../model/providers';
 
 /**
- * 연결을 마치고 돌아왔으면 한 번 알리고 URL 을 정리한다.
+ * 연결을 마치고 돌아왔으면 결과를 한 번 알리고 URL 을 정리한다.
  *
- * 연결은 공급자 페이지를 왕복하므로 훅 안에서는 성공을 알 수 없다.
- * 돌아온 화면이 `?linked=` 를 보고 알린다.
+ * 연결은 공급자 페이지를 왕복하므로 훅 안에서는 결과를 알 수 없다.
+ * 돌아온 화면이 `?linked=`(성공) 또는 `?linkFailed=`(실패)를 보고 알린다.
  *
  * 알린 뒤 파라미터를 지우는 이유: 안 지우면 새로고침할 때마다 다시 뜨고,
  * 그 URL 을 공유하면 남의 화면에서도 뜬다.
  */
-const useLinkedToast = () => {
+const useLinkResultToast = () => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
   const linked = searchParams.get(LINKED_PARAM);
+  const failed = searchParams.get(LINK_FAILED_PARAM);
 
   useEffect(() => {
-    if (!isOAuthProvider(linked)) return;
+    const message = toLinkResultMessage({ linked, failed });
+    if (!message) return;
 
-    toast.success(`${OAUTH_PROVIDERS[linked].label} 계정을 연결했어요.`);
+    if (message.kind === 'success') {
+      toast.success(message.text);
+    } else {
+      // 실패 문구는 길고 할 일이 담겨 있어 기본 시간으로는 다 못 읽는다
+      toast.error(message.text, { duration: 8000 });
+    }
+
     router.replace(pathname, { scroll: false });
-  }, [linked, pathname, router]);
+  }, [linked, failed, pathname, router]);
 };
 
 /**
@@ -45,7 +56,7 @@ export const LinkedAccountsSection = () => {
   const { rows, isPending, error, pendingProvider, link, unlink } =
     useLinkedAccounts();
 
-  useLinkedToast();
+  useLinkResultToast();
 
   return (
     <section className='mt-6 rounded-2xl bg-sunken px-5 py-4'>

--- a/apps/page0127/src/shared/lib/auth/linkFlow.test.ts
+++ b/apps/page0127/src/shared/lib/auth/linkFlow.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { LINK_FAILED_PARAM, LINKED_PARAM, toLinkFailurePath } from './linkFlow';
+
+describe('toLinkFailurePath', () => {
+  it('연결 흐름이면 설정 화면으로 되돌릴 경로를 준다', () => {
+    expect(toLinkFailurePath(`/settings?${LINKED_PARAM}=kakao`)).toBe(
+      `/settings?${LINK_FAILED_PARAM}=kakao`
+    );
+  });
+
+  it('구글도 같다', () => {
+    expect(toLinkFailurePath(`/settings?${LINKED_PARAM}=google`)).toBe(
+      `/settings?${LINK_FAILED_PARAM}=google`
+    );
+  });
+
+  it('일반 로그인이면 null (인증 오류 페이지로 가야 한다)', () => {
+    expect(toLinkFailurePath(null)).toBeNull();
+    expect(toLinkFailurePath('/feed')).toBeNull();
+    expect(toLinkFailurePath('/settings')).toBeNull();
+  });
+
+  it('모르는 공급자면 null — 사용자가 만든 값일 수 있다', () => {
+    expect(toLinkFailurePath(`/settings?${LINKED_PARAM}=nonsense`)).toBeNull();
+  });
+
+  it('설정 화면이 아닌 경로에 linked 를 달아도 속지 않는다', () => {
+    // next 는 사용자가 만들어 열 수 있는 값이다
+    expect(toLinkFailurePath(`/feed?${LINKED_PARAM}=kakao`)).toBeNull();
+  });
+
+  it('외부 주소는 걸러 낸다', () => {
+    expect(toLinkFailurePath(`https://evil.com/settings?${LINKED_PARAM}=kakao`)).toBeNull();
+    expect(toLinkFailurePath(`//evil.com/settings?${LINKED_PARAM}=kakao`)).toBeNull();
+  });
+});

--- a/apps/page0127/src/shared/lib/auth/linkFlow.ts
+++ b/apps/page0127/src/shared/lib/auth/linkFlow.ts
@@ -1,0 +1,49 @@
+/**
+ * 계정 "연결" 흐름을 로그인 흐름과 구분한다.
+ *
+ * 둘 다 같은 OAuth 콜백(/auth/callback)으로 돌아오기 때문에, 콜백만 보고는
+ * 무엇을 하려던 참인지 알 수 없다. 그래서 연결을 시작할 때 `next` 에
+ * `?linked=<공급자>` 를 달아 보내고, 돌아온 콜백이 그걸 보고 판단한다.
+ *
+ * 왜 필요했나: 연결에 실패했는데 **"로그인하지 못했어요"** 가 떴다.
+ * 사용자는 로그인이 아니라 연결을 하던 참이었고, 원인도 "알 수 없는 문제"가
+ * 아니라 대개 "그 계정이 이미 다른 계정에 붙어 있음"이다. 두 번 틀린 안내였다.
+ */
+
+import { toSafeRedirect } from './safeRedirect';
+
+/** 연결을 시작할 때 다는 표시. 성공하면 이 값으로 알림을 띄운다 */
+export const LINKED_PARAM = 'linked';
+
+/** 연결에 실패했을 때 다는 표시. 설정 화면이 이 값으로 안내를 띄운다 */
+export const LINK_FAILED_PARAM = 'linkFailed';
+
+/** 연결 화면이 있는 곳 */
+const SETTINGS_PATH = '/settings';
+
+/** 화면에 낼 수 있는 공급자. providers.tsx 를 끌어오지 않는다 —
+ *  그 파일은 JSX(브랜드 마크)를 들고 있어 서버 라우트로 가져오면 무겁다 */
+const LINKABLE_PROVIDERS = new Set(['kakao', 'google']);
+
+/**
+ * 실패한 콜백이 연결 흐름이었다면, 설정 화면으로 되돌릴 경로를 만든다.
+ *
+ * @param next 콜백이 받은 next 파라미터 (**사용자가 만들어 열 수 있는 값**)
+ * @returns 연결 흐름이면 `/settings?linkFailed=<공급자>`, 아니면 null
+ *          (null 이면 호출한 쪽이 일반 인증 오류 페이지로 보낸다)
+ */
+export function toLinkFailurePath(next: string | null): string | null {
+  // 외부 URL·로그인 되돌리기 같은 것은 여기서 먼저 걸러진다
+  const safe = toSafeRedirect(next);
+  if (!safe) return null;
+
+  // 상대 경로를 파싱하려면 기준이 필요하다. origin 은 쓰지 않고 버린다.
+  const url = new URL(safe, 'http://internal');
+  if (url.pathname !== SETTINGS_PATH) return null;
+
+  const provider = url.searchParams.get(LINKED_PARAM);
+  // 모르는 값이면 연결 흐름으로 보지 않는다 — 손으로 만든 주소일 수 있다
+  if (!provider || !LINKABLE_PROVIDERS.has(provider)) return null;
+
+  return `${SETTINGS_PATH}?${LINK_FAILED_PARAM}=${provider}`;
+}


### PR DESCRIPTION
설정에서 카카오 "연결하기"를 눌러 실패했더니 **"로그인하지 못했어요 / 로그인 중
문제가 생겼어요"** 가 떴다. 사용자는 로그인이 아니라 **연결**을 하던 참이었고,
원인도 "알 수 없는 문제"가 아니었다. 두 번 틀린 안내다.

## 왜 그랬나

계정 연결과 로그인이 **같은 콜백**(`/auth/callback`)으로 돌아온다. 콜백만 보고는
무엇을 하려던 참인지 알 수 없어서, 연결 실패가 로그인 실패로 뭉뚱그려졌다.

## 무엇이 실패였나 (실측)

```
로그인 중이던 계정:  stronger_deer@naver.com
연결하려던 카카오:   dreamfulbud@gmail.com 계정에 이미 붙어 있음
→ Supabase 가 거부
```

**거부 자체는 옳다.** 안 막으면 남의 카카오로 로그인해서 그 사람 계정의 로그인
수단을 가져올 수 있다. `auth-js` 주석에도 명시돼 있다 —
*"If the candidate identity is already linked to the existing user or another
user, `linkIdentity()` will fail."*

이 시나리오는 드물지 않다. 오히려 가장 흔한 실패일 것이다:

1. 카카오로 먼저 가입 → 계정 A
2. 나중에 잊고 구글로 로그인(이메일이 달라 자동 연결 안 됨) → 계정 B
3. B 에서 "카카오 연결하기" → 이미 A 에 붙어 있어 거부

이때 사용자는 **계정이 갈라진 줄도 모른다.** 서재가 비어 보이니 "기록이
사라졌다"고 느끼고, 합치려다 로그인 오류를 본다.

## 고친 것

**① 연결 실패는 설정 화면으로 되돌린다**

연결을 시작할 때 `next` 에 다는 `?linked=<공급자>` 를 콜백이 보고 판단한다.
연결 흐름이면 인증 오류 페이지가 아니라 **시작한 자리**로 돌려보낸다.

`next` 는 사용자가 만들어 열 수 있는 값이라 세 겹으로 거른다 — 외부
주소(`toSafeRedirect`), 설정 화면이 아닌 경로, 모르는 공급자.

**② 빠져나갈 길을 알려 준다**

> 카카오 로그인 계정을 연결하지 못했어요. 이미 다른 계정에서 쓰고 있는
> 계정이라면, **그 계정으로 로그인해 연결을 끊은 뒤** 다시 시도해 주세요.

**원인을 단정하지 않는다** — 서버가 사유를 돌려주지 않고 Auth 로그에도 남지
않는다. 다만 문서상으로도 실측으로도 압도적으로 흔한 원인이라 조건절로 두고
할 일을 준다. 실제로 그 경로로 풀린다.

못 푸는 경우도 있다: 옛 계정에 로그인 수단이 **하나뿐이면** 마지막 하나라
끊을 수 없다(끊으면 계정이 잠긴다). 그건 계정 병합이 있어야 풀리는 문제고
설계 범위 밖이다.

## 검증

단위 테스트 390개 통과(신규 13건), 린트·프로덕션 빌드 통과.

콜백 분기는 **실제 HTTP 요청으로 일곱 갈래**를 확인했다:

| 요청 | 결과 |
| --- | --- |
| `next=/settings?linked=kakao` | `/settings?linkFailed=kakao` |
| `next=/settings?linked=google` | `/settings?linkFailed=google` |
| `next=/feed` (일반 로그인) | `/auth/auth-code-error?reason=unknown` |
| `error=access_denied` (취소) | `…?reason=cancelled` |
| `linked=nonsense` | 인증 오류 페이지 (모르는 공급자) |
| `/feed?linked=kakao` | 인증 오류 페이지 (설정 경로 아님) |
| `https://evil.com/…?linked=kakao` | 인증 오류 페이지 (외부 주소) |

문구 판정은 순수 함수(`toLinkResultMessage`)로 빼서 테스트했다 — 성공·실패·
모르는 값·프로토타입 키·둘 다 실려온 경우까지.

⚠️ **실패 토스트가 화면에 뜨는 것은 직접 보지 못했다.** 로컬 세션 발급이
막혀 로그인 상태 화면에 접근하지 못했다. 성공 토스트는 같은 경로로 동작하는
것이 확인됐고, 이번 변경은 그 분기에 판정 함수를 끼운 것이다.

## 구조 변경 하나

`LINKED_PARAM` 을 `features/auth/api/useLinkedAccounts.ts`(`'use client'`)에서
`shared/lib/auth/linkFlow.ts` 로 옮겼다. 콜백(서버)과 화면(클라이언트)이 같은
값을 봐야 하는데, 클라이언트 파일은 서버에서 가져올 수 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
