### PR TITLE
📝 Docs: 계정 연동 주석에서 확인하지 않은 사실을 걷어낸다

### DIFF
--- a/apps/page0127/src/features/auth/api/useLinkedAccounts.ts
+++ b/apps/page0127/src/features/auth/api/useLinkedAccounts.ts
@@ -35,12 +35,20 @@ const fetchLinkedAccounts = async () => {
  * 연결된 소셜 계정 조회·연결·해제.
  *
  * 대부분의 사용자는 이 기능이 필요 없다 — 같은 이메일이면 Supabase 가 알아서
- * identity 를 붙여 준다. 구글과 카카오에 **다른 이메일**을 쓴 사람이 갈라진
- * 계정을 직접 합치는 자리다.
+ * identity 를 붙여 준다. 구글과 카카오에 **다른 이메일**을 쓴 사람을 위한 자리다.
+ *
+ * ⚠️ **계정을 합치는 기능이 아니다.** 내 계정에 로그인 수단을 하나 더 붙일 뿐이다.
+ *    이미 다른 계정에 붙어 있는 identity 는 가져올 수 없다 — Supabase 가 거부한다
+ *    (안 막으면 남의 카카오로 로그인해 그 사람의 로그인 수단을 빼앗을 수 있다).
+ *    그래서 계정이 이미 둘로 갈라진 사람은 여기서 구제되지 않는다. 옛 계정에서
+ *    연결을 끊어야 옮길 수 있고, 옛 계정의 수단이 하나뿐이면 그마저 안 된다.
  *
  * ⚠️ linkIdentity 는 Supabase 의 **Manual Linking 이 켜져 있어야** 동작한다
- *    (로컬은 config.toml 의 enable_manual_linking, 운영·개발은 대시보드).
- *    꺼져 있으면 422 가 돌아온다.
+ *    (로컬은 config.toml 의 enable_manual_linking, 운영·개발은 대시보드의
+ *    Authentication → Sign In / Providers → Allow manual linking).
+ *    꺼졌을 때의 응답은 직접 확인하지 않았다 — 문서상으로는 "Manual linking is
+ *    disabled" 다. 켜졌는지는 눌러 보는 것 말고 확인할 방법이 없다
+ *    (`/auth/v1/settings` 에도 노출되지 않는다).
  */
 export const useLinkedAccounts = () => {
   const queryClient = useQueryClient();

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -177,8 +177,9 @@ enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
 enable_anonymous_sign_ins = false
 # Allow/disallow testing manual linking of accounts
-# 설정 화면의 "연결된 계정"(linkIdentity)이 이 값에 달려 있다. 꺼져 있으면 422.
+# 설정 화면의 "연결된 계정"(linkIdentity)이 이 값에 달려 있다. 꺼져 있으면 실패한다.
 # ⚠️ 운영·개발 대시보드에서도 따로 켜야 한다 — 이 파일은 로컬에만 적용된다.
+#    (Authentication → Sign In / Providers → Allow manual linking)
 enable_manual_linking = true
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
 minimum_password_length = 6


### PR DESCRIPTION
계정 연동 주석에 **관찰하지 않은 것을 사실처럼 적어 둔 곳** 두 군데를 고친다.
코드 변경은 없다.

## ① "꺼져 있으면 422"

`useLinkedAccounts.ts` 와 `config.toml` 에 그렇게 적어 뒀는데 **본 적 없는
값이다.** 추정을 단정형으로 썼다.

실제로 연동이 실패했을 때 Supabase Auth 로그에도 코드가 남지 않아 확인할 수
없었다. 문서상 표현("Manual linking is disabled")만 남기고, **직접 확인하지
않았다**는 사실을 함께 적는다.

대신 실측한 것을 적는다 — 켜졌는지 확인하는 방법은 **눌러 보는 것뿐**이다.
`/auth/v1/settings` 는 프로바이더 목록은 노출해도 manual linking 은 알려 주지
않는다.

## ② "갈라진 계정을 직접 합치는 자리"

**합칠 수 없다.** 이미 다른 계정에 붙어 있는 identity 는 가져오지 못한다 —
Supabase 가 거부한다. 안 막으면 남의 카카오로 로그인해 그 사람 계정의 로그인
수단을 빼앗을 수 있으니 맞는 동작이다.

이 기능은 **내 계정에 로그인 수단을 하나 더 붙이는 것**이다. 계정이 이미 둘로
갈라진 사람은 여기서 구제되지 않는다. 옛 계정에서 연결을 끊어야 옮길 수 있고,
옛 계정의 수단이 하나뿐이면 그마저 안 된다(마지막 하나는 못 끊는다).

이 사실은 실제 연동 실패를 겪고 나서야 드러났다(#102).

## 곁들여

대시보드 경로도 적어 둔다 — `Authentication → Sign In / Providers →
Allow manual linking`. 프로바이더별 설정이 아니라 프로젝트 전체 설정이라
찾기 어렵다.

## 검증

주석·설정 파일 문구만 바뀐다. 린트, 테스트 390개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
